### PR TITLE
feat(flow): add protocol, transport, discovery, and sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
@@ -139,6 +143,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.98
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
@@ -169,6 +177,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
@@ -210,6 +222,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
@@ -242,6 +258,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
@@ -287,6 +307,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,7 +2434,7 @@ dependencies = [
  "fastrand",
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -7730,9 +7730,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +846,9 @@ name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -1795,10 +1837,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "deranged"
@@ -5356,6 +5418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5643,9 +5714,14 @@ dependencies = [
  "buffa",
  "buffa-build",
  "hkdf",
+ "quinn",
+ "rcgen",
+ "rustls",
  "sha2 0.10.9",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
+ "x509-parser",
 ]
 
 [[package]]
@@ -6693,6 +6769,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6981,6 +7070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -10344,6 +10442,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xcb"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10468,6 +10584,16 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yazi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,6 +3808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,9 +4252,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4551,6 +4561,21 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "mdns-sd"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba97b4c886eea3c2823388120d92063c011ac866919ffc4200a0e4b1642a54a5"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
 ]
 
 [[package]]
@@ -5714,6 +5739,7 @@ dependencies = [
  "buffa",
  "buffa-build",
  "hkdf",
+ "mdns-sd",
  "quinn",
  "rcgen",
  "rustls",
@@ -7679,6 +7705,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
 dependencies = [
  "simdutf8",
+]
+
+[[package]]
+name = "socket-pktinfo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612942246d0cc239cfd83af1dfd39be47f649208a3524e5e9da651910128e0ac"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "buffa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
+dependencies = [
+ "bytes",
+ "foldhash 0.1.5",
+ "hashbrown 0.15.5",
+ "once_cell",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "smoothutf8",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "buffa-build"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247d43740a4854a9c1b98a5931d6d67d8f8b41ffeb2a43ca008d460e79b1eb2c"
+dependencies = [
+ "buffa",
+ "buffa-codegen",
+ "tempfile",
+]
+
+[[package]]
+name = "buffa-codegen"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2074a9c2f76b2ebe6af40f7bf67b6a19d6ce3663253ef2a55124dc93f38b230e"
+dependencies = [
+ "buffa",
+ "buffa-descriptor",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "buffa-descriptor"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964d735e0b06cb24fa15a68c5aa99549abcc7e0bbeb76298f2fec57912fb79c1"
+dependencies = [
+ "buffa",
+ "rustversion",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,6 +5637,14 @@ name = "openlogi-device-registry"
 version = "0.8.1"
 
 [[package]]
+name = "openlogi-flow"
+version = "0.8.1"
+dependencies = [
+ "buffa",
+ "buffa-build",
+]
+
+[[package]]
 name = "openlogi-hid"
 version = "0.8.1"
 dependencies = [
@@ -6401,7 +6464,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7429,6 +7492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7499,6 +7568,15 @@ checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
+]
+
+[[package]]
+name = "smoothutf8"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
+dependencies = [
+ "simdutf8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5642,6 +5642,10 @@ version = "0.8.1"
 dependencies = [
  "buffa",
  "buffa-build",
+ "hkdf",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/openlogi-assets",
     "crates/openlogi-cli",
     "crates/openlogi-ipc",
+    "crates/openlogi-flow",
     "crates/openlogi-agent-core",
     "crates/openlogi-agent",
     "crates/openlogi-desktop",
@@ -67,6 +68,7 @@ thiserror = "2"
 num_enum = "0.7.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
+buffa = "0.9"
 core-graphics = { version = "0.25", default-features = false, features = ["link"] }
 core-foundation = { version = "0.10", default-features = false, features = ["link"] }
 opener = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 buffa = "0.9"
 hkdf = "0.12"
+quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
+rcgen = { version = "0.14", default-features = false, features = ["crypto", "ring"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+subtle = "2"
+x509-parser = { version = "0.18", default-features = false }
 core-graphics = { version = "0.25", default-features = false, features = ["link"] }
 core-foundation = { version = "0.10", default-features = false, features = ["link"] }
 opener = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ num_enum = "0.7.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 buffa = "0.9"
+hkdf = "0.12"
 core-graphics = { version = "0.25", default-features = false, features = ["link"] }
 core-foundation = { version = "0.10", default-features = false, features = ["link"] }
 opener = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 buffa = "0.9"
 hkdf = "0.12"
+mdns-sd = "0.21"
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 rcgen = { version = "0.14", default-features = false, features = ["crypto", "ring"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }

--- a/crates/openlogi-flow/Cargo.toml
+++ b/crates/openlogi-flow/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [dependencies]
 buffa = { workspace = true }
 hkdf = { workspace = true }
+mdns-sd = { workspace = true }
 quinn = { workspace = true }
 rcgen = { workspace = true }
 rustls = { workspace = true }

--- a/crates/openlogi-flow/Cargo.toml
+++ b/crates/openlogi-flow/Cargo.toml
@@ -12,6 +12,10 @@ publish = false
 
 [dependencies]
 buffa = { workspace = true }
+hkdf = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util"] }
 
 [build-dependencies]
 buffa-build = "0.9"

--- a/crates/openlogi-flow/Cargo.toml
+++ b/crates/openlogi-flow/Cargo.toml
@@ -13,12 +13,20 @@ publish = false
 [dependencies]
 buffa = { workspace = true }
 hkdf = { workspace = true }
+quinn = { workspace = true }
+rcgen = { workspace = true }
+rustls = { workspace = true }
 sha2 = { workspace = true }
+subtle = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util"] }
+tokio = { workspace = true, features = ["io-util", "net"] }
+x509-parser = { workspace = true }
 
 [build-dependencies]
 buffa-build = "0.9"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/openlogi-flow/Cargo.toml
+++ b/crates/openlogi-flow/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "openlogi-flow"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "OpenLogi Flow peer protocol, pairing, and QUIC transport."
+# Agent-internal protocol infrastructure; no published crate depends on it.
+publish = false
+
+[dependencies]
+buffa = { workspace = true }
+
+[build-dependencies]
+buffa-build = "0.9"
+
+[lints]
+workspace = true

--- a/crates/openlogi-flow/build.rs
+++ b/crates/openlogi-flow/build.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto/flow.v1.proto");
+    buffa_build::Config::new()
+        .files(&["proto/flow.v1.proto"])
+        .includes(&["proto"])
+        .include_file("_include.rs")
+        .compile()?;
+    Ok(())
+}

--- a/crates/openlogi-flow/proto/flow.v1.proto
+++ b/crates/openlogi-flow/proto/flow.v1.proto
@@ -1,9 +1,8 @@
 // OpenLogi Flow peer protocol, version 1.
 //
 // This file is the authoritative wire contract between two OpenLogi agents
-// (see FLOW-PROTOCOL.md for framing, stream binding, state machines, and the
-// evolution rules that bind every edit to this file). It lives in docs/ until
-// crates/openlogi-flow exists, then moves there verbatim.
+// (see docs/FLOW-PROTOCOL.md for framing, stream binding, state machines, and
+// the evolution rules that bind every edit to this file).
 //
 // Ground rules (enforced in review, restated from FLOW-PROTOCOL.md):
 //   - Field numbers and FrameKind values are never reused or renumbered.

--- a/crates/openlogi-flow/src/discovery.rs
+++ b/crates/openlogi-flow/src/discovery.rs
@@ -1,0 +1,656 @@
+//! Peer-address hints from mDNS and manually configured host strings.
+//!
+//! Discovery never establishes identity. Every address returned here is only a
+//! dial hint; the transport authenticates the responding machine against its
+//! Ed25519 public key during mutual TLS.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt,
+    future::Future,
+    io,
+    net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    pin::Pin,
+    sync::{Arc, RwLock},
+};
+
+use mdns_sd::{ScopedIp, ServiceDaemon, ServiceEvent, ServiceInfo, TxtProperties};
+use thiserror::Error;
+use tokio::task::{JoinHandle, JoinSet};
+
+use crate::sas::PublicKey;
+
+/// DNS-SD service type advertised by Flow peers.
+pub const SERVICE_TYPE: &str = "_openlogi-flow._udp.local.";
+/// UDP port used when a manual address omits one.
+///
+/// mDNS candidates always use their SRV record's port instead. `42424` is an
+/// unprivileged, memorable default and is not part of the frozen wire format.
+pub const DEFAULT_PORT: u16 = 42_424;
+
+const TXT_PUBLIC_KEY: &str = "pk";
+const TXT_PROTO_MIN: &str = "proto_min";
+const TXT_PROTO_MAX: &str = "proto_max";
+
+/// Future returned by a dynamically dispatched [`CandidateSource`].
+pub type CandidateFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<SocketAddr>, DiscoveryError>> + Send + 'a>>;
+
+/// A source of address hints for one authenticated peer identity.
+pub trait CandidateSource: Send + Sync {
+    /// Returns the source's current address hints for `peer_key`.
+    fn candidates(&self, peer_key: PublicKey) -> CandidateFuture<'_>;
+}
+
+/// Merges all candidate sources concurrently and removes duplicate addresses.
+///
+/// A failed source does not hide addresses returned by another source. An
+/// error is returned only when every source failed to produce an address.
+pub async fn collect_candidates(
+    sources: &[Arc<dyn CandidateSource>],
+    peer_key: PublicKey,
+) -> Result<Vec<SocketAddr>, DiscoveryError> {
+    let mut tasks = JoinSet::new();
+    for source in sources {
+        let source = Arc::clone(source);
+        tasks.spawn(async move { source.candidates(peer_key).await });
+    }
+
+    let mut addresses = BTreeSet::new();
+    let mut first_error = None;
+    while let Some(result) = tasks.join_next().await {
+        match result {
+            Ok(Ok(candidates)) => addresses.extend(candidates),
+            Ok(Err(error)) => {
+                first_error.get_or_insert(error);
+            }
+            Err(error) => {
+                first_error.get_or_insert_with(|| DiscoveryError::SourceTask(error.to_string()));
+            }
+        }
+    }
+
+    if addresses.is_empty()
+        && let Some(error) = first_error
+    {
+        Err(error)
+    } else {
+        Ok(addresses.into_iter().collect())
+    }
+}
+
+/// A source that resolves manually configured IP, hostname, or `host:port` strings.
+///
+/// Bare values use [`DEFAULT_PORT`]. Resolution uses Tokio's OS-resolver
+/// adapter, so DNS, `/etc/hosts`, and overlay-network magic DNS all apply.
+#[derive(Clone, Debug)]
+pub struct ManualCandidateSource {
+    addresses: Arc<[String]>,
+    default_port: u16,
+}
+
+impl ManualCandidateSource {
+    /// Creates a source using Flow's documented default port.
+    #[must_use]
+    pub fn new(addresses: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self::with_port(addresses, DEFAULT_PORT)
+    }
+
+    /// Creates a source with an explicit default for values that omit a port.
+    #[must_use]
+    pub fn with_port(
+        addresses: impl IntoIterator<Item = impl Into<String>>,
+        default_port: u16,
+    ) -> Self {
+        Self {
+            addresses: addresses
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>()
+                .into(),
+            default_port,
+        }
+    }
+}
+
+impl CandidateSource for ManualCandidateSource {
+    fn candidates(&self, _peer_key: PublicKey) -> CandidateFuture<'_> {
+        Box::pin(async move {
+            let mut tasks = JoinSet::new();
+            for address in self.addresses.iter() {
+                let address = address.clone();
+                let default_port = self.default_port;
+                tasks.spawn(async move { resolve_manual_address(&address, default_port).await });
+            }
+
+            let mut resolved = BTreeSet::new();
+            let mut first_error = None;
+            while let Some(result) = tasks.join_next().await {
+                match result {
+                    Ok(Ok(addresses)) => resolved.extend(addresses),
+                    Ok(Err(error)) => {
+                        first_error.get_or_insert(error);
+                    }
+                    Err(error) => {
+                        first_error
+                            .get_or_insert_with(|| DiscoveryError::SourceTask(error.to_string()));
+                    }
+                }
+            }
+
+            if resolved.is_empty()
+                && let Some(error) = first_error
+            {
+                Err(error)
+            } else {
+                Ok(resolved.into_iter().collect())
+            }
+        })
+    }
+}
+
+/// Canonical Flow identity and compatibility data carried in an mDNS TXT record.
+///
+/// `pk` is the complete raw Ed25519 public key as exactly 64 lowercase hex
+/// digits. Publishing the key rather than a truncated hash lets browsers index
+/// candidates directly by their configured pin; it remains only a hint until
+/// mutual TLS proves possession of the private key.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MdnsRecord {
+    /// Advertised machine identity.
+    pub public_key: PublicKey,
+    /// Lowest protocol version the peer can receive.
+    pub proto_min: u32,
+    /// Highest protocol version the peer can receive.
+    pub proto_max: u32,
+}
+
+impl MdnsRecord {
+    /// Creates and validates a record.
+    pub fn new(
+        public_key: PublicKey,
+        proto_min: u32,
+        proto_max: u32,
+    ) -> Result<Self, DiscoveryError> {
+        if proto_min == 0 || proto_min > proto_max {
+            return Err(DiscoveryError::InvalidProtocolRange {
+                proto_min,
+                proto_max,
+            });
+        }
+        Ok(Self {
+            public_key,
+            proto_min,
+            proto_max,
+        })
+    }
+
+    /// Encodes this record into canonical DNS-SD TXT key/value pairs.
+    #[must_use]
+    pub fn properties(self) -> HashMap<String, String> {
+        HashMap::from([
+            (TXT_PUBLIC_KEY.to_owned(), public_key_hex(self.public_key)),
+            (TXT_PROTO_MIN.to_owned(), self.proto_min.to_string()),
+            (TXT_PROTO_MAX.to_owned(), self.proto_max.to_string()),
+        ])
+    }
+
+    /// Parses canonical TXT key/value pairs.
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, DiscoveryError> {
+        let property = |key: &'static str| {
+            properties
+                .iter()
+                .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+                .map(|(_, value)| value.as_str())
+                .ok_or(DiscoveryError::MissingTxtProperty(key))
+        };
+        Self::from_values(
+            property(TXT_PUBLIC_KEY)?,
+            property(TXT_PROTO_MIN)?,
+            property(TXT_PROTO_MAX)?,
+        )
+    }
+
+    fn from_txt(properties: &TxtProperties) -> Result<Self, DiscoveryError> {
+        let property = |key: &'static str| {
+            properties
+                .get_property_val_str(key)
+                .ok_or(DiscoveryError::MissingTxtProperty(key))
+        };
+        Self::from_values(
+            property(TXT_PUBLIC_KEY)?,
+            property(TXT_PROTO_MIN)?,
+            property(TXT_PROTO_MAX)?,
+        )
+    }
+
+    fn from_values(
+        public_key: &str,
+        proto_min: &str,
+        proto_max: &str,
+    ) -> Result<Self, DiscoveryError> {
+        let public_key = parse_public_key_hex(public_key)?;
+        let proto_min = proto_min
+            .parse()
+            .map_err(|_| DiscoveryError::InvalidTxtProperty(TXT_PROTO_MIN))?;
+        let proto_max = proto_max
+            .parse()
+            .map_err(|_| DiscoveryError::InvalidTxtProperty(TXT_PROTO_MAX))?;
+        Self::new(public_key, proto_min, proto_max)
+    }
+
+    fn overlaps(self, local_min: u32, local_max: u32) -> bool {
+        self.proto_max.min(local_max) >= self.proto_min.max(local_min)
+    }
+}
+
+/// An active advertisement of this machine's Flow endpoint.
+pub struct MdnsAdvertiser {
+    daemon: ServiceDaemon,
+    fullname: Option<String>,
+}
+
+impl fmt::Debug for MdnsAdvertiser {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MdnsAdvertiser")
+            .field("fullname", &self.fullname)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MdnsAdvertiser {
+    /// Registers an automatically address-tracked Flow service.
+    pub fn start(record: MdnsRecord, port: u16) -> Result<Self, DiscoveryError> {
+        let daemon = ServiceDaemon::new()?;
+        let key = public_key_hex(record.public_key);
+        let short_key = &key[..16];
+        let instance_name = format!("openlogi-flow-{short_key}");
+        let hostname = format!("openlogi-flow-{short_key}.local.");
+        let service = ServiceInfo::new(
+            SERVICE_TYPE,
+            &instance_name,
+            &hostname,
+            (),
+            port,
+            record.properties(),
+        )?
+        .enable_addr_auto();
+        let fullname = service.get_fullname().to_owned();
+        daemon.register(service)?;
+        Ok(Self {
+            daemon,
+            fullname: Some(fullname),
+        })
+    }
+
+    /// Returns the registered DNS-SD service fullname.
+    #[must_use]
+    pub fn fullname(&self) -> Option<&str> {
+        self.fullname.as_deref()
+    }
+}
+
+impl Drop for MdnsAdvertiser {
+    fn drop(&mut self) {
+        if let Some(fullname) = self.fullname.take() {
+            let _ = self.daemon.unregister(&fullname);
+        }
+        let _ = self.daemon.shutdown();
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DiscoveredService {
+    record: MdnsRecord,
+    addresses: BTreeSet<SocketAddr>,
+}
+
+/// A continuously browsing mDNS candidate source.
+///
+/// Resolved records outside the local protocol range are discarded before
+/// they can trigger a connection attempt. The source returns snapshots of its
+/// cache; the session manager retries it as discovery records change.
+pub struct MdnsCandidateSource {
+    daemon: ServiceDaemon,
+    services: Arc<RwLock<BTreeMap<String, DiscoveredService>>>,
+    browser: JoinHandle<()>,
+}
+
+impl fmt::Debug for MdnsCandidateSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MdnsCandidateSource")
+            .field("services", &self.services)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MdnsCandidateSource {
+    /// Starts browsing for compatible Flow services.
+    pub fn browse(local_min: u32, local_max: u32) -> Result<Self, DiscoveryError> {
+        if local_min == 0 || local_min > local_max {
+            return Err(DiscoveryError::InvalidProtocolRange {
+                proto_min: local_min,
+                proto_max: local_max,
+            });
+        }
+        let daemon = ServiceDaemon::new()?;
+        let receiver = daemon.browse(SERVICE_TYPE)?;
+        let services = Arc::new(RwLock::new(BTreeMap::new()));
+        let browser_services = Arc::clone(&services);
+        let browser = tokio::spawn(async move {
+            while let Ok(event) = receiver.recv_async().await {
+                match event {
+                    ServiceEvent::ServiceResolved(service) => {
+                        update_resolved_service(&browser_services, &service, local_min, local_max);
+                    }
+                    ServiceEvent::ServiceRemoved(_, fullname) => {
+                        if let Ok(mut services) = browser_services.write() {
+                            services.remove(&fullname);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+        Ok(Self {
+            daemon,
+            services,
+            browser,
+        })
+    }
+}
+
+impl CandidateSource for MdnsCandidateSource {
+    fn candidates(&self, peer_key: PublicKey) -> CandidateFuture<'_> {
+        Box::pin(async move {
+            let services = self
+                .services
+                .read()
+                .map_err(|_| DiscoveryError::CachePoisoned)?;
+            Ok(services
+                .values()
+                .filter(|service| service.record.public_key == peer_key)
+                .flat_map(|service| service.addresses.iter().copied())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect())
+        })
+    }
+}
+
+impl Drop for MdnsCandidateSource {
+    fn drop(&mut self) {
+        self.browser.abort();
+        let _ = self.daemon.stop_browse(SERVICE_TYPE);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+/// Errors produced by candidate discovery and manual resolution.
+#[derive(Debug, Error)]
+pub enum DiscoveryError {
+    /// The mDNS daemon rejected an operation or record.
+    #[error("mDNS discovery failed: {0}")]
+    Mdns(#[from] mdns_sd::Error),
+    /// A manual hostname could not be resolved.
+    #[error("failed to resolve manual address {address}: {source}")]
+    Resolve {
+        /// Address string supplied by configuration.
+        address: String,
+        /// OS resolver failure.
+        source: io::Error,
+    },
+    /// A manual address has an invalid or ambiguous shape.
+    #[error("invalid manual address {0}")]
+    InvalidManualAddress(String),
+    /// An advertised protocol range is malformed.
+    #[error("invalid protocol range {proto_min}..={proto_max}")]
+    InvalidProtocolRange {
+        /// Advertised lower bound.
+        proto_min: u32,
+        /// Advertised upper bound.
+        proto_max: u32,
+    },
+    /// A required TXT property is absent.
+    #[error("mDNS TXT record is missing {0}")]
+    MissingTxtProperty(&'static str),
+    /// A TXT property is not in its canonical representation.
+    #[error("mDNS TXT property {0} is invalid")]
+    InvalidTxtProperty(&'static str),
+    /// A candidate-source task failed before returning its result.
+    #[error("candidate source task failed: {0}")]
+    SourceTask(String),
+    /// The mDNS cache's synchronization primitive was poisoned.
+    #[error("mDNS candidate cache is unavailable")]
+    CachePoisoned,
+}
+
+async fn resolve_manual_address(
+    address: &str,
+    default_port: u16,
+) -> Result<Vec<SocketAddr>, DiscoveryError> {
+    let address = address.trim();
+    if address.is_empty() {
+        return Err(DiscoveryError::InvalidManualAddress(address.to_owned()));
+    }
+    if let Ok(socket) = address.parse::<SocketAddr>() {
+        return Ok(vec![socket]);
+    }
+    if let Ok(ip) = address.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(ip, default_port)]);
+    }
+    if let Some(bracketed) = address
+        .strip_prefix('[')
+        .and_then(|address| address.strip_suffix(']'))
+    {
+        let ip = bracketed
+            .parse::<IpAddr>()
+            .map_err(|_| DiscoveryError::InvalidManualAddress(address.to_owned()))?;
+        return Ok(vec![SocketAddr::new(ip, default_port)]);
+    }
+
+    let colon_count = address.bytes().filter(|byte| *byte == b':').count();
+    let (hostname, port) = match colon_count {
+        0 => (address, default_port),
+        1 => {
+            let (hostname, port) = address
+                .rsplit_once(':')
+                .ok_or_else(|| DiscoveryError::InvalidManualAddress(address.to_owned()))?;
+            let port = port
+                .parse::<u16>()
+                .map_err(|_| DiscoveryError::InvalidManualAddress(address.to_owned()))?;
+            if hostname.is_empty() {
+                return Err(DiscoveryError::InvalidManualAddress(address.to_owned()));
+            }
+            (hostname, port)
+        }
+        _ => return Err(DiscoveryError::InvalidManualAddress(address.to_owned())),
+    };
+    let addresses = tokio::net::lookup_host((hostname, port))
+        .await
+        .map_err(|source| DiscoveryError::Resolve {
+            address: address.to_owned(),
+            source,
+        })?;
+    Ok(addresses.collect())
+}
+
+fn update_resolved_service(
+    services: &RwLock<BTreeMap<String, DiscoveredService>>,
+    service: &mdns_sd::ResolvedService,
+    local_min: u32,
+    local_max: u32,
+) {
+    let Ok(mut services) = services.write() else {
+        return;
+    };
+    services.remove(service.get_fullname());
+    let Ok(record) = MdnsRecord::from_txt(service.get_properties()) else {
+        return;
+    };
+    if service.get_port() == 0 || !record.overlaps(local_min, local_max) {
+        return;
+    }
+    let port = service.get_port();
+    let addresses = service
+        .get_addresses()
+        .iter()
+        .filter_map(|address| match address {
+            ScopedIp::V4(address) => Some(SocketAddr::V4(SocketAddrV4::new(*address.addr(), port))),
+            ScopedIp::V6(address) => Some(SocketAddr::V6(SocketAddrV6::new(
+                *address.addr(),
+                port,
+                0,
+                address.scope_id().index,
+            ))),
+            _ => None,
+        })
+        .collect();
+    services.insert(
+        service.get_fullname().to_owned(),
+        DiscoveredService { record, addresses },
+    );
+}
+
+fn public_key_hex(public_key: PublicKey) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(64);
+    for byte in public_key.as_bytes() {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+fn parse_public_key_hex(encoded: &str) -> Result<PublicKey, DiscoveryError> {
+    if encoded.len() != 64
+        || !encoded
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(DiscoveryError::InvalidTxtProperty(TXT_PUBLIC_KEY));
+    }
+    let mut key = [0_u8; 32];
+    for (index, pair) in encoded.as_bytes().as_chunks::<2>().0.iter().enumerate() {
+        key[index] = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
+    }
+    Ok(PublicKey::new(key))
+}
+
+fn hex_nibble(byte: u8) -> Result<u8, DiscoveryError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        _ => Err(DiscoveryError::InvalidTxtProperty(TXT_PUBLIC_KEY)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use tokio::sync::Barrier;
+
+    use super::*;
+
+    struct FakeSource {
+        barrier: Arc<Barrier>,
+        result: Result<Vec<SocketAddr>, &'static str>,
+    }
+
+    impl CandidateSource for FakeSource {
+        fn candidates(&self, _peer_key: PublicKey) -> CandidateFuture<'_> {
+            Box::pin(async move {
+                self.barrier.wait().await;
+                self.result
+                    .clone()
+                    .map_err(|detail| DiscoveryError::SourceTask(detail.to_owned()))
+            })
+        }
+    }
+
+    #[test]
+    fn mdns_record_round_trips_canonical_txt_properties() {
+        let record = MdnsRecord::new(PublicKey::new([0xab; 32]), 1, 3).unwrap();
+        let properties = record.properties();
+        assert_eq!(properties[TXT_PUBLIC_KEY], "ab".repeat(32));
+        assert_eq!(MdnsRecord::from_properties(&properties).unwrap(), record);
+
+        let mut uppercase = properties;
+        uppercase.insert(TXT_PUBLIC_KEY.to_owned(), "AB".repeat(32));
+        assert!(matches!(
+            MdnsRecord::from_properties(&uppercase),
+            Err(DiscoveryError::InvalidTxtProperty(TXT_PUBLIC_KEY))
+        ));
+    }
+
+    #[test]
+    fn protocol_overlap_filters_disjoint_records() {
+        let record = MdnsRecord::new(PublicKey::new([1; 32]), 2, 4).unwrap();
+        assert!(record.overlaps(1, 2));
+        assert!(!record.overlaps(5, 6));
+    }
+
+    #[tokio::test]
+    async fn manual_addresses_use_default_and_explicit_ports() {
+        let source =
+            ManualCandidateSource::with_port(["127.0.0.1", "127.0.0.1:5000", "[::1]"], 4000);
+        let addresses = source.candidates(PublicKey::new([0; 32])).await.unwrap();
+        assert_eq!(
+            addresses.into_iter().collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "127.0.0.1:4000".parse().unwrap(),
+                "127.0.0.1:5000".parse().unwrap(),
+                "[::1]:4000".parse().unwrap(),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn candidate_sources_are_polled_concurrently_and_deduplicated() {
+        let barrier = Arc::new(Barrier::new(3));
+        let repeated = "127.0.0.1:4000".parse().unwrap();
+        let unique = "127.0.0.1:5000".parse().unwrap();
+        let sources: Vec<Arc<dyn CandidateSource>> = vec![
+            Arc::new(FakeSource {
+                barrier: Arc::clone(&barrier),
+                result: Ok(vec![repeated]),
+            }),
+            Arc::new(FakeSource {
+                barrier: Arc::clone(&barrier),
+                result: Ok(vec![repeated, unique]),
+            }),
+        ];
+
+        let collected =
+            tokio::spawn(
+                async move { collect_candidates(&sources, PublicKey::new([1; 32])).await },
+            );
+        tokio::time::timeout(Duration::from_secs(1), barrier.wait())
+            .await
+            .unwrap();
+        assert_eq!(collected.await.unwrap().unwrap(), [repeated, unique]);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires multicast-capable host networking"]
+    async fn live_mdns_round_trip() {
+        let key = PublicKey::new([0x42; 32]);
+        let source = MdnsCandidateSource::browse(1, 1).unwrap();
+        let _advertiser =
+            MdnsAdvertiser::start(MdnsRecord::new(key, 1, 1).unwrap(), 42_424).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if !source.candidates(key).await.unwrap().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/crates/openlogi-flow/src/discovery.rs
+++ b/crates/openlogi-flow/src/discovery.rs
@@ -12,6 +12,7 @@ use std::{
     net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
     pin::Pin,
     sync::{Arc, RwLock},
+    time::Instant,
 };
 
 use mdns_sd::{ScopedIp, ServiceDaemon, ServiceEvent, ServiceInfo, TxtProperties};
@@ -31,6 +32,7 @@ pub const DEFAULT_PORT: u16 = 42_424;
 const TXT_PUBLIC_KEY: &str = "pk";
 const TXT_PROTO_MIN: &str = "proto_min";
 const TXT_PROTO_MAX: &str = "proto_max";
+const MAX_MDNS_SERVICES: usize = 256;
 
 /// Future returned by a dynamically dispatched [`CandidateSource`].
 pub type CandidateFuture<'a> =
@@ -304,6 +306,7 @@ impl Drop for MdnsAdvertiser {
 struct DiscoveredService {
     record: MdnsRecord,
     addresses: BTreeSet<SocketAddr>,
+    last_resolved: Instant,
 }
 
 /// A continuously browsing mDNS candidate source.
@@ -508,10 +511,32 @@ fn update_resolved_service(
             _ => None,
         })
         .collect();
-    services.insert(
+    insert_discovered_service(
+        &mut services,
         service.get_fullname().to_owned(),
-        DiscoveredService { record, addresses },
+        DiscoveredService {
+            record,
+            addresses,
+            last_resolved: Instant::now(),
+        },
     );
+}
+
+fn insert_discovered_service(
+    services: &mut BTreeMap<String, DiscoveredService>,
+    fullname: String,
+    service: DiscoveredService,
+) {
+    if services.len() >= MAX_MDNS_SERVICES
+        && !services.contains_key(&fullname)
+        && let Some(oldest) = services
+            .iter()
+            .min_by_key(|(name, service)| (service.last_resolved, *name))
+            .map(|(name, _)| name.clone())
+    {
+        services.remove(&oldest);
+    }
+    services.insert(fullname, service);
 }
 
 fn public_key_hex(public_key: PublicKey) -> String {
@@ -591,6 +616,38 @@ mod tests {
         let record = MdnsRecord::new(PublicKey::new([1; 32]), 2, 4).unwrap();
         assert!(record.overlaps(1, 2));
         assert!(!record.overlaps(5, 6));
+    }
+
+    #[test]
+    fn mdns_cache_evicts_oldest_service_at_capacity() {
+        let now = Instant::now();
+        let record = MdnsRecord::new(PublicKey::new([1; 32]), 1, 1).unwrap();
+        let mut services = BTreeMap::new();
+        for index in 0..MAX_MDNS_SERVICES {
+            insert_discovered_service(
+                &mut services,
+                format!("service-{index}"),
+                DiscoveredService {
+                    record,
+                    addresses: BTreeSet::new(),
+                    last_resolved: now + Duration::from_millis(index as u64),
+                },
+            );
+        }
+
+        insert_discovered_service(
+            &mut services,
+            "new-service".to_owned(),
+            DiscoveredService {
+                record,
+                addresses: BTreeSet::new(),
+                last_resolved: now + Duration::from_secs(1),
+            },
+        );
+
+        assert_eq!(services.len(), MAX_MDNS_SERVICES);
+        assert!(!services.contains_key("service-0"));
+        assert!(services.contains_key("new-service"));
     }
 
     #[tokio::test]

--- a/crates/openlogi-flow/src/frame.rs
+++ b/crates/openlogi-flow/src/frame.rs
@@ -1,0 +1,445 @@
+//! Frozen Flow frame envelope and protobuf payload helpers.
+
+use std::io;
+
+use buffa::Message;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::proto::openlogi::flow::v1 as proto;
+
+/// Number of bytes in the frozen frame header.
+pub const HEADER_LEN: usize = 8;
+/// Maximum payload size for ordinary frames.
+pub const MAX_PAYLOAD_LEN: usize = 1024 * 1024;
+/// Maximum payload size for [`FrameKind::Chunk`].
+pub const MAX_CHUNK_LEN: usize = 64 * 1024;
+
+/// A frame discriminator, preserving values introduced by newer peers.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FrameKind {
+    /// The invalid zero discriminator.
+    Unspecified,
+    /// Link negotiation.
+    Hello,
+    /// Rejected link negotiation.
+    HelloReject,
+    /// Generic RPC error.
+    Error,
+    /// Liveness request.
+    Ping,
+    /// Liveness response.
+    Pong,
+    /// Pairing request.
+    PairStart,
+    /// Pairing prompt acknowledgement.
+    PairPrompted,
+    /// Pairing confirmation.
+    PairConfirm,
+    /// Pairing outcome.
+    PairOutcome,
+    /// Pairing cancellation.
+    PairAbort,
+    /// Peer information request.
+    GetPeerInfo,
+    /// Peer information response.
+    PeerInfo,
+    /// Device-state notification.
+    AnnounceDevices,
+    /// Peer-state notification.
+    PeerState,
+    /// Device handoff request.
+    HandoffRequest,
+    /// Accepted handoff.
+    HandoffAccept,
+    /// Rejected handoff.
+    HandoffReject,
+    /// Handoff result notification.
+    HandoffResult,
+    /// Handoff cancellation notification.
+    HandoffCancel,
+    /// Clipboard availability notification.
+    ClipboardAnnounce,
+    /// Clipboard payload request.
+    ClipboardFetch,
+    /// Bulk payload response head.
+    ClipboardData,
+    /// Bulk payload slice.
+    Chunk,
+    /// Bulk payload terminator.
+    ChunkEnd,
+    /// Clipboard file request.
+    FileFetch,
+    /// A discriminator unknown to this implementation.
+    Unknown(u16),
+}
+
+impl FrameKind {
+    /// Returns the frozen wire value.
+    #[must_use]
+    pub const fn wire_value(self) -> u16 {
+        match self {
+            Self::Unspecified => 0x00,
+            Self::Hello => 0x01,
+            Self::HelloReject => 0x02,
+            Self::Error => 0x03,
+            Self::Ping => 0x04,
+            Self::Pong => 0x05,
+            Self::PairStart => 0x10,
+            Self::PairPrompted => 0x11,
+            Self::PairConfirm => 0x12,
+            Self::PairOutcome => 0x13,
+            Self::PairAbort => 0x14,
+            Self::GetPeerInfo => 0x20,
+            Self::PeerInfo => 0x21,
+            Self::AnnounceDevices => 0x22,
+            Self::PeerState => 0x23,
+            Self::HandoffRequest => 0x30,
+            Self::HandoffAccept => 0x31,
+            Self::HandoffReject => 0x32,
+            Self::HandoffResult => 0x33,
+            Self::HandoffCancel => 0x34,
+            Self::ClipboardAnnounce => 0x40,
+            Self::ClipboardFetch => 0x41,
+            Self::ClipboardData => 0x42,
+            Self::Chunk => 0x43,
+            Self::ChunkEnd => 0x44,
+            Self::FileFetch => 0x45,
+            Self::Unknown(value) => value,
+        }
+    }
+
+    /// Returns the payload cap for this kind.
+    #[must_use]
+    pub const fn payload_cap(self) -> usize {
+        if matches!(self, Self::Chunk) {
+            MAX_CHUNK_LEN
+        } else {
+            MAX_PAYLOAD_LEN
+        }
+    }
+
+    /// Returns whether the discriminator is known and meaningful.
+    #[must_use]
+    pub const fn is_supported(self) -> bool {
+        !matches!(self, Self::Unspecified | Self::Unknown(_))
+    }
+}
+
+impl From<u16> for FrameKind {
+    fn from(value: u16) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Hello,
+            2 => Self::HelloReject,
+            3 => Self::Error,
+            4 => Self::Ping,
+            5 => Self::Pong,
+            0x10 => Self::PairStart,
+            0x11 => Self::PairPrompted,
+            0x12 => Self::PairConfirm,
+            0x13 => Self::PairOutcome,
+            0x14 => Self::PairAbort,
+            0x20 => Self::GetPeerInfo,
+            0x21 => Self::PeerInfo,
+            0x22 => Self::AnnounceDevices,
+            0x23 => Self::PeerState,
+            0x30 => Self::HandoffRequest,
+            0x31 => Self::HandoffAccept,
+            0x32 => Self::HandoffReject,
+            0x33 => Self::HandoffResult,
+            0x34 => Self::HandoffCancel,
+            0x40 => Self::ClipboardAnnounce,
+            0x41 => Self::ClipboardFetch,
+            0x42 => Self::ClipboardData,
+            0x43 => Self::Chunk,
+            0x44 => Self::ChunkEnd,
+            0x45 => Self::FileFetch,
+            other => Self::Unknown(other),
+        }
+    }
+}
+
+impl From<proto::FrameKind> for FrameKind {
+    fn from(value: proto::FrameKind) -> Self {
+        Self::from(value as u16)
+    }
+}
+
+impl TryFrom<FrameKind> for proto::FrameKind {
+    type Error = u16;
+    fn try_from(value: FrameKind) -> Result<Self, Self::Error> {
+        use buffa::Enumeration;
+        let wire = value.wire_value();
+        proto::FrameKind::from_i32(i32::from(wire)).ok_or(wire)
+    }
+}
+
+/// An owned, validated envelope and its opaque payload.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Envelope {
+    /// Frame discriminator.
+    pub kind: FrameKind,
+    /// Reserved envelope flags; senders must use zero.
+    pub flags: u16,
+    /// Protobuf payload bytes.
+    pub payload: Vec<u8>,
+}
+
+/// A frame paired with its decoded protobuf message.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Frame<M> {
+    /// Frame discriminator.
+    pub kind: FrameKind,
+    /// Reserved envelope flags.
+    pub flags: u16,
+    /// Decoded protobuf payload.
+    pub message: M,
+}
+
+/// Why an envelope could not be read or encoded.
+#[derive(Debug, thiserror::Error)]
+pub enum FrameError {
+    /// The input ended before the declared frame ended.
+    #[error("truncated frame")]
+    Truncated,
+    /// The declared payload exceeds its kind-specific cap.
+    #[error("frame payload length {len} exceeds cap {cap}")]
+    TooLarge {
+        /// Declared payload length.
+        len: usize,
+        /// Applicable limit.
+        cap: usize,
+    },
+    /// Protobuf encoding exceeded buffa's limit.
+    #[error("protobuf encoding failed: {0}")]
+    Encode(#[from] buffa::EncodeError),
+    /// An asynchronous transport operation failed.
+    #[error("frame transport failed: {0}")]
+    Io(#[from] io::Error),
+}
+
+impl FrameError {
+    /// Returns the protocol action when this error represents an oversized frame.
+    #[must_use]
+    pub const fn too_large_decision(&self, role: InboundRole) -> Option<InvalidDecision> {
+        match self {
+            Self::TooLarge { .. } => Some(role.invalid(proto::ErrorCode::TooLarge)),
+            _ => None,
+        }
+    }
+}
+
+/// Protocol action for a malformed, unsupported, or oversized inbound frame.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvalidDecision {
+    /// Silently discard a notification.
+    Drop,
+    /// Send an `Error` response with this code for a request.
+    Respond(proto::ErrorCode),
+}
+
+/// Whether an inbound frame occupies a response-bearing request position.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InboundRole {
+    /// A one-way notification.
+    Notification,
+    /// A request on a bidirectional stream.
+    Request,
+}
+
+impl InboundRole {
+    /// Chooses the spec-mandated action for an error code.
+    #[must_use]
+    pub const fn invalid(self, code: proto::ErrorCode) -> InvalidDecision {
+        match self {
+            Self::Notification => InvalidDecision::Drop,
+            Self::Request => InvalidDecision::Respond(code),
+        }
+    }
+}
+
+impl Envelope {
+    /// Creates an envelope, enforcing the kind-specific payload cap.
+    pub fn new(kind: FrameKind, flags: u16, payload: Vec<u8>) -> Result<Self, FrameError> {
+        check_len(kind, payload.len())?;
+        Ok(Self {
+            kind,
+            flags,
+            payload,
+        })
+    }
+
+    /// Encodes one complete envelope into bytes.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, FrameError> {
+        check_len(self.kind, self.payload.len())?;
+        let len = u32::try_from(self.payload.len()).map_err(|_| FrameError::TooLarge {
+            len: self.payload.len(),
+            cap: self.kind.payload_cap(),
+        })?;
+        let mut out = Vec::with_capacity(HEADER_LEN + self.payload.len());
+        out.extend_from_slice(&self.kind.wire_value().to_le_bytes());
+        out.extend_from_slice(&self.flags.to_le_bytes());
+        out.extend_from_slice(&len.to_le_bytes());
+        out.extend_from_slice(&self.payload);
+        Ok(out)
+    }
+
+    /// Decodes exactly one envelope from a byte slice.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, FrameError> {
+        if bytes.len() < HEADER_LEN {
+            return Err(FrameError::Truncated);
+        }
+        let kind = FrameKind::from(u16::from_le_bytes([bytes[0], bytes[1]]));
+        let flags = u16::from_le_bytes([bytes[2], bytes[3]]);
+        let len = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+        check_len(kind, len)?;
+        if bytes.len() != HEADER_LEN + len {
+            return Err(FrameError::Truncated);
+        }
+        Ok(Self {
+            kind,
+            flags,
+            payload: bytes[HEADER_LEN..].to_vec(),
+        })
+    }
+
+    /// Reads one envelope from a Tokio-compatible asynchronous reader.
+    pub async fn read_from(reader: &mut (impl AsyncRead + Unpin)) -> Result<Self, FrameError> {
+        let mut header = [0; HEADER_LEN];
+        reader.read_exact(&mut header).await?;
+        let kind = FrameKind::from(u16::from_le_bytes([header[0], header[1]]));
+        let flags = u16::from_le_bytes([header[2], header[3]]);
+        let len = u32::from_le_bytes([header[4], header[5], header[6], header[7]]) as usize;
+        check_len(kind, len)?;
+        let mut payload = vec![0; len];
+        reader.read_exact(&mut payload).await?;
+        Ok(Self {
+            kind,
+            flags,
+            payload,
+        })
+    }
+
+    /// Writes one envelope to a Tokio-compatible asynchronous writer.
+    pub async fn write_to(&self, writer: &mut (impl AsyncWrite + Unpin)) -> Result<(), FrameError> {
+        writer.write_all(&self.to_bytes()?).await?;
+        Ok(())
+    }
+
+    /// Applies unknown-kind and unknown-flags policy before payload decoding.
+    #[must_use]
+    pub const fn policy(&self, role: InboundRole) -> Option<InvalidDecision> {
+        if !self.kind.is_supported() {
+            Some(role.invalid(proto::ErrorCode::UnsupportedKind))
+        } else if self.flags != 0 {
+            Some(role.invalid(proto::ErrorCode::UnsupportedFlags))
+        } else {
+            None
+        }
+    }
+
+    /// Decodes the payload, returning the spec's `INVALID` action on failure.
+    pub fn decode<M: Message>(&self, role: InboundRole) -> Result<M, InvalidDecision> {
+        M::decode_from_slice(&self.payload).map_err(|_| role.invalid(proto::ErrorCode::Invalid))
+    }
+}
+
+impl<M: Message> Frame<M> {
+    /// Encodes a typed protobuf frame while enforcing envelope limits.
+    pub fn encode(kind: FrameKind, message: M) -> Result<Self, FrameError> {
+        let mut payload = Vec::new();
+        message.try_encode(&mut payload)?;
+        check_len(kind, payload.len())?;
+        Ok(Self {
+            kind,
+            flags: 0,
+            message,
+        })
+    }
+
+    /// Converts this typed frame to an opaque envelope.
+    pub fn into_envelope(self) -> Result<Envelope, FrameError> {
+        let mut payload = Vec::new();
+        self.message.try_encode(&mut payload)?;
+        Envelope::new(self.kind, self.flags, payload)
+    }
+}
+
+fn check_len(kind: FrameKind, len: usize) -> Result<(), FrameError> {
+    let cap = kind.payload_cap();
+    if len > cap {
+        Err(FrameError::TooLarge { len, cap })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn golden_bytes_freeze_layout() {
+        let frame = Envelope::new(FrameKind::Hello, 0x0201, vec![0xaa, 0xbb, 0xcc]).unwrap();
+        assert_eq!(
+            frame.to_bytes().unwrap(),
+            [0x01, 0x00, 0x01, 0x02, 0x03, 0, 0, 0, 0xaa, 0xbb, 0xcc]
+        );
+    }
+
+    #[test]
+    fn unknown_kind_is_preserved_and_policy_depends_on_role() {
+        let frame = Envelope::from_bytes(&[0xfe, 0xca, 0, 0, 0, 0, 0, 0]).unwrap();
+        assert_eq!(frame.kind, FrameKind::Unknown(0xcafe));
+        assert_eq!(
+            frame.policy(InboundRole::Notification),
+            Some(InvalidDecision::Drop)
+        );
+        assert_eq!(
+            frame.policy(InboundRole::Request),
+            Some(InvalidDecision::Respond(proto::ErrorCode::UnsupportedKind))
+        );
+    }
+
+    #[test]
+    fn flags_and_decode_failure_have_typed_decisions() {
+        let flagged = Envelope::new(FrameKind::Ping, 1, Vec::new()).unwrap();
+        assert_eq!(
+            flagged.policy(InboundRole::Request),
+            Some(InvalidDecision::Respond(proto::ErrorCode::UnsupportedFlags))
+        );
+        let invalid = Envelope::new(FrameKind::Ping, 0, vec![0xff]).unwrap();
+        assert_eq!(
+            invalid.decode::<proto::Ping>(InboundRole::Notification),
+            Err(InvalidDecision::Drop)
+        );
+    }
+
+    #[test]
+    fn chunk_has_smaller_cap() {
+        let error = Envelope::new(FrameKind::Chunk, 0, vec![0; MAX_CHUNK_LEN + 1]).unwrap_err();
+        assert!(matches!(
+            error,
+            FrameError::TooLarge {
+                cap: MAX_CHUNK_LEN,
+                ..
+            }
+        ));
+        Envelope::new(FrameKind::Ping, 0, vec![0; MAX_CHUNK_LEN + 1]).unwrap();
+    }
+
+    #[test]
+    fn truncated_and_declared_oversize_are_rejected() {
+        assert!(matches!(
+            Envelope::from_bytes(&[1, 0]),
+            Err(FrameError::Truncated)
+        ));
+        let mut header = [0; HEADER_LEN];
+        header[0] = 0x43;
+        header[4..].copy_from_slice(&(u32::try_from(MAX_CHUNK_LEN).unwrap() + 1).to_le_bytes());
+        assert!(matches!(
+            Envelope::from_bytes(&header),
+            Err(FrameError::TooLarge { .. })
+        ));
+    }
+}

--- a/crates/openlogi-flow/src/identity.rs
+++ b/crates/openlogi-flow/src/identity.rs
@@ -1,0 +1,242 @@
+//! Validated, canonical identifiers used for cross-transport device correlation.
+
+use crate::proto::openlogi::flow::v1::{
+    DeviceIdentifier as WireDeviceIdentifier, DeviceIdentity, IdentifierKind,
+};
+use thiserror::Error;
+
+/// A validated device identifier in its canonical wire representation.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum CanonicalDeviceIdentifier {
+    /// A serial number represented by its exact UTF-8 bytes.
+    Serial(String),
+    /// A HID++ unit ID represented canonically as a 32-bit value.
+    UnitId(u32),
+    /// A Bluetooth address in transmission order (most-significant byte first).
+    BluetoothAddress([u8; 6]),
+}
+
+impl CanonicalDeviceIdentifier {
+    /// Creates a canonical serial identifier without padding or case folding.
+    #[must_use]
+    pub fn serial(serial: impl Into<String>) -> Self {
+        Self::Serial(serial.into())
+    }
+
+    /// Creates a canonical HID++ unit-ID identifier.
+    #[must_use]
+    pub const fn unit_id(unit_id: u32) -> Self {
+        Self::UnitId(unit_id)
+    }
+
+    /// Creates a canonical Bluetooth-address identifier from MSB-first bytes.
+    #[must_use]
+    pub const fn bluetooth_address(address: [u8; 6]) -> Self {
+        Self::BluetoothAddress(address)
+    }
+
+    /// Returns the generated protocol identifier kind.
+    #[must_use]
+    pub const fn kind(&self) -> IdentifierKind {
+        match self {
+            Self::Serial(_) => IdentifierKind::Serial,
+            Self::UnitId(_) => IdentifierKind::UnitId,
+            Self::BluetoothAddress(_) => IdentifierKind::BluetoothAddress,
+        }
+    }
+
+    /// Returns this identifier's canonical wire bytes.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Serial(serial) => serial.as_bytes().to_vec(),
+            Self::UnitId(unit_id) => unit_id.to_be_bytes().to_vec(),
+            Self::BluetoothAddress(address) => address.to_vec(),
+        }
+    }
+}
+
+impl TryFrom<&WireDeviceIdentifier> for CanonicalDeviceIdentifier {
+    type Error = DeviceIdentifierError;
+
+    fn try_from(identifier: &WireDeviceIdentifier) -> Result<Self, Self::Error> {
+        match identifier.kind.as_known() {
+            Some(IdentifierKind::Serial) => std::str::from_utf8(&identifier.value)
+                .map(str::to_owned)
+                .map(Self::Serial)
+                .map_err(|_| DeviceIdentifierError::InvalidSerialUtf8),
+            Some(IdentifierKind::UnitId) => {
+                let bytes = exact_bytes::<4>(IdentifierKind::UnitId, &identifier.value)?;
+                Ok(Self::UnitId(u32::from_be_bytes(bytes)))
+            }
+            Some(IdentifierKind::BluetoothAddress) => {
+                let bytes = exact_bytes::<6>(IdentifierKind::BluetoothAddress, &identifier.value)?;
+                Ok(Self::BluetoothAddress(bytes))
+            }
+            Some(IdentifierKind::Unspecified) => Err(DeviceIdentifierError::UnspecifiedKind),
+            None => Err(DeviceIdentifierError::UnknownKind(identifier.kind.to_i32())),
+        }
+    }
+}
+
+impl From<CanonicalDeviceIdentifier> for WireDeviceIdentifier {
+    fn from(identifier: CanonicalDeviceIdentifier) -> Self {
+        let (kind, value) = match identifier {
+            CanonicalDeviceIdentifier::Serial(serial) => {
+                (IdentifierKind::Serial, serial.into_bytes())
+            }
+            CanonicalDeviceIdentifier::UnitId(unit_id) => {
+                (IdentifierKind::UnitId, unit_id.to_be_bytes().to_vec())
+            }
+            CanonicalDeviceIdentifier::BluetoothAddress(address) => {
+                (IdentifierKind::BluetoothAddress, address.to_vec())
+            }
+        };
+        Self {
+            kind: kind.into(),
+            value,
+            ..Self::default()
+        }
+    }
+}
+
+/// A validation error for a generated device identifier.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum DeviceIdentifierError {
+    /// The required identifier kind was omitted.
+    #[error("identifier kind is unspecified")]
+    UnspecifiedKind,
+    /// The identifier kind is newer than this implementation understands.
+    #[error("unknown identifier kind {0}")]
+    UnknownKind(i32),
+    /// A serial identifier does not contain valid UTF-8.
+    #[error("serial identifier is not valid UTF-8")]
+    InvalidSerialUtf8,
+    /// A fixed-width identifier has a noncanonical byte count.
+    #[error("{kind:?} identifier must be {expected} bytes, received {actual}")]
+    InvalidLength {
+        /// The kind whose value was malformed.
+        kind: IdentifierKind,
+        /// The canonical byte count.
+        expected: usize,
+        /// The supplied byte count.
+        actual: usize,
+    },
+}
+
+/// Returns whether two generated identities denote the same physical device.
+///
+/// Every identifier in both identities is validated first. Malformed,
+/// unspecified, or unknown identifiers prevent correlation and return an error.
+pub fn same_device(
+    first: &DeviceIdentity,
+    second: &DeviceIdentity,
+) -> Result<bool, DeviceIdentifierError> {
+    let first = validated_identifiers(first)?;
+    let second = validated_identifiers(second)?;
+    Ok(first.iter().any(|identifier| second.contains(identifier)))
+}
+
+fn validated_identifiers(
+    identity: &DeviceIdentity,
+) -> Result<Vec<CanonicalDeviceIdentifier>, DeviceIdentifierError> {
+    identity.ids.iter().map(TryFrom::try_from).collect()
+}
+
+fn exact_bytes<const N: usize>(
+    kind: IdentifierKind,
+    value: &[u8],
+) -> Result<[u8; N], DeviceIdentifierError> {
+    value
+        .try_into()
+        .map_err(|_| DeviceIdentifierError::InvalidLength {
+            kind,
+            expected: N,
+            actual: value.len(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CanonicalDeviceIdentifier, DeviceIdentifierError, same_device};
+    use crate::proto::openlogi::flow::v1::{DeviceIdentifier, DeviceIdentity, IdentifierKind};
+
+    fn identity(ids: Vec<CanonicalDeviceIdentifier>) -> DeviceIdentity {
+        DeviceIdentity {
+            ids: ids.into_iter().map(Into::into).collect(),
+            ..DeviceIdentity::default()
+        }
+    }
+
+    #[test]
+    fn canonical_constructors_encode_protocol_bytes() {
+        let serial: DeviceIdentifier = CanonicalDeviceIdentifier::serial("Mx-123").into();
+        let unit: DeviceIdentifier = CanonicalDeviceIdentifier::unit_id(0x1234_abcd).into();
+        let bluetooth: DeviceIdentifier =
+            CanonicalDeviceIdentifier::bluetooth_address([1, 2, 3, 4, 5, 6]).into();
+
+        assert_eq!(serial.value, b"Mx-123");
+        assert_eq!(unit.value, [0x12, 0x34, 0xab, 0xcd]);
+        assert_eq!(bluetooth.value, [1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn nonintersecting_identifiers_do_not_match() {
+        let first = identity(vec![CanonicalDeviceIdentifier::unit_id(1)]);
+        let second = identity(vec![CanonicalDeviceIdentifier::unit_id(2)]);
+        assert!(!same_device(&first, &second).unwrap());
+    }
+
+    #[test]
+    fn any_identifier_intersection_matches() {
+        let first = identity(vec![
+            CanonicalDeviceIdentifier::serial("first"),
+            CanonicalDeviceIdentifier::unit_id(42),
+        ]);
+        let second = identity(vec![
+            CanonicalDeviceIdentifier::serial("second"),
+            CanonicalDeviceIdentifier::unit_id(42),
+        ]);
+        assert!(same_device(&first, &second).unwrap());
+    }
+
+    #[test]
+    fn malformed_identifier_is_rejected() {
+        let malformed = DeviceIdentifier {
+            kind: IdentifierKind::UnitId.into(),
+            value: vec![0, 1, 2],
+            ..DeviceIdentifier::default()
+        };
+        let first = DeviceIdentity {
+            ids: vec![malformed],
+            ..DeviceIdentity::default()
+        };
+
+        assert_eq!(
+            same_device(&first, &DeviceIdentity::default()).unwrap_err(),
+            DeviceIdentifierError::InvalidLength {
+                kind: IdentifierKind::UnitId,
+                expected: 4,
+                actual: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn unspecified_and_unknown_kinds_are_rejected() {
+        let unspecified = DeviceIdentifier::default();
+        let unknown = DeviceIdentifier {
+            kind: 99.into(),
+            ..DeviceIdentifier::default()
+        };
+
+        assert_eq!(
+            CanonicalDeviceIdentifier::try_from(&unspecified).unwrap_err(),
+            DeviceIdentifierError::UnspecifiedKind
+        );
+        assert_eq!(
+            CanonicalDeviceIdentifier::try_from(&unknown).unwrap_err(),
+            DeviceIdentifierError::UnknownKind(99)
+        );
+    }
+}

--- a/crates/openlogi-flow/src/identity.rs
+++ b/crates/openlogi-flow/src/identity.rs
@@ -61,10 +61,14 @@ impl TryFrom<&WireDeviceIdentifier> for CanonicalDeviceIdentifier {
 
     fn try_from(identifier: &WireDeviceIdentifier) -> Result<Self, Self::Error> {
         match identifier.kind.as_known() {
-            Some(IdentifierKind::Serial) => std::str::from_utf8(&identifier.value)
-                .map(str::to_owned)
-                .map(Self::Serial)
-                .map_err(|_| DeviceIdentifierError::InvalidSerialUtf8),
+            Some(IdentifierKind::Serial) => {
+                let serial = std::str::from_utf8(&identifier.value)
+                    .map_err(|_| DeviceIdentifierError::InvalidSerialUtf8)?;
+                if serial.is_empty() {
+                    return Err(DeviceIdentifierError::EmptySerial);
+                }
+                Ok(Self::Serial(serial.to_owned()))
+            }
             Some(IdentifierKind::UnitId) => {
                 let bytes = exact_bytes::<4>(IdentifierKind::UnitId, &identifier.value)?;
                 Ok(Self::UnitId(u32::from_be_bytes(bytes)))
@@ -112,6 +116,9 @@ pub enum DeviceIdentifierError {
     /// A serial identifier does not contain valid UTF-8.
     #[error("serial identifier is not valid UTF-8")]
     InvalidSerialUtf8,
+    /// A serial identifier contains no bytes and cannot identify a device.
+    #[error("serial identifier is empty")]
+    EmptySerial,
     /// A fixed-width identifier has a noncanonical byte count.
     #[error("{kind:?} identifier must be {expected} bytes, received {actual}")]
     InvalidLength {
@@ -219,6 +226,19 @@ mod tests {
                 expected: 4,
                 actual: 3,
             }
+        );
+    }
+
+    #[test]
+    fn empty_serial_is_rejected() {
+        let empty = DeviceIdentifier {
+            kind: IdentifierKind::Serial.into(),
+            ..DeviceIdentifier::default()
+        };
+
+        assert_eq!(
+            CanonicalDeviceIdentifier::try_from(&empty).unwrap_err(),
+            DeviceIdentifierError::EmptySerial
         );
     }
 

--- a/crates/openlogi-flow/src/lib.rs
+++ b/crates/openlogi-flow/src/lib.rs
@@ -8,6 +8,12 @@
 //! [`FLOW-PROTOCOL.md`]: ../../../docs/FLOW-PROTOCOL.md
 //! [`proto/flow.v1.proto`]: ../proto/flow.v1.proto
 
+pub mod frame;
+pub mod identity;
+pub mod negotiation;
+pub mod pairing;
+pub mod sas;
+
 /// Types generated from the authoritative Flow protobuf schema.
 // Buffa emits compatibility suppressions and intentionally mechanical code.
 // The allow is scoped to generated include expansions; clippy cannot credit an

--- a/crates/openlogi-flow/src/lib.rs
+++ b/crates/openlogi-flow/src/lib.rs
@@ -14,6 +14,7 @@ pub mod identity;
 pub mod negotiation;
 pub mod pairing;
 pub mod sas;
+pub mod session;
 pub mod transport;
 
 /// Types generated from the authoritative Flow protobuf schema.

--- a/crates/openlogi-flow/src/lib.rs
+++ b/crates/openlogi-flow/src/lib.rs
@@ -13,6 +13,7 @@ pub mod identity;
 pub mod negotiation;
 pub mod pairing;
 pub mod sas;
+pub mod transport;
 
 /// Types generated from the authoritative Flow protobuf schema.
 // Buffa emits compatibility suppressions and intentionally mechanical code.

--- a/crates/openlogi-flow/src/lib.rs
+++ b/crates/openlogi-flow/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`FLOW-PROTOCOL.md`]: ../../../docs/FLOW-PROTOCOL.md
 //! [`proto/flow.v1.proto`]: ../proto/flow.v1.proto
 
+pub mod discovery;
 pub mod frame;
 pub mod identity;
 pub mod negotiation;

--- a/crates/openlogi-flow/src/lib.rs
+++ b/crates/openlogi-flow/src/lib.rs
@@ -1,0 +1,27 @@
+//! OpenLogi Flow's peer-protocol core.
+//!
+//! The normative protocol is [`FLOW-PROTOCOL.md`], and the authoritative
+//! protobuf schema is [`proto/flow.v1.proto`]. The envelope layout
+//! (`kind: u16 LE`, `flags: u16 LE`, `len: u32 LE`, then payload) and the
+//! existing fields and encoding of `Hello` are frozen forever.
+//!
+//! [`FLOW-PROTOCOL.md`]: ../../../docs/FLOW-PROTOCOL.md
+//! [`proto/flow.v1.proto`]: ../proto/flow.v1.proto
+
+/// Types generated from the authoritative Flow protobuf schema.
+// Buffa emits compatibility suppressions and intentionally mechanical code.
+// The allow is scoped to generated include expansions; clippy cannot credit an
+// `expect` with lints originating there, so fulfilment cannot be tracked.
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "buffa-generated code is not maintained by this crate"
+)]
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/_include.rs"));
+}
+
+/// Generated message and enum types for protocol version 1.
+pub use proto::openlogi::flow::v1 as generated;

--- a/crates/openlogi-flow/src/negotiation.rs
+++ b/crates/openlogi-flow/src/negotiation.rs
@@ -1,0 +1,218 @@
+//! Pure protocol-version, identity, and capability negotiation.
+
+use std::collections::BTreeSet;
+
+use buffa::EnumValue;
+
+use crate::{frame::FrameKind, proto::openlogi::flow::v1 as proto, sas::PublicKey};
+
+/// A capability understood by this implementation.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Capability {
+    /// Text clipboard representations and their bulk transfer frames.
+    ClipboardText,
+    /// Clipboard file-list representations and individual file fetches.
+    ClipboardFiles,
+}
+
+/// Successful result of negotiating two `Hello` messages.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Negotiated {
+    /// Highest mutually supported protocol version.
+    pub version: u32,
+    /// Known capabilities advertised by both peers.
+    pub capabilities: BTreeSet<Capability>,
+}
+
+/// A typed reason to reject the peer's `Hello`.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum HelloRejection {
+    /// The two inclusive version ranges do not overlap.
+    #[error("protocol version ranges are disjoint")]
+    VersionDisjoint,
+    /// The protobuf key does not match the authenticated TLS identity.
+    #[error("Hello public key does not match TLS identity")]
+    KeyMismatch,
+    /// A frozen Hello field violates its required shape.
+    #[error("Hello contains an invalid version range or session nonce")]
+    Malformed,
+}
+
+impl HelloRejection {
+    /// Returns the corresponding protobuf rejection reason.
+    #[must_use]
+    pub const fn reason(&self) -> proto::RejectReason {
+        match self {
+            Self::VersionDisjoint => proto::RejectReason::VersionDisjoint,
+            Self::KeyMismatch => proto::RejectReason::KeyMismatch,
+            Self::Malformed => proto::RejectReason::Malformed,
+        }
+    }
+}
+
+/// Negotiates a local and peer `Hello` after TLS authentication.
+///
+/// Unknown capability numbers are deliberately ignored: protobuf evolution
+/// requires accepting them, but this implementation cannot enable semantics
+/// it does not understand.
+pub fn negotiate(
+    local: &proto::Hello,
+    peer: &proto::Hello,
+    peer_tls_identity: &PublicKey,
+) -> Result<Negotiated, HelloRejection> {
+    let hello_key =
+        PublicKey::try_from(peer.public_key.as_slice()).map_err(|_| HelloRejection::KeyMismatch)?;
+    if &hello_key != peer_tls_identity {
+        return Err(HelloRejection::KeyMismatch);
+    }
+    if peer.proto_min == 0
+        || peer.proto_min > peer.proto_max
+        || peer.session_nonce.len() != 16
+        || local.proto_min == 0
+        || local.proto_min > local.proto_max
+        || local.session_nonce.len() != 16
+    {
+        return Err(HelloRejection::Malformed);
+    }
+
+    let version = local.proto_max.min(peer.proto_max);
+    if version < local.proto_min.max(peer.proto_min) {
+        return Err(HelloRejection::VersionDisjoint);
+    }
+
+    let local_caps = known_capabilities(&local.capabilities);
+    let peer_caps = known_capabilities(&peer.capabilities);
+    Ok(Negotiated {
+        version,
+        capabilities: local_caps.intersection(&peer_caps).copied().collect(),
+    })
+}
+
+/// Send-side protocol and capability gate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SendGate {
+    negotiated: Negotiated,
+}
+
+impl SendGate {
+    /// Creates a gate for a completed negotiation.
+    #[must_use]
+    pub const fn new(negotiated: Negotiated) -> Self {
+        Self { negotiated }
+    }
+
+    /// Returns whether the peer enabled a known capability.
+    #[must_use]
+    pub fn may_send_capability(&self, capability: Capability) -> bool {
+        self.negotiated.capabilities.contains(&capability)
+    }
+
+    /// Returns whether a frame kind may be sent.
+    ///
+    /// All current kinds are version 1. Link and pairing kinds are always
+    /// legal at v1. Clipboard announce/fetch/data use `CLIPBOARD_TEXT`;
+    /// `FileFetch` uses `CLIPBOARD_FILES`. `Chunk` and `ChunkEnd` are legal
+    /// when either clipboard capability is enabled because they carry both
+    /// text and file-fetch response bodies.
+    #[must_use]
+    pub fn may_send_kind(&self, kind: FrameKind) -> bool {
+        if self.negotiated.version < 1 || !kind.is_supported() {
+            return false;
+        }
+        match kind {
+            FrameKind::ClipboardAnnounce | FrameKind::ClipboardFetch => {
+                self.may_send_capability(Capability::ClipboardText)
+            }
+            FrameKind::FileFetch => self.may_send_capability(Capability::ClipboardFiles),
+            FrameKind::ClipboardData | FrameKind::Chunk | FrameKind::ChunkEnd => {
+                self.may_send_capability(Capability::ClipboardText)
+                    || self.may_send_capability(Capability::ClipboardFiles)
+            }
+            _ => true,
+        }
+    }
+}
+
+fn known_capabilities(values: &[EnumValue<proto::Capability>]) -> BTreeSet<Capability> {
+    values
+        .iter()
+        .filter_map(|value| match value.to_i32() {
+            1 => Some(Capability::ClipboardText),
+            2 => Some(Capability::ClipboardFiles),
+            _ => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hello(min: u32, max: u32, key: [u8; 32], caps: &[i32]) -> proto::Hello {
+        proto::Hello {
+            proto_min: min,
+            proto_max: max,
+            public_key: key.to_vec(),
+            session_nonce: vec![0; 16],
+            capabilities: caps.iter().copied().map(EnumValue::from).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn overlap_uses_lower_max_and_intersects_known_caps() {
+        let key = PublicKey::from([7; 32]);
+        let local = hello(1, 3, [1; 32], &[1, 2, 99]);
+        let peer = hello(2, 4, [7; 32], &[1, 99]);
+        let result = negotiate(&local, &peer, &key).unwrap();
+        assert_eq!(result.version, 3);
+        assert_eq!(
+            result.capabilities,
+            BTreeSet::from([Capability::ClipboardText])
+        );
+    }
+
+    #[test]
+    fn disjoint_versions_are_rejected() {
+        let key = PublicKey::from([7; 32]);
+        assert_eq!(
+            negotiate(&hello(1, 1, [1; 32], &[]), &hello(2, 3, [7; 32], &[]), &key),
+            Err(HelloRejection::VersionDisjoint)
+        );
+    }
+
+    #[test]
+    fn key_mismatch_is_rejected() {
+        let key = PublicKey::from([8; 32]);
+        assert_eq!(
+            negotiate(&hello(1, 1, [1; 32], &[]), &hello(1, 1, [7; 32], &[]), &key),
+            Err(HelloRejection::KeyMismatch)
+        );
+    }
+
+    #[test]
+    fn malformed_nonce_is_rejected() {
+        let key = PublicKey::from([7; 32]);
+        let local = hello(1, 1, [1; 32], &[]);
+        let mut peer = hello(1, 1, [7; 32], &[]);
+        peer.session_nonce = vec![0; 15];
+        assert_eq!(
+            negotiate(&local, &peer, &key),
+            Err(HelloRejection::Malformed)
+        );
+    }
+
+    #[test]
+    fn send_gate_applies_family_capabilities() {
+        let gate = SendGate::new(Negotiated {
+            version: 1,
+            capabilities: BTreeSet::from([Capability::ClipboardFiles]),
+        });
+        assert!(gate.may_send_kind(FrameKind::PairStart));
+        assert!(!gate.may_send_kind(FrameKind::ClipboardFetch));
+        assert!(gate.may_send_kind(FrameKind::FileFetch));
+        assert!(gate.may_send_kind(FrameKind::ClipboardData));
+        assert!(gate.may_send_kind(FrameKind::Chunk));
+        assert!(!gate.may_send_kind(FrameKind::Unknown(0x99)));
+    }
+}

--- a/crates/openlogi-flow/src/pairing.rs
+++ b/crates/openlogi-flow/src/pairing.rs
@@ -220,17 +220,19 @@ impl PairingSession {
     /// key and atomically moves the session to [`PairingState::Paired`].
     pub fn confirm_local(
         &mut self,
+        now: Instant,
         store: &mut impl PeerKeyStore,
     ) -> Result<proto::PairResult, PairingError> {
-        self.confirm(ConfirmationSide::Local, store)
+        self.confirm(ConfirmationSide::Local, now, store)
     }
 
     /// Handles a peer `PairConfirm` and returns its idempotent RPC outcome.
     pub fn receive_confirm(
         &mut self,
+        now: Instant,
         store: &mut impl PeerKeyStore,
     ) -> Result<proto::PairOutcome, PairingError> {
-        let result = self.confirm(ConfirmationSide::Peer, store)?;
+        let result = self.confirm(ConfirmationSide::Peer, now, store)?;
         Ok(proto::PairOutcome {
             result: result.into(),
             ..Default::default()
@@ -328,6 +330,7 @@ impl PairingSession {
     fn confirm(
         &mut self,
         side: ConfirmationSide,
+        now: Instant,
         store: &mut impl PeerKeyStore,
     ) -> Result<proto::PairResult, PairingError> {
         if matches!(self.phase, Phase::Paired) {
@@ -343,6 +346,10 @@ impl PairingSession {
         let Phase::Prompted(mut prompted) = self.phase else {
             return Err(PairingError::InvalidTransition(self.state()));
         };
+        if now >= prompted.deadline {
+            self.terminal(Phase::TimedOut);
+            return Ok(proto::PairResult::Timeout);
+        }
         match side {
             ConfirmationSide::Local => prompted.local_confirmed = true,
             ConfirmationSide::Peer => prompted.peer_confirmed = true,
@@ -417,17 +424,18 @@ mod tests {
 
     #[test]
     fn both_confirms_persist_once_and_pair() {
+        let now = Instant::now();
         let mut session = session();
         let mut store = MemoryStore::default();
-        session.receive_start(Instant::now(), None).unwrap();
+        session.receive_start(now, None).unwrap();
 
         assert_eq!(
-            session.confirm_local(&mut store).unwrap(),
+            session.confirm_local(now, &mut store).unwrap(),
             proto::PairResult::PendingLocal
         );
         assert_eq!(
             session
-                .receive_confirm(&mut store)
+                .receive_confirm(now, &mut store)
                 .unwrap()
                 .result
                 .as_known(),
@@ -439,13 +447,39 @@ mod tests {
 
         assert_eq!(
             session
-                .receive_confirm(&mut store)
+                .receive_confirm(now, &mut store)
                 .unwrap()
                 .result
                 .as_known(),
             Some(proto::PairResult::Paired)
         );
         assert_eq!(store.0.len(), 1);
+    }
+
+    #[test]
+    fn confirmation_at_deadline_times_out_without_persisting() {
+        let now = Instant::now();
+        let mut session = session();
+        let mut store = MemoryStore::default();
+        session
+            .receive_start(now, Some(Duration::from_secs(1)))
+            .unwrap();
+
+        assert_eq!(
+            session.confirm_local(now, &mut store).unwrap(),
+            proto::PairResult::PendingLocal
+        );
+        assert_eq!(
+            session
+                .receive_confirm(now + Duration::from_secs(1), &mut store)
+                .unwrap()
+                .result
+                .as_known(),
+            Some(proto::PairResult::Timeout)
+        );
+        assert_eq!(session.state(), PairingState::TimedOut);
+        assert!(store.0.is_empty());
+        assert!(session.sas_code().is_none());
     }
 
     #[test]
@@ -532,13 +566,14 @@ mod tests {
 
     #[test]
     fn repeated_peer_confirm_replays_terminal_outcome() {
+        let now = Instant::now();
         let mut session = session();
         let mut store = MemoryStore::default();
-        session.receive_start(Instant::now(), None).unwrap();
+        session.receive_start(now, None).unwrap();
         session.reject().unwrap();
         assert_eq!(
             session
-                .receive_confirm(&mut store)
+                .receive_confirm(now, &mut store)
                 .unwrap()
                 .result
                 .as_known(),

--- a/crates/openlogi-flow/src/pairing.rs
+++ b/crates/openlogi-flow/src/pairing.rs
@@ -1,0 +1,549 @@
+//! Pairing ceremony state machine and injected peer-key persistence.
+
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+
+use crate::{
+    generated as proto,
+    sas::{PublicKey, SasCode, SessionNonce, derive_sas},
+};
+
+/// Default time for users to compare and confirm the pairing code.
+pub const DEFAULT_PAIRING_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Durable storage used when a pairing session becomes authenticated.
+pub trait PeerKeyStore {
+    /// Persists a newly authenticated peer key.
+    ///
+    /// Implementations must durably commit the key before returning success.
+    fn persist_peer_key(&mut self, key: PublicKey) -> Result<(), PersistPeerKeyError>;
+}
+
+/// Failure while durably persisting an authenticated peer key.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+#[error("failed to persist peer key: {detail}")]
+pub struct PersistPeerKeyError {
+    detail: String,
+}
+
+impl PersistPeerKeyError {
+    /// Creates a persistence error from storage-specific detail.
+    #[must_use]
+    pub fn new(detail: impl Into<String>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+}
+
+/// A pairing abort reason after protobuf validation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PairingAbortReason {
+    /// A user cancelled the ceremony.
+    UserCancelled,
+    /// A user reported that the displayed codes differ.
+    CodeMismatch,
+    /// The confirmation deadline expired.
+    Timeout,
+}
+
+impl From<PairingAbortReason> for proto::PairAbortReason {
+    fn from(reason: PairingAbortReason) -> Self {
+        match reason {
+            PairingAbortReason::UserCancelled => Self::UserCancelled,
+            PairingAbortReason::CodeMismatch => Self::CodeMismatch,
+            PairingAbortReason::Timeout => Self::Timeout,
+        }
+    }
+}
+
+/// Externally observable pairing state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PairingState {
+    /// No `PairStart` / `PairPrompted` exchange has completed.
+    Idle,
+    /// This side sent `PairStart` and is waiting for `PairPrompted`.
+    AwaitingPrompt,
+    /// Both prompts may be shown and confirmations are pending.
+    Prompted {
+        /// Receiver-declared timeout in milliseconds.
+        timeout_ms: u32,
+        /// Whether this side has sent `PairConfirm`.
+        local_confirmed: bool,
+        /// Whether this side has received `PairConfirm`.
+        peer_confirmed: bool,
+    },
+    /// Both confirmations were observed and the peer key was persisted.
+    Paired,
+    /// A user declined the ceremony.
+    Rejected,
+    /// The receiver-declared confirmation deadline expired.
+    TimedOut,
+    /// Either peer aborted the ceremony.
+    Aborted(PairingAbortReason),
+}
+
+/// Invalid state, wire value, or persistence failure during pairing.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum PairingError {
+    /// The requested transition is not legal in the current state.
+    #[error("pairing transition is invalid while in {0:?}")]
+    InvalidTransition(PairingState),
+    /// A required open enum carried an unspecified or unknown value.
+    #[error("invalid pairing enum value {0}")]
+    InvalidEnum(i32),
+    /// The peer key could not be durably persisted.
+    #[error(transparent)]
+    Persistence(#[from] PersistPeerKeyError),
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Prompted {
+    timeout_ms: u32,
+    deadline: Instant,
+    local_confirmed: bool,
+    peer_confirmed: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Phase {
+    Idle,
+    AwaitingPrompt,
+    Prompted(Prompted),
+    Paired,
+    Rejected,
+    TimedOut,
+    Aborted(PairingAbortReason),
+}
+
+/// One connection-scoped, symmetric Flow pairing ceremony.
+///
+/// The session owns the two nonces and discards them on every terminal path.
+/// A retry therefore requires a fresh connection and fresh [`SessionNonce`]s.
+#[derive(Clone, Debug)]
+pub struct PairingSession {
+    peer_key: PublicKey,
+    local_key: PublicKey,
+    nonces: Option<(SessionNonce, SessionNonce)>,
+    phase: Phase,
+}
+
+impl PairingSession {
+    /// Creates an idle session from the authenticated TLS identities and Hello nonces.
+    #[must_use]
+    pub const fn new(
+        local_key: PublicKey,
+        peer_key: PublicKey,
+        local_nonce: SessionNonce,
+        peer_nonce: SessionNonce,
+    ) -> Self {
+        Self {
+            peer_key,
+            local_key,
+            nonces: Some((local_nonce, peer_nonce)),
+            phase: Phase::Idle,
+        }
+    }
+
+    /// Returns the current externally observable state.
+    #[must_use]
+    pub const fn state(&self) -> PairingState {
+        match self.phase {
+            Phase::Idle => PairingState::Idle,
+            Phase::AwaitingPrompt => PairingState::AwaitingPrompt,
+            Phase::Prompted(prompted) => PairingState::Prompted {
+                timeout_ms: prompted.timeout_ms,
+                local_confirmed: prompted.local_confirmed,
+                peer_confirmed: prompted.peer_confirmed,
+            },
+            Phase::Paired => PairingState::Paired,
+            Phase::Rejected => PairingState::Rejected,
+            Phase::TimedOut => PairingState::TimedOut,
+            Phase::Aborted(reason) => PairingState::Aborted(reason),
+        }
+    }
+
+    /// Returns the TLS-authenticated peer key this ceremony can persist.
+    #[must_use]
+    pub const fn peer_key(&self) -> PublicKey {
+        self.peer_key
+    }
+
+    /// Derives the code shown on this side while the ceremony is active.
+    #[must_use]
+    pub fn sas_code(&self) -> Option<SasCode> {
+        self.nonces.map(|(local_nonce, peer_nonce)| {
+            derive_sas(self.local_key, self.peer_key, local_nonce, peer_nonce)
+        })
+    }
+
+    /// Begins an initiating-side ceremony and creates its `PairStart` request.
+    pub fn start(&mut self) -> Result<proto::PairStart, PairingError> {
+        self.ensure_idle()?;
+        self.phase = Phase::AwaitingPrompt;
+        Ok(proto::PairStart::default())
+    }
+
+    /// Handles `PairStart` and returns the receiver-declared prompt timeout.
+    pub fn receive_start(
+        &mut self,
+        now: Instant,
+        timeout: Option<Duration>,
+    ) -> Result<proto::PairPrompted, PairingError> {
+        self.ensure_idle()?;
+        let timeout = timeout.unwrap_or(DEFAULT_PAIRING_TIMEOUT);
+        Ok(self.enter_prompted(now, timeout))
+    }
+
+    /// Handles a `PairPrompted` response on the initiating side.
+    pub fn receive_prompted(
+        &mut self,
+        prompted: &proto::PairPrompted,
+        now: Instant,
+    ) -> Result<(), PairingError> {
+        if !matches!(self.phase, Phase::AwaitingPrompt) {
+            return Err(PairingError::InvalidTransition(self.state()));
+        }
+        let timeout = if prompted.timeout_ms == 0 {
+            DEFAULT_PAIRING_TIMEOUT
+        } else {
+            Duration::from_millis(u64::from(prompted.timeout_ms))
+        };
+        self.enter_prompted(now, timeout);
+        Ok(())
+    }
+
+    /// Records that this side sent `PairConfirm`.
+    ///
+    /// If the peer confirmation was already received, this persists the peer
+    /// key and atomically moves the session to [`PairingState::Paired`].
+    pub fn confirm_local(
+        &mut self,
+        store: &mut impl PeerKeyStore,
+    ) -> Result<proto::PairResult, PairingError> {
+        self.confirm(ConfirmationSide::Local, store)
+    }
+
+    /// Handles a peer `PairConfirm` and returns its idempotent RPC outcome.
+    pub fn receive_confirm(
+        &mut self,
+        store: &mut impl PeerKeyStore,
+    ) -> Result<proto::PairOutcome, PairingError> {
+        let result = self.confirm(ConfirmationSide::Peer, store)?;
+        Ok(proto::PairOutcome {
+            result: result.into(),
+            ..Default::default()
+        })
+    }
+
+    /// Applies a peer-provided `PairOutcome` after validating its open enum.
+    pub fn receive_outcome(&mut self, outcome: &proto::PairOutcome) -> Result<(), PairingError> {
+        match outcome.result.as_known() {
+            Some(proto::PairResult::Paired) => {
+                if matches!(self.phase, Phase::Paired) {
+                    Ok(())
+                } else {
+                    Err(PairingError::InvalidTransition(self.state()))
+                }
+            }
+            Some(proto::PairResult::PendingLocal) => self.ensure_prompted(),
+            Some(proto::PairResult::Rejected) => {
+                self.ensure_prompted()?;
+                self.terminal(Phase::Rejected);
+                Ok(())
+            }
+            Some(proto::PairResult::Timeout) => {
+                self.ensure_prompted()?;
+                self.terminal(Phase::TimedOut);
+                Ok(())
+            }
+            Some(proto::PairResult::Unspecified) | None => {
+                Err(PairingError::InvalidEnum(outcome.result.to_i32()))
+            }
+        }
+    }
+
+    /// Rejects the local prompt and returns the terminal RPC outcome.
+    pub fn reject(&mut self) -> Result<proto::PairOutcome, PairingError> {
+        self.ensure_prompted()?;
+        self.terminal(Phase::Rejected);
+        Ok(pair_outcome(proto::PairResult::Rejected))
+    }
+
+    /// Aborts the current ceremony and discards its nonces.
+    pub fn abort(&mut self, reason: PairingAbortReason) -> Result<proto::PairAbort, PairingError> {
+        self.ensure_prompted()?;
+        self.terminal(Phase::Aborted(reason));
+        Ok(proto::PairAbort {
+            reason: proto::PairAbortReason::from(reason).into(),
+            ..Default::default()
+        })
+    }
+
+    /// Handles a peer `PairAbort` after validating its open enum.
+    pub fn receive_abort(&mut self, abort: &proto::PairAbort) -> Result<(), PairingError> {
+        self.ensure_prompted()?;
+        let reason = match abort.reason.as_known() {
+            Some(proto::PairAbortReason::UserCancelled) => PairingAbortReason::UserCancelled,
+            Some(proto::PairAbortReason::CodeMismatch) => PairingAbortReason::CodeMismatch,
+            Some(proto::PairAbortReason::Timeout) => PairingAbortReason::Timeout,
+            Some(proto::PairAbortReason::Unspecified) | None => {
+                return Err(PairingError::InvalidEnum(abort.reason.to_i32()));
+            }
+        };
+        self.terminal(Phase::Aborted(reason));
+        Ok(())
+    }
+
+    /// Transitions an expired prompted session to `TIMEOUT`.
+    ///
+    /// Returns `None` when the deadline has not expired or the session is
+    /// already terminal.
+    pub fn check_timeout(&mut self, now: Instant) -> Option<proto::PairOutcome> {
+        let Phase::Prompted(prompted) = self.phase else {
+            return None;
+        };
+        if now < prompted.deadline {
+            return None;
+        }
+        self.terminal(Phase::TimedOut);
+        Some(pair_outcome(proto::PairResult::Timeout))
+    }
+
+    fn enter_prompted(&mut self, now: Instant, timeout: Duration) -> proto::PairPrompted {
+        let timeout_ms = u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX);
+        self.phase = Phase::Prompted(Prompted {
+            timeout_ms,
+            deadline: now + Duration::from_millis(u64::from(timeout_ms)),
+            local_confirmed: false,
+            peer_confirmed: false,
+        });
+        proto::PairPrompted {
+            timeout_ms,
+            ..Default::default()
+        }
+    }
+
+    fn confirm(
+        &mut self,
+        side: ConfirmationSide,
+        store: &mut impl PeerKeyStore,
+    ) -> Result<proto::PairResult, PairingError> {
+        if matches!(self.phase, Phase::Paired) {
+            return Ok(proto::PairResult::Paired);
+        }
+        if matches!(side, ConfirmationSide::Peer) {
+            match self.phase {
+                Phase::Rejected => return Ok(proto::PairResult::Rejected),
+                Phase::TimedOut => return Ok(proto::PairResult::Timeout),
+                _ => {}
+            }
+        }
+        let Phase::Prompted(mut prompted) = self.phase else {
+            return Err(PairingError::InvalidTransition(self.state()));
+        };
+        match side {
+            ConfirmationSide::Local => prompted.local_confirmed = true,
+            ConfirmationSide::Peer => prompted.peer_confirmed = true,
+        }
+        self.phase = Phase::Prompted(prompted);
+        if prompted.local_confirmed && prompted.peer_confirmed {
+            store.persist_peer_key(self.peer_key)?;
+            self.terminal(Phase::Paired);
+            Ok(proto::PairResult::Paired)
+        } else {
+            Ok(proto::PairResult::PendingLocal)
+        }
+    }
+
+    fn ensure_idle(&self) -> Result<(), PairingError> {
+        if matches!(self.phase, Phase::Idle) {
+            Ok(())
+        } else {
+            Err(PairingError::InvalidTransition(self.state()))
+        }
+    }
+
+    fn ensure_prompted(&self) -> Result<(), PairingError> {
+        if matches!(self.phase, Phase::Prompted(_)) {
+            Ok(())
+        } else {
+            Err(PairingError::InvalidTransition(self.state()))
+        }
+    }
+
+    fn terminal(&mut self, phase: Phase) {
+        self.nonces = None;
+        self.phase = phase;
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ConfirmationSide {
+    Local,
+    Peer,
+}
+
+fn pair_outcome(result: proto::PairResult) -> proto::PairOutcome {
+    proto::PairOutcome {
+        result: result.into(),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct MemoryStore(Vec<PublicKey>);
+
+    impl PeerKeyStore for MemoryStore {
+        fn persist_peer_key(&mut self, key: PublicKey) -> Result<(), PersistPeerKeyError> {
+            self.0.push(key);
+            Ok(())
+        }
+    }
+
+    fn session() -> PairingSession {
+        PairingSession::new(
+            PublicKey::new([1; 32]),
+            PublicKey::new([2; 32]),
+            SessionNonce::new([3; 16]),
+            SessionNonce::new([4; 16]),
+        )
+    }
+
+    #[test]
+    fn both_confirms_persist_once_and_pair() {
+        let mut session = session();
+        let mut store = MemoryStore::default();
+        session.receive_start(Instant::now(), None).unwrap();
+
+        assert_eq!(
+            session.confirm_local(&mut store).unwrap(),
+            proto::PairResult::PendingLocal
+        );
+        assert_eq!(
+            session
+                .receive_confirm(&mut store)
+                .unwrap()
+                .result
+                .as_known(),
+            Some(proto::PairResult::Paired)
+        );
+        assert_eq!(session.state(), PairingState::Paired);
+        assert_eq!(store.0, [PublicKey::new([2; 32])]);
+        assert!(session.sas_code().is_none());
+
+        assert_eq!(
+            session
+                .receive_confirm(&mut store)
+                .unwrap()
+                .result
+                .as_known(),
+            Some(proto::PairResult::Paired)
+        );
+        assert_eq!(store.0.len(), 1);
+    }
+
+    #[test]
+    fn timeout_uses_default_and_discards_nonce() {
+        let now = Instant::now();
+        let mut session = session();
+        let prompted = session.receive_start(now, None).unwrap();
+        assert_eq!(prompted.timeout_ms, 120_000);
+        assert!(
+            session
+                .check_timeout(now + Duration::from_secs(119))
+                .is_none()
+        );
+        assert_eq!(
+            session
+                .check_timeout(now + Duration::from_secs(120))
+                .unwrap()
+                .result
+                .as_known(),
+            Some(proto::PairResult::Timeout)
+        );
+        assert_eq!(session.state(), PairingState::TimedOut);
+        assert!(session.sas_code().is_none());
+    }
+
+    #[test]
+    fn abort_paths_are_terminal() {
+        for reason in [
+            PairingAbortReason::UserCancelled,
+            PairingAbortReason::CodeMismatch,
+            PairingAbortReason::Timeout,
+        ] {
+            let mut session = session();
+            session.receive_start(Instant::now(), None).unwrap();
+            session.abort(reason).unwrap();
+            assert_eq!(session.state(), PairingState::Aborted(reason));
+            assert!(session.sas_code().is_none());
+        }
+    }
+
+    #[test]
+    fn outcomes_cannot_start_or_overwrite_a_session() {
+        let mut session = session();
+        for result in [
+            proto::PairResult::PendingLocal,
+            proto::PairResult::Rejected,
+            proto::PairResult::Timeout,
+        ] {
+            assert_eq!(
+                session.receive_outcome(&pair_outcome(result)),
+                Err(PairingError::InvalidTransition(PairingState::Idle))
+            );
+        }
+
+        session.receive_start(Instant::now(), None).unwrap();
+        session.reject().unwrap();
+        assert_eq!(
+            session.receive_outcome(&pair_outcome(proto::PairResult::Timeout)),
+            Err(PairingError::InvalidTransition(PairingState::Rejected))
+        );
+    }
+
+    #[test]
+    fn prompted_requires_a_locally_started_session() {
+        let mut session = session();
+        let prompted = proto::PairPrompted {
+            timeout_ms: 1_000,
+            ..Default::default()
+        };
+        assert_eq!(
+            session.receive_prompted(&prompted, Instant::now()),
+            Err(PairingError::InvalidTransition(PairingState::Idle))
+        );
+        session.start().unwrap();
+        session.receive_prompted(&prompted, Instant::now()).unwrap();
+        assert!(matches!(
+            session.state(),
+            PairingState::Prompted {
+                timeout_ms: 1_000,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn repeated_peer_confirm_replays_terminal_outcome() {
+        let mut session = session();
+        let mut store = MemoryStore::default();
+        session.receive_start(Instant::now(), None).unwrap();
+        session.reject().unwrap();
+        assert_eq!(
+            session
+                .receive_confirm(&mut store)
+                .unwrap()
+                .result
+                .as_known(),
+            Some(proto::PairResult::Rejected)
+        );
+        assert!(store.0.is_empty());
+    }
+}

--- a/crates/openlogi-flow/src/sas.rs
+++ b/crates/openlogi-flow/src/sas.rs
@@ -1,0 +1,194 @@
+//! Short authentication string derivation for Flow pairing.
+
+use std::fmt;
+
+use hkdf::Hkdf;
+use sha2::Sha256;
+use thiserror::Error;
+
+const SAS_INFO: &[u8] = b"openlogi-flow-sas-v1";
+
+/// A validated 32-byte Ed25519 public key.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PublicKey([u8; 32]);
+
+impl PublicKey {
+    /// Creates a public key from its canonical 32-byte representation.
+    #[must_use]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the canonical key bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for PublicKey {
+    fn from(value: [u8; 32]) -> Self {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = FixedBytesError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        <[u8; 32]>::try_from(value)
+            .map(Self)
+            .map_err(|_| FixedBytesError::new(32, value.len()))
+    }
+}
+
+/// A validated 16-byte nonce that uniquely identifies a pairing session.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SessionNonce([u8; 16]);
+
+impl SessionNonce {
+    /// Creates a session nonce from its canonical 16-byte representation.
+    #[must_use]
+    pub const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the nonce bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl From<[u8; 16]> for SessionNonce {
+    fn from(value: [u8; 16]) -> Self {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&[u8]> for SessionNonce {
+    type Error = FixedBytesError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        <[u8; 16]>::try_from(value)
+            .map(Self)
+            .map_err(|_| FixedBytesError::new(16, value.len()))
+    }
+}
+
+/// An error converting bytes into a fixed-width Flow value.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("expected {expected} bytes, received {actual}")]
+pub struct FixedBytesError {
+    expected: usize,
+    actual: usize,
+}
+
+impl FixedBytesError {
+    const fn new(expected: usize, actual: usize) -> Self {
+        Self { expected, actual }
+    }
+
+    /// Returns the required byte count.
+    #[must_use]
+    pub const fn expected(self) -> usize {
+        self.expected
+    }
+
+    /// Returns the supplied byte count.
+    #[must_use]
+    pub const fn actual(self) -> usize {
+        self.actual
+    }
+}
+
+/// A six-decimal-digit Flow short authentication string.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct SasCode(u32);
+
+impl SasCode {
+    /// Returns the numeric code in the range `0..1_000_000`.
+    #[must_use]
+    pub const fn value(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for SasCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:06}", self.0)
+    }
+}
+
+/// Derives the symmetric Flow SAS from two peers' public keys and session nonces.
+///
+/// Keys and nonces are independently ordered byte-lexicographically, making the
+/// result independent of which peer initiates the connection.
+#[must_use]
+pub fn derive_sas(
+    first_key: PublicKey,
+    second_key: PublicKey,
+    first_nonce: SessionNonce,
+    second_nonce: SessionNonce,
+) -> SasCode {
+    let (low_key, high_key) = ordered(first_key.as_bytes(), second_key.as_bytes());
+    let (low_nonce, high_nonce) = ordered(first_nonce.as_bytes(), second_nonce.as_bytes());
+
+    let mut ikm = [0_u8; 64];
+    ikm[..32].copy_from_slice(low_key);
+    ikm[32..].copy_from_slice(high_key);
+    let mut salt = [0_u8; 32];
+    salt[..16].copy_from_slice(low_nonce);
+    salt[16..].copy_from_slice(high_nonce);
+
+    let hkdf = Hkdf::<Sha256>::new(Some(&salt), &ikm);
+    let mut output = [0_u8; 4];
+    // Four bytes are always below HKDF-SHA256's 8160-byte output limit.
+    hkdf.expand(SAS_INFO, &mut output)
+        .unwrap_or_else(|_| unreachable!("four-byte HKDF output is always valid"));
+    SasCode(u32::from_be_bytes(output) % 1_000_000)
+}
+
+fn ordered<'a, T: Ord>(first: &'a T, second: &'a T) -> (&'a T, &'a T) {
+    if first <= second {
+        (first, second)
+    } else {
+        (second, first)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PublicKey, SessionNonce, derive_sas};
+
+    #[test]
+    fn fixed_protocol_vector() {
+        let first_key = PublicKey::new(core::array::from_fn(|index| u8::try_from(index).unwrap()));
+        let second_key = PublicKey::new(core::array::from_fn(|index| {
+            u8::try_from(index + 32).unwrap()
+        }));
+        let first_nonce =
+            SessionNonce::new(core::array::from_fn(|index| u8::try_from(index).unwrap()));
+        let second_nonce = SessionNonce::new(core::array::from_fn(|index| {
+            u8::try_from(index + 16).unwrap()
+        }));
+
+        assert_eq!(
+            derive_sas(first_key, second_key, first_nonce, second_nonce).to_string(),
+            "136751"
+        );
+    }
+
+    #[test]
+    fn swapping_peers_preserves_code() {
+        let first_key = PublicKey::new([0x55; 32]);
+        let second_key = PublicKey::new([0xaa; 32]);
+        let first_nonce = SessionNonce::new([0x11; 16]);
+        let second_nonce = SessionNonce::new([0xee; 16]);
+
+        assert_eq!(
+            derive_sas(first_key, second_key, first_nonce, second_nonce),
+            derive_sas(second_key, first_key, second_nonce, first_nonce)
+        );
+    }
+}

--- a/crates/openlogi-flow/src/session.rs
+++ b/crates/openlogi-flow/src/session.rs
@@ -1,0 +1,713 @@
+//! Long-lived peer sessions over discovered address hints.
+//!
+//! The manager owns connection establishment and Ping/Pong datagrams. It does
+//! not consume RPC or notification streams; embedders obtain the current
+//! [`FlowConnection`] through [`PeerSessionHandle`] and retain ownership of
+//! application protocol handling.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    sync::Arc,
+    time::Duration,
+};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::{
+    runtime::Handle,
+    sync::{mpsc, watch},
+    task::{JoinHandle, JoinSet},
+    time::{Instant, MissedTickBehavior},
+};
+
+use crate::{
+    discovery::{CandidateSource, collect_candidates},
+    frame::{FrameKind, InboundRole},
+    generated as proto,
+    sas::PublicKey,
+    transport::{
+        ConnectionDirection, FlowConnection, FlowEndpoint, SessionTrust, message_envelope,
+    },
+};
+
+const INCOMING_QUEUE: usize = 4;
+const TRUST_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Churn-safe state of a configured peer session.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LinkState {
+    /// QUIC and Hello are established and liveness is healthy or in its initial grace period.
+    Connected,
+    /// QUIC remains established, but no valid application-level Pong arrived within the limit.
+    Degraded,
+    /// No established QUIC connection exists.
+    Lost,
+}
+
+/// Timing policy for dialing and application-level liveness.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SessionPolicy {
+    /// Delay before the first retry, doubled for each consecutive failure.
+    pub retry_base: Duration,
+    /// Maximum retry delay after deterministic ±25% per-peer jitter.
+    pub retry_max: Duration,
+    /// Interval between Ping datagrams.
+    pub ping_interval: Duration,
+    /// Time without a valid Pong before [`LinkState::Degraded`].
+    pub degraded_after: Duration,
+}
+
+impl Default for SessionPolicy {
+    fn default() -> Self {
+        Self {
+            retry_base: Duration::from_millis(250),
+            retry_max: Duration::from_secs(30),
+            ping_interval: Duration::from_secs(5),
+            degraded_after: Duration::from_secs(15),
+        }
+    }
+}
+
+impl SessionPolicy {
+    fn validate(self) -> Result<(), SessionManagerError> {
+        if self.retry_base.is_zero() {
+            return Err(SessionManagerError::InvalidPolicy(
+                "retry_base must be nonzero",
+            ));
+        }
+        if self.retry_max < self.retry_base {
+            return Err(SessionManagerError::InvalidPolicy(
+                "retry_max must not be shorter than retry_base",
+            ));
+        }
+        if self.ping_interval.is_zero() {
+            return Err(SessionManagerError::InvalidPolicy(
+                "ping_interval must be nonzero",
+            ));
+        }
+        if self.degraded_after <= self.ping_interval {
+            return Err(SessionManagerError::InvalidPolicy(
+                "degraded_after must be longer than ping_interval",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Discovery configuration for one pinned peer identity.
+pub struct PeerConfig {
+    /// TLS-authenticated Ed25519 peer key.
+    pub public_key: PublicKey,
+    /// Concurrent sources of untrusted address hints.
+    pub sources: Vec<Arc<dyn CandidateSource>>,
+}
+
+impl fmt::Debug for PeerConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PeerConfig")
+            .field("public_key", &self.public_key)
+            .field("source_count", &self.sources.len())
+            .finish()
+    }
+}
+
+/// Whole-state payloads sent once whenever a session becomes trusted.
+#[derive(Clone, Debug, Default)]
+pub struct TrustedInitialState {
+    /// Complete current device inventory.
+    pub announce_devices: proto::AnnounceDevices,
+    /// Complete current coarse peer state.
+    pub peer_state: proto::PeerState,
+}
+
+/// Embedder-owned provider for state that has no dependency on OpenLogi device types.
+pub trait TrustedStateProvider: Send + Sync {
+    /// Returns the current whole-state notifications for `peer_key`.
+    fn initial_state(&self, peer_key: PublicKey) -> TrustedInitialState;
+}
+
+/// Watchable state and current connection for one configured peer.
+#[derive(Clone, Debug)]
+pub struct PeerSessionHandle {
+    public_key: PublicKey,
+    state: watch::Receiver<LinkState>,
+    connection: watch::Receiver<Option<Arc<FlowConnection>>>,
+}
+
+impl PeerSessionHandle {
+    /// Returns the configured peer identity.
+    #[must_use]
+    pub const fn public_key(&self) -> PublicKey {
+        self.public_key
+    }
+
+    /// Returns the most recently published coarse state.
+    #[must_use]
+    pub fn state(&self) -> LinkState {
+        *self.state.borrow()
+    }
+
+    /// Subscribes to coarse state changes.
+    #[must_use]
+    pub fn subscribe_state(&self) -> watch::Receiver<LinkState> {
+        self.state.clone()
+    }
+
+    /// Returns the current live connection, if one exists.
+    ///
+    /// The manager retains authority to close and replace this connection.
+    #[must_use]
+    pub fn connection(&self) -> Option<Arc<FlowConnection>> {
+        self.connection.borrow().clone()
+    }
+
+    /// Subscribes to live-connection replacement.
+    #[must_use]
+    pub fn subscribe_connection(&self) -> watch::Receiver<Option<Arc<FlowConnection>>> {
+        self.connection.clone()
+    }
+}
+
+/// Owns one reconnecting session worker per configured peer key.
+pub struct SessionManager {
+    shutdown: watch::Sender<bool>,
+    accept_task: Option<JoinHandle<()>>,
+    peer_tasks: Vec<JoinHandle<()>>,
+    peers: BTreeMap<PublicKey, PeerSessionHandle>,
+    _provider: Arc<dyn TrustedStateProvider>,
+}
+
+impl fmt::Debug for SessionManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionManager")
+            .field("peer_count", &self.peers.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl SessionManager {
+    /// Starts accepting and dialing sessions on `endpoint`.
+    ///
+    /// The endpoint's TLS trust policy remains the source of peer identity;
+    /// configured candidate addresses never grant trust.
+    pub fn start(
+        endpoint: Arc<FlowEndpoint>,
+        peers: impl IntoIterator<Item = PeerConfig>,
+        provider: Arc<dyn TrustedStateProvider>,
+        policy: SessionPolicy,
+    ) -> Result<Self, SessionManagerError> {
+        policy.validate()?;
+        let runtime = Handle::try_current()
+            .map_err(|error| SessionManagerError::Runtime(error.to_string()))?;
+        let peers = peers.into_iter().collect::<Vec<_>>();
+        let mut unique = BTreeSet::new();
+        for peer in &peers {
+            if peer.public_key == endpoint.public_key() {
+                return Err(SessionManagerError::LocalPeer(peer.public_key));
+            }
+            if !unique.insert(peer.public_key) {
+                return Err(SessionManagerError::DuplicatePeer(peer.public_key));
+            }
+        }
+
+        let (shutdown, shutdown_rx) = watch::channel(false);
+        let mut routes = BTreeMap::new();
+        let mut handles = BTreeMap::new();
+        let mut peer_tasks = Vec::with_capacity(peers.len());
+        for peer in peers {
+            let (incoming_tx, incoming_rx) = mpsc::channel(INCOMING_QUEUE);
+            let (state_tx, state_rx) = watch::channel(LinkState::Lost);
+            let (connection_tx, connection_rx) = watch::channel(None);
+            let public_key = peer.public_key;
+            routes.insert(public_key, incoming_tx);
+            handles.insert(
+                public_key,
+                PeerSessionHandle {
+                    public_key,
+                    state: state_rx,
+                    connection: connection_rx,
+                },
+            );
+            let signals = PeerSignals {
+                state: state_tx,
+                connection: connection_tx,
+            };
+            peer_tasks.push(runtime.spawn(run_peer(
+                Arc::clone(&endpoint),
+                peer,
+                incoming_rx,
+                signals,
+                Arc::clone(&provider),
+                policy,
+                shutdown_rx.clone(),
+            )));
+        }
+        let accept_task = runtime.spawn(accept_connections(endpoint, routes, shutdown_rx));
+        Ok(Self {
+            shutdown,
+            accept_task: Some(accept_task),
+            peer_tasks,
+            peers: handles,
+            _provider: provider,
+        })
+    }
+
+    /// Returns the handle for one configured peer.
+    #[must_use]
+    pub fn peer(&self, public_key: PublicKey) -> Option<&PeerSessionHandle> {
+        self.peers.get(&public_key)
+    }
+
+    /// Iterates all configured peer handles in public-key order.
+    #[must_use]
+    pub fn peers(&self) -> impl ExactSizeIterator<Item = &PeerSessionHandle> {
+        self.peers.values()
+    }
+
+    /// Stops all workers and closes their live connections without closing the shared endpoint.
+    pub async fn shutdown(mut self) {
+        self.signal_shutdown();
+        if let Some(task) = self.accept_task.take() {
+            let _ = task.await;
+        }
+        for task in self.peer_tasks.drain(..) {
+            let _ = task.await;
+        }
+    }
+
+    fn signal_shutdown(&self) {
+        self.shutdown.send_replace(true);
+        for peer in self.peers.values() {
+            if let Some(connection) = peer.connection() {
+                connection.close();
+            }
+        }
+    }
+}
+
+impl Drop for SessionManager {
+    fn drop(&mut self) {
+        self.signal_shutdown();
+        if let Some(task) = self.accept_task.take() {
+            task.abort();
+        }
+        for task in &self.peer_tasks {
+            task.abort();
+        }
+    }
+}
+
+/// Configuration errors that prevent a session manager from starting.
+#[derive(Debug, Error)]
+pub enum SessionManagerError {
+    /// A timing relationship would make retry or liveness behavior invalid.
+    #[error("invalid session policy: {0}")]
+    InvalidPolicy(&'static str),
+    /// One peer key appeared more than once.
+    #[error("duplicate configured peer key {0:?}")]
+    DuplicatePeer(PublicKey),
+    /// The local machine key was incorrectly configured as a peer.
+    #[error("local machine key cannot be configured as peer {0:?}")]
+    LocalPeer(PublicKey),
+    /// The manager was started outside a Tokio runtime.
+    #[error("Tokio runtime is unavailable: {0}")]
+    Runtime(String),
+}
+
+async fn accept_connections(
+    endpoint: Arc<FlowEndpoint>,
+    routes: BTreeMap<PublicKey, mpsc::Sender<FlowConnection>>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        tokio::select! {
+            accepted = endpoint.accept() => match accepted {
+                Ok(connection) => {
+                    let Some(route) = routes.get(&connection.peer_key()) else {
+                        connection.close();
+                        continue;
+                    };
+                    if let Err(error) = route.try_send(connection) {
+                        error.into_inner().close();
+                    }
+                }
+                Err(crate::transport::TransportError::EndpointClosed) => return,
+                Err(_) => {}
+            },
+            _ = shutdown.changed() => return,
+        }
+    }
+}
+
+struct PeerSignals {
+    state: watch::Sender<LinkState>,
+    connection: watch::Sender<Option<Arc<FlowConnection>>>,
+}
+
+async fn run_peer(
+    endpoint: Arc<FlowEndpoint>,
+    peer: PeerConfig,
+    mut incoming: mpsc::Receiver<FlowConnection>,
+    signals: PeerSignals,
+    provider: Arc<dyn TrustedStateProvider>,
+    policy: SessionPolicy,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let mut retry_attempt = 0;
+    let mut pending_connection = None;
+    loop {
+        let connection = if let Some(connection) = pending_connection.take() {
+            connection
+        } else {
+            match acquire_connection(&endpoint, &peer, &mut incoming, &mut shutdown).await {
+                AcquireOutcome::Connection(connection) => {
+                    retry_attempt = 0;
+                    connection
+                }
+                AcquireOutcome::Unavailable => {
+                    let delay = retry_delay(policy, peer.public_key, retry_attempt);
+                    retry_attempt = retry_attempt.saturating_add(1);
+                    match wait_before_retry(delay, &mut incoming, &mut shutdown).await {
+                        WaitOutcome::Connection(connection) => connection,
+                        WaitOutcome::Elapsed => continue,
+                        WaitOutcome::Shutdown => return,
+                    }
+                }
+                AcquireOutcome::Shutdown => return,
+            }
+        };
+        signals.state.send_replace(LinkState::Connected);
+        signals
+            .connection
+            .send_replace(Some(Arc::clone(&connection)));
+
+        match run_connection(
+            &connection,
+            &mut incoming,
+            &signals.state,
+            provider.as_ref(),
+            policy,
+            &mut shutdown,
+        )
+        .await
+        {
+            LiveOutcome::Replace(replacement) => {
+                pending_connection = Some(replacement);
+            }
+            LiveOutcome::Closed => {
+                connection.close();
+                signals.connection.send_replace(None);
+                signals.state.send_replace(LinkState::Lost);
+                retry_attempt = 0;
+                match wait_before_retry(
+                    retry_delay(policy, peer.public_key, retry_attempt),
+                    &mut incoming,
+                    &mut shutdown,
+                )
+                .await
+                {
+                    WaitOutcome::Connection(replacement) => {
+                        pending_connection = Some(replacement);
+                    }
+                    WaitOutcome::Elapsed => {
+                        retry_attempt = 1;
+                    }
+                    WaitOutcome::Shutdown => return,
+                }
+            }
+            LiveOutcome::Shutdown => {
+                connection.close();
+                signals.connection.send_replace(None);
+                signals.state.send_replace(LinkState::Lost);
+                return;
+            }
+        }
+    }
+}
+
+enum AcquireOutcome {
+    Connection(Arc<FlowConnection>),
+    Unavailable,
+    Shutdown,
+}
+
+async fn acquire_connection(
+    endpoint: &Arc<FlowEndpoint>,
+    peer: &PeerConfig,
+    incoming: &mut mpsc::Receiver<FlowConnection>,
+    shutdown: &mut watch::Receiver<bool>,
+) -> AcquireOutcome {
+    if *shutdown.borrow() {
+        return AcquireOutcome::Shutdown;
+    }
+    let dial = dial_candidates(endpoint, peer);
+    tokio::pin!(dial);
+    let mut pending_incoming = None;
+    loop {
+        tokio::select! {
+            dialed = &mut dial => {
+                return match (dialed, pending_incoming) {
+                    (Some(outgoing), Some(incoming)) if endpoint.public_key() < peer.public_key => {
+                        outgoing.close();
+                        AcquireOutcome::Connection(incoming)
+                    }
+                    (Some(outgoing), Some(incoming)) => {
+                        incoming.close();
+                        AcquireOutcome::Connection(outgoing)
+                    }
+                    (Some(outgoing), None) => AcquireOutcome::Connection(outgoing),
+                    (None, Some(incoming)) => AcquireOutcome::Connection(incoming),
+                    (None, None) => AcquireOutcome::Unavailable,
+                };
+            }
+            candidate = incoming.recv() => {
+                let Some(candidate) = candidate else {
+                    return AcquireOutcome::Unavailable;
+                };
+                let candidate = Arc::new(candidate);
+                if endpoint.public_key() < peer.public_key {
+                    return AcquireOutcome::Connection(candidate);
+                }
+                if pending_incoming.is_some() {
+                    candidate.close();
+                } else {
+                    pending_incoming = Some(candidate);
+                }
+            }
+            _ = shutdown.changed() => return AcquireOutcome::Shutdown,
+        }
+    }
+}
+
+async fn dial_candidates(
+    endpoint: &Arc<FlowEndpoint>,
+    peer: &PeerConfig,
+) -> Option<Arc<FlowConnection>> {
+    let addresses = collect_candidates(&peer.sources, peer.public_key)
+        .await
+        .ok()?;
+    let mut attempts = JoinSet::new();
+    for address in addresses {
+        let endpoint = Arc::clone(endpoint);
+        attempts.spawn(async move { endpoint.connect(address).await });
+    }
+    while let Some(result) = attempts.join_next().await {
+        if let Ok(Ok(connection)) = result {
+            if connection.peer_key() == peer.public_key {
+                return Some(Arc::new(connection));
+            }
+            connection.close();
+        }
+    }
+    None
+}
+
+enum WaitOutcome {
+    Connection(Arc<FlowConnection>),
+    Elapsed,
+    Shutdown,
+}
+
+async fn wait_before_retry(
+    delay: Duration,
+    incoming: &mut mpsc::Receiver<FlowConnection>,
+    shutdown: &mut watch::Receiver<bool>,
+) -> WaitOutcome {
+    if *shutdown.borrow() {
+        return WaitOutcome::Shutdown;
+    }
+    tokio::select! {
+        () = tokio::time::sleep(delay) => WaitOutcome::Elapsed,
+        candidate = incoming.recv() => match candidate {
+            Some(candidate) => WaitOutcome::Connection(Arc::new(candidate)),
+            None => WaitOutcome::Elapsed,
+        },
+        _ = shutdown.changed() => WaitOutcome::Shutdown,
+    }
+}
+
+enum LiveOutcome {
+    Replace(Arc<FlowConnection>),
+    Closed,
+    Shutdown,
+}
+
+async fn run_connection(
+    connection: &Arc<FlowConnection>,
+    incoming: &mut mpsc::Receiver<FlowConnection>,
+    state: &watch::Sender<LinkState>,
+    provider: &dyn TrustedStateProvider,
+    policy: SessionPolicy,
+    shutdown: &mut watch::Receiver<bool>,
+) -> LiveOutcome {
+    let now = Instant::now();
+    let mut last_pong = now;
+    let mut highest_sent = 0_u64;
+    let mut highest_pong = 0_u64;
+    let mut announced = false;
+    if send_initial_state(connection, provider, &mut announced)
+        .await
+        .is_err()
+    {
+        return LiveOutcome::Closed;
+    }
+
+    let mut heartbeat = tokio::time::interval_at(now + policy.ping_interval, policy.ping_interval);
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut trust = tokio::time::interval(TRUST_POLL_INTERVAL);
+    trust.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            datagram = connection.read_datagram() => {
+                let Ok(datagram) = datagram else {
+                    return LiveOutcome::Closed;
+                };
+                match datagram.kind {
+                    FrameKind::Ping => {
+                        let Ok(message) = datagram.decode::<proto::Ping>(InboundRole::Notification) else {
+                            return LiveOutcome::Closed;
+                        };
+                        let Ok(pong) = message_envelope(FrameKind::Pong, &proto::Pong {
+                            seq: message.seq,
+                            ..Default::default()
+                        }) else {
+                            return LiveOutcome::Closed;
+                        };
+                        if connection.send_datagram(&pong).is_err() {
+                            return LiveOutcome::Closed;
+                        }
+                    }
+                    FrameKind::Pong => {
+                        let Ok(message) = datagram.decode::<proto::Pong>(InboundRole::Notification) else {
+                            return LiveOutcome::Closed;
+                        };
+                        if message.seq > highest_pong && message.seq <= highest_sent {
+                            highest_pong = message.seq;
+                            last_pong = Instant::now();
+                            state.send_replace(LinkState::Connected);
+                        }
+                    }
+                    _ => return LiveOutcome::Closed,
+                }
+            }
+            candidate = incoming.recv() => {
+                let Some(candidate) = candidate else {
+                    return LiveOutcome::Closed;
+                };
+                if connection.direction() == ConnectionDirection::Outgoing
+                    && connection.close_if_outgoing_loses_tie()
+                {
+                    return LiveOutcome::Replace(Arc::new(candidate));
+                }
+                candidate.close();
+            }
+            _ = heartbeat.tick() => {
+                if Instant::now().duration_since(last_pong) >= policy.degraded_after {
+                    state.send_replace(LinkState::Degraded);
+                }
+                highest_sent = highest_sent.saturating_add(1);
+                let Ok(ping) = message_envelope(FrameKind::Ping, &proto::Ping {
+                    seq: highest_sent,
+                    ..Default::default()
+                }) else {
+                    return LiveOutcome::Closed;
+                };
+                if connection.send_datagram(&ping).is_err() {
+                    return LiveOutcome::Closed;
+                }
+            }
+            _ = trust.tick() => {
+                if send_initial_state(connection, provider, &mut announced).await.is_err() {
+                    return LiveOutcome::Closed;
+                }
+            }
+            () = connection.wait_closed() => return LiveOutcome::Closed,
+            _ = shutdown.changed() => return LiveOutcome::Shutdown,
+        }
+    }
+}
+
+async fn send_initial_state(
+    connection: &FlowConnection,
+    provider: &dyn TrustedStateProvider,
+    announced: &mut bool,
+) -> Result<(), ()> {
+    if *announced || connection.trust() != SessionTrust::Trusted {
+        return Ok(());
+    }
+    let initial = provider.initial_state(connection.peer_key());
+    let announce =
+        message_envelope(FrameKind::AnnounceDevices, &initial.announce_devices).map_err(|_| ())?;
+    connection.notify(announce).await.map_err(|_| ())?;
+    let peer_state = message_envelope(FrameKind::PeerState, &initial.peer_state).map_err(|_| ())?;
+    connection.notify(peer_state).await.map_err(|_| ())?;
+    *announced = true;
+    Ok(())
+}
+
+fn retry_delay(policy: SessionPolicy, peer_key: PublicKey, attempt: u32) -> Duration {
+    let multiplier = 1_u32.checked_shl(attempt.min(31)).unwrap_or(u32::MAX);
+    let exponential = policy.retry_base.saturating_mul(multiplier);
+    let capped = exponential.min(policy.retry_max);
+    let mut hasher = Sha256::new();
+    hasher.update(peer_key.as_bytes());
+    hasher.update(attempt.to_le_bytes());
+    let digest = hasher.finalize();
+    let sample = u16::from_be_bytes([digest[0], digest[1]]);
+    let per_mille = 750_u128 + u128::from(sample % 501);
+    let nanos = capped.as_nanos().saturating_mul(per_mille) / 1_000;
+    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX)).min(policy.retry_max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> SessionPolicy {
+        SessionPolicy {
+            retry_base: Duration::from_millis(100),
+            retry_max: Duration::from_secs(2),
+            ping_interval: Duration::from_secs(1),
+            degraded_after: Duration::from_secs(3),
+        }
+    }
+
+    #[test]
+    fn retry_backoff_is_deterministic_jittered_and_capped() {
+        let policy = policy();
+        let key = PublicKey::new([1; 32]);
+        let first = retry_delay(policy, key, 0);
+        let second = retry_delay(policy, key, 1);
+        let third = retry_delay(policy, key, 2);
+
+        assert_eq!(first, retry_delay(policy, key, 0));
+        assert!((Duration::from_millis(75)..=Duration::from_millis(125)).contains(&first));
+        assert!(second > first);
+        assert!(third > second);
+        assert!(retry_delay(policy, key, u32::MAX) <= policy.retry_max);
+    }
+
+    #[test]
+    fn retry_jitter_is_scoped_to_peer_key() {
+        assert_ne!(
+            retry_delay(policy(), PublicKey::new([1; 32]), 2),
+            retry_delay(policy(), PublicKey::new([2; 32]), 2)
+        );
+    }
+
+    #[test]
+    fn invalid_liveness_policy_is_rejected() {
+        let mut invalid = policy();
+        invalid.degraded_after = invalid.ping_interval;
+        assert!(matches!(
+            invalid.validate(),
+            Err(SessionManagerError::InvalidPolicy(_))
+        ));
+    }
+}

--- a/crates/openlogi-flow/src/transport.rs
+++ b/crates/openlogi-flow/src/transport.rs
@@ -74,6 +74,12 @@ impl FlowEndpoint {
         self.endpoint.local_addr().map_err(TransportError::from)
     }
 
+    /// Returns this endpoint's stable machine identity.
+    #[must_use]
+    pub const fn public_key(&self) -> PublicKey {
+        self.identity.public_key()
+    }
+
     /// Dials and performs the control-stream Hello exchange.
     pub async fn connect(&self, address: SocketAddr) -> Result<FlowConnection, TransportError> {
         let connection = self.endpoint.connect(address, "openlogi-flow")?.await?;
@@ -447,6 +453,10 @@ impl FlowConnection {
     pub fn close(&self) {
         self.connection
             .close(VarInt::from_u32(0), b"Flow connection closed");
+    }
+
+    pub(crate) async fn wait_closed(&self) {
+        let _ = self.connection.closed().await;
     }
 
     fn ensure_send_allowed(&self, kind: FrameKind) -> Result<(), TransportError> {

--- a/crates/openlogi-flow/src/transport.rs
+++ b/crates/openlogi-flow/src/transport.rs
@@ -1,0 +1,920 @@
+//! QUIC transport binding for Flow frames, streams, datagrams, and mutual trust.
+
+mod tls;
+
+use std::{
+    io,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use buffa::Message;
+use quinn::{Connection, Endpoint, RecvStream, SendStream, VarInt};
+use rustls::pki_types::CertificateDer;
+use thiserror::Error;
+
+use crate::{
+    frame::{Envelope, FrameError, FrameKind, InboundRole, InvalidDecision},
+    generated as proto,
+    negotiation::{HelloRejection, Negotiated, SendGate, negotiate},
+    pairing::{PairingSession, PairingState},
+    sas::{PublicKey, SessionNonce},
+};
+
+pub use tls::{
+    ALPN, IdentityError, MachineIdentity, PeerTrust, SessionTrust, public_key_from_certificate,
+};
+
+const CLOSE_PROTOCOL: VarInt = VarInt::from_u32(1);
+const STOP_OVERSIZED: VarInt = VarInt::from_u32(2);
+
+/// Whether the local endpoint initiated a Flow connection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConnectionDirection {
+    /// The local endpoint dialed the peer.
+    Outgoing,
+    /// The local endpoint accepted the peer's dial.
+    Incoming,
+}
+
+/// A local QUIC endpoint configured for pinned-key mutual authentication.
+#[derive(Debug)]
+pub struct FlowEndpoint {
+    endpoint: Endpoint,
+    identity: MachineIdentity,
+    trust: PeerTrust,
+    hello: proto::Hello,
+}
+
+impl FlowEndpoint {
+    /// Binds a Flow endpoint and configures both TLS directions with one trust policy.
+    pub fn bind(
+        address: SocketAddr,
+        identity: MachineIdentity,
+        trust: PeerTrust,
+        hello: proto::Hello,
+    ) -> Result<Self, TransportError> {
+        validate_local_hello(&hello, identity.public_key())?;
+        let (server_config, client_config) = quic_configs(&identity, trust.clone())?;
+        let mut endpoint = Endpoint::server(server_config, address)?;
+        endpoint.set_default_client_config(client_config);
+        Ok(Self {
+            endpoint,
+            identity,
+            trust,
+            hello,
+        })
+    }
+
+    /// Returns the bound local socket address.
+    pub fn local_addr(&self) -> Result<SocketAddr, TransportError> {
+        self.endpoint.local_addr().map_err(TransportError::from)
+    }
+
+    /// Dials and performs the control-stream Hello exchange.
+    pub async fn connect(&self, address: SocketAddr) -> Result<FlowConnection, TransportError> {
+        let connection = self.endpoint.connect(address, "openlogi-flow")?.await?;
+        self.establish(connection, ConnectionDirection::Outgoing)
+            .await
+    }
+
+    /// Accepts one dial and performs the control-stream Hello exchange.
+    pub async fn accept(&self) -> Result<FlowConnection, TransportError> {
+        let incoming = self
+            .endpoint
+            .accept()
+            .await
+            .ok_or(TransportError::EndpointClosed)?;
+        let connection = incoming.await?;
+        self.establish(connection, ConnectionDirection::Incoming)
+            .await
+    }
+
+    /// Gracefully closes all connections owned by this endpoint.
+    pub async fn close(self) {
+        self.endpoint.close(VarInt::from_u32(0), b"endpoint closed");
+        self.endpoint.wait_idle().await;
+    }
+
+    async fn establish(
+        &self,
+        connection: Connection,
+        direction: ConnectionDirection,
+    ) -> Result<FlowConnection, TransportError> {
+        verify_alpn(&connection)?;
+        let peer_key = connection_peer_key(&connection)?;
+        let initial_trust = self
+            .trust
+            .classify(peer_key)
+            .map_err(|error| TransportError::Trust(error.to_string()))?;
+        let (mut control_send, mut control_recv) = match direction {
+            ConnectionDirection::Outgoing => connection.open_bi().await?,
+            ConnectionDirection::Incoming => connection.accept_bi().await?,
+        };
+
+        message_envelope(FrameKind::Hello, &self.hello)?
+            .write_to(&mut control_send)
+            .await?;
+        let peer_frame = Envelope::read_from(&mut control_recv).await?;
+        if peer_frame.flags != 0 {
+            reject_hello(
+                &connection,
+                &mut control_send,
+                &self.hello,
+                proto::RejectReason::Malformed,
+                "Hello frame used reserved flags",
+            )
+            .await?;
+            return Err(TransportError::InvalidControlFrame);
+        }
+        if peer_frame.kind == FrameKind::HelloReject {
+            let rejection = peer_frame
+                .decode::<proto::HelloReject>(InboundRole::Request)
+                .map_err(|_| TransportError::InvalidControlFrame)?;
+            return Err(TransportError::PeerHelloRejected(rejection.reason.to_i32()));
+        }
+        if peer_frame.kind != FrameKind::Hello {
+            reject_hello(
+                &connection,
+                &mut control_send,
+                &self.hello,
+                proto::RejectReason::Malformed,
+                "control stream did not carry Hello",
+            )
+            .await?;
+            return Err(TransportError::InvalidControlFrame);
+        }
+        let peer_hello = peer_frame
+            .decode::<proto::Hello>(InboundRole::Request)
+            .map_err(|_| TransportError::InvalidControlFrame)?;
+        let negotiated = match negotiate(&self.hello, &peer_hello, &peer_key) {
+            Ok(negotiated) => negotiated,
+            Err(rejection) => {
+                reject_hello(
+                    &connection,
+                    &mut control_send,
+                    &self.hello,
+                    rejection.reason(),
+                    &rejection.to_string(),
+                )
+                .await?;
+                return Err(TransportError::HelloRejected(rejection));
+            }
+        };
+
+        let trusted = Arc::new(AtomicBool::new(initial_trust == SessionTrust::Trusted));
+        let monitor_connection = connection.clone();
+        let control_monitor = tokio::spawn(async move {
+            let _ = control_recv.read_chunk(1, true).await;
+            monitor_connection.close(CLOSE_PROTOCOL, b"control stream closed");
+        });
+        Ok(FlowConnection {
+            connection,
+            _control_send: control_send,
+            control_monitor,
+            direction,
+            local_key: self.identity.public_key(),
+            peer_key,
+            peer_hello,
+            send_gate: SendGate::new(negotiated.clone()),
+            negotiated,
+            trusted,
+        })
+    }
+}
+
+/// An authenticated Flow connection after Hello negotiation.
+#[derive(Debug)]
+pub struct FlowConnection {
+    connection: Connection,
+    _control_send: SendStream,
+    control_monitor: tokio::task::JoinHandle<()>,
+    direction: ConnectionDirection,
+    local_key: PublicKey,
+    peer_key: PublicKey,
+    peer_hello: proto::Hello,
+    send_gate: SendGate,
+    negotiated: Negotiated,
+    trusted: Arc<AtomicBool>,
+}
+
+impl FlowConnection {
+    /// Returns whether this connection was dialed or accepted locally.
+    #[must_use]
+    pub const fn direction(&self) -> ConnectionDirection {
+        self.direction
+    }
+
+    /// Returns the TLS-authenticated peer key.
+    #[must_use]
+    pub const fn peer_key(&self) -> PublicKey {
+        self.peer_key
+    }
+
+    /// Returns the peer's negotiated Hello message.
+    #[must_use]
+    pub const fn peer_hello(&self) -> &proto::Hello {
+        &self.peer_hello
+    }
+
+    /// Returns the negotiated protocol version and capability intersection.
+    #[must_use]
+    pub const fn negotiated(&self) -> &Negotiated {
+        &self.negotiated
+    }
+
+    /// Returns this connection's current trust classification.
+    #[must_use]
+    pub fn trust(&self) -> SessionTrust {
+        if self.trusted.load(Ordering::Acquire) {
+            SessionTrust::Trusted
+        } else {
+            SessionTrust::Untrusted
+        }
+    }
+
+    /// Promotes an untrusted connection after its pairing state machine persists this peer key.
+    pub fn promote_after_pairing(&self, pairing: &PairingSession) -> Result<(), TransportError> {
+        if pairing.state() != PairingState::Paired || pairing.peer_key() != self.peer_key {
+            return Err(TransportError::PairingNotComplete);
+        }
+        self.trusted.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    /// Applies the simultaneous-dial tiebreak after the caller detects a race.
+    ///
+    /// The lexicographically smaller local public key closes its outgoing
+    /// connection and keeps the incoming connection. Returns whether this
+    /// outgoing connection was closed.
+    #[must_use]
+    pub fn close_if_outgoing_loses_tie(&self) -> bool {
+        let loses =
+            self.direction == ConnectionDirection::Outgoing && self.local_key < self.peer_key;
+        if loses {
+            self.connection
+                .close(VarInt::from_u32(0), b"simultaneous dial tiebreak");
+        }
+        loses
+    }
+
+    /// Opens the one bidirectional stream for a raw RPC exchange.
+    ///
+    /// This low-level API supports bulk responses and protocol conformance
+    /// tests. Callers must write exactly one request frame before reading the
+    /// response sequence and must finish their send direction.
+    pub async fn open_rpc_stream(&self) -> Result<(SendStream, RecvStream), TransportError> {
+        self.connection
+            .open_bi()
+            .await
+            .map_err(TransportError::from)
+    }
+
+    /// Calls one single-response RPC and validates its paired response kind.
+    pub async fn call(&self, request: Envelope) -> Result<Envelope, TransportError> {
+        self.ensure_send_allowed(request.kind)?;
+        if is_bulk_request(request.kind) {
+            return Err(TransportError::BulkResponseRequired(request.kind));
+        }
+        let expected = expected_response(request.kind)
+            .ok_or(TransportError::InvalidRequestKind(request.kind))?;
+        validate_payload(&request)?;
+        let (mut send, mut receive) = self.open_rpc_stream().await?;
+        request.write_to(&mut send).await?;
+        send.finish()?;
+        let response = Envelope::read_from(&mut receive).await?;
+        ensure_stream_finished(&mut receive).await?;
+        validate_response_envelope(&response)?;
+        if response.kind != FrameKind::Error && !expected.contains(&response.kind) {
+            return Err(TransportError::UnexpectedResponse(response.kind));
+        }
+        Ok(response)
+    }
+
+    /// Calls a clipboard/file RPC and validates its ordered bulk response sequence.
+    pub async fn call_bulk(&self, request: Envelope) -> Result<BulkRpcResponse, TransportError> {
+        self.ensure_send_allowed(request.kind)?;
+        if !is_bulk_request(request.kind) {
+            return Err(TransportError::InvalidRequestKind(request.kind));
+        }
+        validate_payload(&request)?;
+        let (mut send, mut receive) = self.open_rpc_stream().await?;
+        request.write_to(&mut send).await?;
+        send.finish()?;
+
+        let head = Envelope::read_from(&mut receive).await?;
+        validate_response_envelope(&head)?;
+        if head.kind == FrameKind::Error {
+            ensure_stream_finished(&mut receive).await?;
+            return Ok(BulkRpcResponse::Error(head));
+        }
+        if head.kind != FrameKind::ClipboardData {
+            return Err(TransportError::UnexpectedResponse(head.kind));
+        }
+        Ok(BulkRpcResponse::Data(BulkResponse {
+            head,
+            receive,
+            finished: false,
+        }))
+    }
+
+    /// Accepts and validates one inbound RPC stream.
+    ///
+    /// Envelope, stream-binding, size, and pre-pairing violations are answered
+    /// automatically with the mandated `Error` code.
+    pub async fn accept_rpc(&self) -> Result<RpcEvent, TransportError> {
+        let (send, mut receive) = self.connection.accept_bi().await?;
+        let request = match Envelope::read_from(&mut receive).await {
+            Ok(request) => request,
+            Err(error @ FrameError::TooLarge { .. }) => {
+                let _ = receive.stop(STOP_OVERSIZED);
+                return reject_rpc(send, proto::ErrorCode::TooLarge, error).await;
+            }
+            Err(error) => return Err(error.into()),
+        };
+        ensure_stream_finished(&mut receive).await?;
+        if let Some(decision) = request.policy(InboundRole::Request) {
+            let InvalidDecision::Respond(code) = decision else {
+                return Err(TransportError::InvalidControlFrame);
+            };
+            return reject_rpc(send, code, "invalid request envelope").await;
+        }
+        if !is_request_kind(request.kind) {
+            return reject_rpc(
+                send,
+                proto::ErrorCode::Invalid,
+                "invalid RPC stream binding",
+            )
+            .await;
+        }
+        if self.trust() == SessionTrust::Untrusted && !request.kind.is_pretrust() {
+            return reject_rpc(send, proto::ErrorCode::NotPaired, "peer is not paired").await;
+        }
+        if !self.send_gate.may_send_kind(request.kind) {
+            return reject_rpc(
+                send,
+                proto::ErrorCode::Invalid,
+                "request kind was not enabled by Hello negotiation",
+            )
+            .await;
+        }
+        if !payload_decodes(&request) {
+            return reject_rpc(
+                send,
+                proto::ErrorCode::Invalid,
+                "request payload is not valid protobuf for its frame kind",
+            )
+            .await;
+        }
+        Ok(RpcEvent::Request(IncomingRpc { request, send }))
+    }
+
+    /// Sends one notification frame on its own unidirectional stream.
+    pub async fn notify(&self, notification: Envelope) -> Result<(), TransportError> {
+        self.ensure_send_allowed(notification.kind)?;
+        if !is_notification_kind(notification.kind) {
+            return Err(TransportError::InvalidNotificationKind(notification.kind));
+        }
+        validate_payload(&notification)?;
+        let mut send = self.connection.open_uni().await?;
+        notification.write_to(&mut send).await?;
+        send.finish()?;
+        Ok(())
+    }
+
+    /// Accepts and validates one notification stream.
+    pub async fn accept_notification(&self) -> Result<NotificationEvent, TransportError> {
+        let mut receive = self.connection.accept_uni().await?;
+        let notification = match Envelope::read_from(&mut receive).await {
+            Ok(notification) => notification,
+            Err(FrameError::TooLarge { .. }) => {
+                let _ = receive.stop(STOP_OVERSIZED);
+                return Ok(NotificationEvent::Dropped(proto::ErrorCode::TooLarge));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        ensure_stream_finished(&mut receive).await?;
+        if let Some(InvalidDecision::Drop) = notification.policy(InboundRole::Notification) {
+            let code = if notification.flags == 0 {
+                proto::ErrorCode::UnsupportedKind
+            } else {
+                proto::ErrorCode::UnsupportedFlags
+            };
+            return Ok(NotificationEvent::Dropped(code));
+        }
+        if !is_notification_kind(notification.kind) {
+            return Ok(NotificationEvent::Dropped(proto::ErrorCode::Invalid));
+        }
+        if self.trust() == SessionTrust::Untrusted && !notification.kind.is_pretrust() {
+            return Ok(NotificationEvent::Dropped(proto::ErrorCode::NotPaired));
+        }
+        if !self.send_gate.may_send_kind(notification.kind) {
+            return Ok(NotificationEvent::Dropped(proto::ErrorCode::Invalid));
+        }
+        if !payload_decodes(&notification) {
+            return Ok(NotificationEvent::Dropped(proto::ErrorCode::Invalid));
+        }
+        Ok(NotificationEvent::Notification(notification))
+    }
+
+    /// Sends a `Ping` or `Pong` envelope as a QUIC datagram.
+    pub fn send_datagram(&self, datagram: &Envelope) -> Result<(), TransportError> {
+        if !matches!(datagram.kind, FrameKind::Ping | FrameKind::Pong) {
+            return Err(TransportError::InvalidDatagramKind(datagram.kind));
+        }
+        self.ensure_send_allowed(datagram.kind)?;
+        validate_payload(datagram)?;
+        self.connection
+            .send_datagram(buffa::bytes::Bytes::from(datagram.to_bytes()?))?;
+        Ok(())
+    }
+
+    /// Reads and validates one `Ping` or `Pong` QUIC datagram.
+    pub async fn read_datagram(&self) -> Result<Envelope, TransportError> {
+        let bytes = self.connection.read_datagram().await?;
+        let datagram = Envelope::from_bytes(&bytes)?;
+        if datagram.flags != 0 || !matches!(datagram.kind, FrameKind::Ping | FrameKind::Pong) {
+            return Err(TransportError::InvalidDatagramKind(datagram.kind));
+        }
+        validate_payload(&datagram)?;
+        Ok(datagram)
+    }
+
+    /// Closes this QUIC connection.
+    pub fn close(&self) {
+        self.connection
+            .close(VarInt::from_u32(0), b"Flow connection closed");
+    }
+
+    fn ensure_send_allowed(&self, kind: FrameKind) -> Result<(), TransportError> {
+        if self.trust() == SessionTrust::Untrusted && !kind.is_pretrust() {
+            return Err(TransportError::NotPaired(kind));
+        }
+        if !self.send_gate.may_send_kind(kind) {
+            return Err(TransportError::SendGated(kind));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for FlowConnection {
+    fn drop(&mut self) {
+        self.connection
+            .close(VarInt::from_u32(0), b"Flow connection dropped");
+        self.control_monitor.abort();
+    }
+}
+
+/// Result of accepting an RPC stream.
+#[derive(Debug)]
+pub enum RpcEvent {
+    /// A validated request requiring an application response.
+    Request(IncomingRpc),
+    /// A rejected request already answered by the transport.
+    Rejected(proto::ErrorCode),
+}
+
+/// A validated request and its response-bearing QUIC stream direction.
+#[derive(Debug)]
+pub struct IncomingRpc {
+    request: Envelope,
+    send: SendStream,
+}
+
+/// The head of a validated response to `ClipboardFetch` or `FileFetch`.
+#[derive(Debug)]
+pub enum BulkRpcResponse {
+    /// The peer rejected the request with one generic error frame.
+    Error(Envelope),
+    /// A streaming data response beginning with `ClipboardData`.
+    Data(BulkResponse),
+}
+
+/// A streaming bulk response after its `ClipboardData` head was validated.
+#[derive(Debug)]
+pub struct BulkResponse {
+    head: Envelope,
+    receive: RecvStream,
+    finished: bool,
+}
+
+impl BulkResponse {
+    /// Returns the `ClipboardData` response head.
+    #[must_use]
+    pub const fn head(&self) -> &Envelope {
+        &self.head
+    }
+
+    /// Returns the next `Chunk` or terminal `ChunkEnd` frame.
+    ///
+    /// The first call after `ChunkEnd` returns `None`. Any other frame kind,
+    /// malformed payload, or trailing bytes fail the response.
+    pub async fn next_frame(&mut self) -> Result<Option<Envelope>, TransportError> {
+        if self.finished {
+            return Ok(None);
+        }
+        let frame = Envelope::read_from(&mut self.receive).await?;
+        validate_response_envelope(&frame)?;
+        match frame.kind {
+            FrameKind::Chunk => Ok(Some(frame)),
+            FrameKind::ChunkEnd => {
+                ensure_stream_finished(&mut self.receive).await?;
+                self.finished = true;
+                Ok(Some(frame))
+            }
+            kind => Err(TransportError::UnexpectedResponse(kind)),
+        }
+    }
+}
+
+impl IncomingRpc {
+    /// Returns the decoded envelope supplied by the peer.
+    #[must_use]
+    pub const fn request(&self) -> &Envelope {
+        &self.request
+    }
+
+    /// Sends the request's paired response or a generic `Error`.
+    pub async fn respond(mut self, response: Envelope) -> Result<(), TransportError> {
+        let expected = expected_response(self.request.kind)
+            .ok_or(TransportError::InvalidRequestKind(self.request.kind))?;
+        if is_bulk_request(self.request.kind) && response.kind != FrameKind::Error {
+            return Err(TransportError::BulkResponseRequired(self.request.kind));
+        }
+        if response.kind != FrameKind::Error && !expected.contains(&response.kind) {
+            return Err(TransportError::UnexpectedResponse(response.kind));
+        }
+        validate_payload(&response)?;
+        response.write_to(&mut self.send).await?;
+        self.send.finish()?;
+        Ok(())
+    }
+
+    /// Sends `ClipboardData`, zero or more `Chunk`s, and one `ChunkEnd`.
+    pub async fn respond_bulk(
+        mut self,
+        head: Envelope,
+        chunks: impl IntoIterator<Item = Envelope>,
+        end: Envelope,
+    ) -> Result<(), TransportError> {
+        if !is_bulk_request(self.request.kind) {
+            return Err(TransportError::InvalidRequestKind(self.request.kind));
+        }
+        validate_sequence_frame(&head, FrameKind::ClipboardData)?;
+        head.write_to(&mut self.send).await?;
+        for chunk in chunks {
+            validate_sequence_frame(&chunk, FrameKind::Chunk)?;
+            chunk.write_to(&mut self.send).await?;
+        }
+        validate_sequence_frame(&end, FrameKind::ChunkEnd)?;
+        end.write_to(&mut self.send).await?;
+        self.send.finish()?;
+        Ok(())
+    }
+}
+
+/// Result of accepting a unidirectional notification stream.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum NotificationEvent {
+    /// A valid notification for application handling.
+    Notification(Envelope),
+    /// A dropped notification and the diagnostic code that would apply to an RPC.
+    Dropped(proto::ErrorCode),
+}
+
+/// Encodes a generated protobuf message into a zero-flags envelope.
+pub fn message_envelope(
+    kind: FrameKind,
+    message: &impl Message,
+) -> Result<Envelope, TransportError> {
+    let payload = message.try_encode_to_vec()?;
+    Envelope::new(kind, 0, payload).map_err(TransportError::from)
+}
+
+/// Builds the generated generic error payload used in an RPC response position.
+pub fn error_envelope(
+    code: proto::ErrorCode,
+    detail: impl Into<String>,
+) -> Result<Envelope, TransportError> {
+    message_envelope(
+        FrameKind::Error,
+        &proto::Error {
+            code: code.into(),
+            detail: detail.into(),
+            retryable: code == proto::ErrorCode::Busy,
+            ..Default::default()
+        },
+    )
+}
+
+/// Errors from identity setup, QUIC, framing, negotiation, or stream binding.
+#[derive(Debug, Error)]
+pub enum TransportError {
+    /// Machine identity setup failed.
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
+    /// Socket or endpoint setup failed.
+    #[error("endpoint I/O failed: {0}")]
+    Io(#[from] io::Error),
+    /// A QUIC dial could not be started.
+    #[error("QUIC connect setup failed: {0}")]
+    Connect(#[from] quinn::ConnectError),
+    /// The QUIC handshake or connection failed.
+    #[error("QUIC connection failed: {0}")]
+    Connection(#[from] quinn::ConnectionError),
+    /// Finishing a stream failed because it was already closed.
+    #[error("QUIC stream is already closed")]
+    ClosedStream(#[from] quinn::ClosedStream),
+    /// Reading a QUIC stream failed.
+    #[error("QUIC stream read failed: {0}")]
+    Read(#[from] quinn::ReadError),
+    /// Sending a QUIC datagram failed.
+    #[error("QUIC datagram send failed: {0}")]
+    SendDatagram(#[from] quinn::SendDatagramError),
+    /// Frame encoding or decoding failed.
+    #[error(transparent)]
+    Frame(#[from] FrameError),
+    /// Protobuf encoding failed.
+    #[error("protobuf encoding failed: {0}")]
+    ProtobufEncode(#[from] buffa::EncodeError),
+    /// Rustls rejected the local certificate/key configuration.
+    #[error("TLS identity configuration failed: {0}")]
+    Rustls(#[from] rustls::Error),
+    /// TLS/QUIC configuration could not be constructed.
+    #[error("TLS configuration failed: {0}")]
+    Config(String),
+    /// The authenticated key no longer satisfies the endpoint trust policy.
+    #[error("peer trust classification failed: {0}")]
+    Trust(String),
+    /// The endpoint was closed before another connection arrived.
+    #[error("endpoint is closed")]
+    EndpointClosed,
+    /// The negotiated TLS session did not select `olf/1`.
+    #[error("TLS did not negotiate the Flow ALPN")]
+    AlpnMismatch,
+    /// Quinn did not expose exactly one peer certificate.
+    #[error("TLS peer identity is missing or malformed")]
+    MissingPeerIdentity,
+    /// The local Hello does not match the local TLS identity or wire invariants.
+    #[error("invalid local Hello: {0}")]
+    InvalidLocalHello(&'static str),
+    /// The peer's control stream violated the Hello binding.
+    #[error("invalid Flow control stream")]
+    InvalidControlFrame,
+    /// Local negotiation rejected the peer's Hello.
+    #[error(transparent)]
+    HelloRejected(#[from] HelloRejection),
+    /// The peer sent a generated HelloReject reason.
+    #[error("peer rejected Hello with reason {0}")]
+    PeerHelloRejected(i32),
+    /// The caller attempted to send a kind excluded by negotiation.
+    #[error("negotiation does not permit sending {0:?}")]
+    SendGated(FrameKind),
+    /// The caller attempted to send a post-trust kind before pairing completed.
+    #[error("cannot send {0:?} before the peer is paired")]
+    NotPaired(FrameKind),
+    /// A kind does not occupy an RPC request position.
+    #[error("{0:?} is not an RPC request kind")]
+    InvalidRequestKind(FrameKind),
+    /// A response does not match its request stream.
+    #[error("unexpected RPC response kind {0:?}")]
+    UnexpectedResponse(FrameKind),
+    /// A clipboard/file RPC must use the ordered bulk-response API.
+    #[error("{0:?} requires a ClipboardData + Chunk* + ChunkEnd response")]
+    BulkResponseRequired(FrameKind),
+    /// The protobuf payload does not match its frame kind.
+    #[error("invalid protobuf payload for {0:?}")]
+    InvalidPayload(FrameKind),
+    /// A kind does not occupy a notification stream.
+    #[error("{0:?} is not a notification kind")]
+    InvalidNotificationKind(FrameKind),
+    /// A kind is not legal in a Flow datagram.
+    #[error("{0:?} is not a Ping/Pong datagram kind")]
+    InvalidDatagramKind(FrameKind),
+    /// A stream contained bytes after its one permitted frame.
+    #[error("one-frame stream contained trailing data")]
+    TrailingStreamData,
+    /// The pairing session did not authenticate this connection's peer key.
+    #[error("pairing is not complete for this peer")]
+    PairingNotComplete,
+}
+
+fn quic_configs(
+    identity: &MachineIdentity,
+    trust: PeerTrust,
+) -> Result<(quinn::ServerConfig, quinn::ClientConfig), TransportError> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let server_verifier = Arc::new(tls::PinnedServerVerifier::new(
+        trust.clone(),
+        provider.clone(),
+    ));
+    let client_verifier = Arc::new(tls::PinnedClientVerifier::new(trust, provider.clone()));
+
+    let mut client_tls = rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .map_err(|error| TransportError::Config(error.to_string()))?
+        .dangerous()
+        .with_custom_certificate_verifier(server_verifier)
+        .with_client_auth_cert(vec![identity.certificate()], identity.private_key())?;
+    client_tls.alpn_protocols = vec![ALPN.to_vec()];
+    client_tls.resumption = rustls::client::Resumption::disabled();
+
+    let mut server_tls = rustls::ServerConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .map_err(|error| TransportError::Config(error.to_string()))?
+        .with_client_cert_verifier(client_verifier)
+        .with_single_cert(vec![identity.certificate()], identity.private_key())?;
+    server_tls.alpn_protocols = vec![ALPN.to_vec()];
+    server_tls.max_early_data_size = 0;
+
+    let client_crypto = quinn::crypto::rustls::QuicClientConfig::try_from(client_tls)
+        .map_err(|error| TransportError::Config(error.to_string()))?;
+    let server_crypto = quinn::crypto::rustls::QuicServerConfig::try_from(server_tls)
+        .map_err(|error| TransportError::Config(error.to_string()))?;
+    Ok((
+        quinn::ServerConfig::with_crypto(Arc::new(server_crypto)),
+        quinn::ClientConfig::new(Arc::new(client_crypto)),
+    ))
+}
+
+fn validate_local_hello(hello: &proto::Hello, public_key: PublicKey) -> Result<(), TransportError> {
+    if hello.public_key.as_slice() != public_key.as_bytes() {
+        return Err(TransportError::InvalidLocalHello(
+            "public key differs from TLS identity",
+        ));
+    }
+    SessionNonce::try_from(hello.session_nonce.as_slice())
+        .map_err(|_| TransportError::InvalidLocalHello("session nonce is not 16 bytes"))?;
+    if hello.proto_min == 0 || hello.proto_min > hello.proto_max {
+        return Err(TransportError::InvalidLocalHello(
+            "protocol version range is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn verify_alpn(connection: &Connection) -> Result<(), TransportError> {
+    let handshake = connection
+        .handshake_data()
+        .and_then(|data| data.downcast::<quinn::crypto::rustls::HandshakeData>().ok())
+        .ok_or(TransportError::AlpnMismatch)?;
+    if handshake.protocol.as_deref() == Some(ALPN) {
+        Ok(())
+    } else {
+        Err(TransportError::AlpnMismatch)
+    }
+}
+
+fn connection_peer_key(connection: &Connection) -> Result<PublicKey, TransportError> {
+    let certificates = connection
+        .peer_identity()
+        .and_then(|identity| identity.downcast::<Vec<CertificateDer<'static>>>().ok())
+        .ok_or(TransportError::MissingPeerIdentity)?;
+    if certificates.len() != 1 {
+        return Err(TransportError::MissingPeerIdentity);
+    }
+    public_key_from_certificate(certificates[0].as_ref()).map_err(TransportError::from)
+}
+
+async fn reject_hello(
+    connection: &Connection,
+    send: &mut SendStream,
+    local: &proto::Hello,
+    reason: proto::RejectReason,
+    detail: &str,
+) -> Result<(), TransportError> {
+    message_envelope(
+        FrameKind::HelloReject,
+        &proto::HelloReject {
+            reason: reason.into(),
+            proto_min: local.proto_min,
+            proto_max: local.proto_max,
+            detail: detail.to_owned(),
+            ..Default::default()
+        },
+    )?
+    .write_to(send)
+    .await?;
+    send.finish()?;
+    connection.close(CLOSE_PROTOCOL, b"Hello rejected");
+    Ok(())
+}
+
+async fn ensure_stream_finished(receive: &mut RecvStream) -> Result<(), TransportError> {
+    match receive.read_chunk(1, true).await? {
+        None => Ok(()),
+        Some(_) => Err(TransportError::TrailingStreamData),
+    }
+}
+
+async fn reject_rpc(
+    mut send: SendStream,
+    code: proto::ErrorCode,
+    detail: impl ToString,
+) -> Result<RpcEvent, TransportError> {
+    error_envelope(code, detail.to_string())?
+        .write_to(&mut send)
+        .await?;
+    send.finish()?;
+    Ok(RpcEvent::Rejected(code))
+}
+
+fn expected_response(request: FrameKind) -> Option<&'static [FrameKind]> {
+    match request {
+        FrameKind::PairStart => Some(&[FrameKind::PairPrompted]),
+        FrameKind::PairConfirm => Some(&[FrameKind::PairOutcome]),
+        FrameKind::GetPeerInfo => Some(&[FrameKind::PeerInfo]),
+        FrameKind::HandoffRequest => Some(&[FrameKind::HandoffAccept, FrameKind::HandoffReject]),
+        FrameKind::ClipboardFetch | FrameKind::FileFetch => Some(&[FrameKind::ClipboardData]),
+        _ => None,
+    }
+}
+
+const fn is_bulk_request(kind: FrameKind) -> bool {
+    matches!(kind, FrameKind::ClipboardFetch | FrameKind::FileFetch)
+}
+
+fn is_request_kind(kind: FrameKind) -> bool {
+    expected_response(kind).is_some()
+}
+
+fn is_notification_kind(kind: FrameKind) -> bool {
+    matches!(
+        kind,
+        FrameKind::PairAbort
+            | FrameKind::AnnounceDevices
+            | FrameKind::PeerState
+            | FrameKind::HandoffResult
+            | FrameKind::HandoffCancel
+            | FrameKind::ClipboardAnnounce
+    )
+}
+
+fn validate_sequence_frame(envelope: &Envelope, expected: FrameKind) -> Result<(), TransportError> {
+    if envelope.kind != expected {
+        return Err(TransportError::UnexpectedResponse(envelope.kind));
+    }
+    validate_payload(envelope)
+}
+
+fn validate_response_envelope(envelope: &Envelope) -> Result<(), TransportError> {
+    if envelope.policy(InboundRole::Request).is_some() || !payload_decodes(envelope) {
+        Err(TransportError::InvalidPayload(envelope.kind))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_payload(envelope: &Envelope) -> Result<(), TransportError> {
+    if envelope.flags != 0 || !payload_decodes(envelope) {
+        Err(TransportError::InvalidPayload(envelope.kind))
+    } else {
+        Ok(())
+    }
+}
+
+fn payload_decodes(envelope: &Envelope) -> bool {
+    macro_rules! decodes {
+        ($message:ty) => {
+            <$message as Message>::decode_from_slice(&envelope.payload).is_ok()
+        };
+    }
+
+    match envelope.kind {
+        FrameKind::Hello => decodes!(proto::Hello),
+        FrameKind::HelloReject => decodes!(proto::HelloReject),
+        FrameKind::Error => decodes!(proto::Error),
+        FrameKind::Ping => decodes!(proto::Ping),
+        FrameKind::Pong => decodes!(proto::Pong),
+        FrameKind::PairStart => decodes!(proto::PairStart),
+        FrameKind::PairPrompted => decodes!(proto::PairPrompted),
+        FrameKind::PairConfirm => decodes!(proto::PairConfirm),
+        FrameKind::PairOutcome => decodes!(proto::PairOutcome),
+        FrameKind::PairAbort => decodes!(proto::PairAbort),
+        FrameKind::GetPeerInfo => decodes!(proto::GetPeerInfo),
+        FrameKind::PeerInfo => decodes!(proto::PeerInfo),
+        FrameKind::AnnounceDevices => decodes!(proto::AnnounceDevices),
+        FrameKind::PeerState => decodes!(proto::PeerState),
+        FrameKind::HandoffRequest => decodes!(proto::HandoffRequest),
+        FrameKind::HandoffAccept => decodes!(proto::HandoffAccept),
+        FrameKind::HandoffReject => decodes!(proto::HandoffReject),
+        FrameKind::HandoffResult => decodes!(proto::HandoffResult),
+        FrameKind::HandoffCancel => decodes!(proto::HandoffCancel),
+        FrameKind::ClipboardAnnounce => decodes!(proto::ClipboardAnnounce),
+        FrameKind::ClipboardFetch => decodes!(proto::ClipboardFetch),
+        FrameKind::ClipboardData => decodes!(proto::ClipboardData),
+        FrameKind::Chunk => decodes!(proto::Chunk),
+        FrameKind::ChunkEnd => decodes!(proto::ChunkEnd),
+        FrameKind::FileFetch => decodes!(proto::FileFetch),
+        FrameKind::Unspecified | FrameKind::Unknown(_) => false,
+    }
+}
+
+impl FrameKind {
+    const fn is_pretrust(self) -> bool {
+        matches!(self.wire_value(), 0x0001..=0x001f)
+    }
+}

--- a/crates/openlogi-flow/src/transport/tls.rs
+++ b/crates/openlogi-flow/src/transport/tls.rs
@@ -1,0 +1,401 @@
+//! Ed25519 machine identities and bidirectional pinned-key TLS verification.
+
+use std::{
+    collections::BTreeSet,
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+use rustls::{
+    CertificateError, DigitallySignedStruct, DistinguishedName, Error as RustlsError,
+    SignatureScheme,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime},
+    server::danger::{ClientCertVerified, ClientCertVerifier},
+};
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+use x509_parser::{oid_registry::OID_SIG_ED25519, parse_x509_certificate};
+
+use crate::sas::{FixedBytesError, PublicKey};
+
+/// The application-layer protocol negotiated by every Flow QUIC connection.
+pub const ALPN: &[u8] = b"olf/1";
+
+/// A persistent Ed25519 private key and its replaceable self-signed certificate.
+///
+/// Persist [`Self::private_key_pkcs8`] as machine-local secret state. Reloading
+/// it may produce a fresh certificate while preserving the pinned public key.
+#[derive(Clone)]
+pub struct MachineIdentity {
+    public_key: PublicKey,
+    certificate: CertificateDer<'static>,
+    private_key_pkcs8: Vec<u8>,
+}
+
+impl fmt::Debug for MachineIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MachineIdentity")
+            .field("public_key", &self.public_key)
+            .field("certificate_len", &self.certificate.len())
+            .field("private_key_pkcs8", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl MachineIdentity {
+    /// Generates a new persistent Ed25519 machine identity.
+    pub fn generate() -> Result<Self, IdentityError> {
+        let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519)?;
+        let private_key_pkcs8 = key_pair.serialize_der();
+        Self::from_key_pair(&key_pair, private_key_pkcs8)
+    }
+
+    /// Reloads a persistent identity from an Ed25519 PKCS#8 private key.
+    pub fn from_pkcs8(private_key_pkcs8: Vec<u8>) -> Result<Self, IdentityError> {
+        let der = PrivatePkcs8KeyDer::from(private_key_pkcs8.as_slice());
+        let key_pair = rcgen::KeyPair::from_pkcs8_der_and_sign_algo(&der, &rcgen::PKCS_ED25519)?;
+        Self::from_key_pair(&key_pair, private_key_pkcs8)
+    }
+
+    /// Returns the stable raw Ed25519 public key used as Flow peer identity.
+    #[must_use]
+    pub const fn public_key(&self) -> PublicKey {
+        self.public_key
+    }
+
+    /// Returns the current self-signed certificate in DER form.
+    #[must_use]
+    pub fn certificate_der(&self) -> &[u8] {
+        self.certificate.as_ref()
+    }
+
+    /// Returns the secret Ed25519 PKCS#8 bytes for caller-provided persistence.
+    ///
+    /// Callers must protect these bytes as machine-local secret state and must
+    /// never place them in OpenLogi's syncable configuration.
+    #[must_use]
+    pub fn private_key_pkcs8(&self) -> &[u8] {
+        &self.private_key_pkcs8
+    }
+
+    pub(super) fn certificate(&self) -> CertificateDer<'static> {
+        self.certificate.clone()
+    }
+
+    pub(super) fn private_key(&self) -> PrivateKeyDer<'static> {
+        PrivatePkcs8KeyDer::from(self.private_key_pkcs8.clone()).into()
+    }
+
+    fn from_key_pair(
+        key_pair: &rcgen::KeyPair,
+        private_key_pkcs8: Vec<u8>,
+    ) -> Result<Self, IdentityError> {
+        let public_key = PublicKey::try_from(key_pair.public_key_raw())?;
+        let parameters = rcgen::CertificateParams::new(vec!["openlogi-flow".to_owned()])?;
+        let certificate = parameters.self_signed(&key_pair)?.der().clone();
+        Ok(Self {
+            public_key,
+            certificate,
+            private_key_pkcs8,
+        })
+    }
+}
+
+/// Failure generating, loading, or parsing an Ed25519 machine identity.
+#[derive(Debug, Error)]
+pub enum IdentityError {
+    /// Certificate or private-key generation failed.
+    #[error("identity generation failed: {0}")]
+    Rcgen(#[from] rcgen::Error),
+    /// An Ed25519 key did not have its required fixed width.
+    #[error(transparent)]
+    KeyWidth(#[from] FixedBytesError),
+    /// A peer certificate was not a canonical Ed25519 leaf certificate.
+    #[error("peer certificate is not a canonical Ed25519 certificate")]
+    InvalidCertificate,
+}
+
+/// Whether the TLS-authenticated peer key was already trusted.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionTrust {
+    /// The peer key was in the configured pin set before this connection.
+    Trusted,
+    /// Pairing mode admitted this one unknown key, pending SAS confirmation.
+    Untrusted,
+}
+
+#[derive(Debug)]
+struct TrustState {
+    pinned: BTreeSet<PublicKey>,
+    pairing_candidate: Option<Mutex<Option<PublicKey>>>,
+}
+
+/// Pinned peer-key policy shared by the TLS client and server verifiers.
+///
+/// Pairing mode is explicit and admits at most one distinct unknown key. It
+/// records the candidate but never persists it; persistence belongs to the
+/// pairing state machine after user confirmation.
+#[derive(Clone, Debug)]
+pub struct PeerTrust(Arc<TrustState>);
+
+impl PeerTrust {
+    /// Creates strict trust that accepts only the supplied peer keys.
+    #[must_use]
+    pub fn pinned(keys: impl IntoIterator<Item = PublicKey>) -> Self {
+        Self(Arc::new(TrustState {
+            pinned: keys.into_iter().collect(),
+            pairing_candidate: None,
+        }))
+    }
+
+    /// Creates explicit pairing mode, while continuing to trust existing pins.
+    #[must_use]
+    pub fn pairing(keys: impl IntoIterator<Item = PublicKey>) -> Self {
+        Self(Arc::new(TrustState {
+            pinned: keys.into_iter().collect(),
+            pairing_candidate: Some(Mutex::new(None)),
+        }))
+    }
+
+    /// Returns the unknown key admitted by pairing mode, if any.
+    #[must_use]
+    pub fn pairing_candidate(&self) -> Option<PublicKey> {
+        self.0
+            .pairing_candidate
+            .as_ref()
+            .and_then(|candidate| candidate.lock().ok().and_then(|guard| *guard))
+    }
+
+    pub(super) fn classify(&self, key: PublicKey) -> Result<SessionTrust, RustlsError> {
+        if self
+            .0
+            .pinned
+            .iter()
+            .any(|pinned| constant_time_key_eq(*pinned, key))
+        {
+            return Ok(SessionTrust::Trusted);
+        }
+        let Some(candidate) = &self.0.pairing_candidate else {
+            return Err(untrusted_certificate());
+        };
+        let mut candidate = candidate
+            .lock()
+            .map_err(|_| RustlsError::General("pairing candidate lock poisoned".to_owned()))?;
+        match *candidate {
+            Some(existing) if constant_time_key_eq(existing, key) => Ok(SessionTrust::Untrusted),
+            Some(_) => Err(untrusted_certificate()),
+            None => {
+                *candidate = Some(key);
+                Ok(SessionTrust::Untrusted)
+            }
+        }
+    }
+}
+
+/// Extracts the raw Ed25519 identity from a DER certificate's SPKI.
+pub fn public_key_from_certificate(certificate: &[u8]) -> Result<PublicKey, IdentityError> {
+    let (remaining, certificate) =
+        parse_x509_certificate(certificate).map_err(|_| IdentityError::InvalidCertificate)?;
+    if !remaining.is_empty() {
+        return Err(IdentityError::InvalidCertificate);
+    }
+    let spki = certificate.public_key();
+    if spki.algorithm.algorithm != OID_SIG_ED25519
+        || spki.algorithm.parameters.is_some()
+        || spki.subject_public_key.unused_bits != 0
+    {
+        return Err(IdentityError::InvalidCertificate);
+    }
+    PublicKey::try_from(spki.subject_public_key.data.as_ref()).map_err(IdentityError::from)
+}
+
+fn verify_peer(
+    policy: &PeerTrust,
+    end_entity: &CertificateDer<'_>,
+    intermediates: &[CertificateDer<'_>],
+) -> Result<(), RustlsError> {
+    if !intermediates.is_empty() {
+        return Err(RustlsError::InvalidCertificate(
+            CertificateError::BadEncoding,
+        ));
+    }
+    let key = public_key_from_certificate(end_entity.as_ref())
+        .map_err(|_| RustlsError::InvalidCertificate(CertificateError::BadEncoding))?;
+    policy.classify(key).map(|_| ())
+}
+
+fn constant_time_key_eq(first: PublicKey, second: PublicKey) -> bool {
+    bool::from(first.as_bytes().ct_eq(second.as_bytes()))
+}
+
+fn untrusted_certificate() -> RustlsError {
+    RustlsError::InvalidCertificate(CertificateError::UnknownIssuer)
+}
+
+#[derive(Debug)]
+pub(super) struct PinnedServerVerifier {
+    policy: PeerTrust,
+    provider: Arc<CryptoProvider>,
+}
+
+impl PinnedServerVerifier {
+    pub(super) fn new(policy: PeerTrust, provider: Arc<CryptoProvider>) -> Self {
+        Self { policy, provider }
+    }
+}
+
+impl ServerCertVerifier for PinnedServerVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        verify_peer(&self.policy, end_entity, intermediates)?;
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        certificate: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            certificate,
+            signature,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        certificate: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            certificate,
+            signature,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct PinnedClientVerifier {
+    policy: PeerTrust,
+    provider: Arc<CryptoProvider>,
+}
+
+impl PinnedClientVerifier {
+    pub(super) fn new(policy: PeerTrust, provider: Arc<CryptoProvider>) -> Self {
+        Self { policy, provider }
+    }
+}
+
+impl ClientCertVerifier for PinnedClientVerifier {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        true
+    }
+
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        &[]
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _now: UnixTime,
+    ) -> Result<ClientCertVerified, RustlsError> {
+        verify_peer(&self.policy, end_entity, intermediates)?;
+        Ok(ClientCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        certificate: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            certificate,
+            signature,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        certificate: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            certificate,
+            signature,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_identity_round_trips_through_pkcs8_and_certificate() {
+        let identity = MachineIdentity::generate().unwrap();
+        let reloaded = MachineIdentity::from_pkcs8(identity.private_key_pkcs8().to_vec()).unwrap();
+        assert_eq!(identity.public_key(), reloaded.public_key());
+        assert_eq!(
+            public_key_from_certificate(reloaded.certificate_der()).unwrap(),
+            identity.public_key()
+        );
+    }
+
+    #[test]
+    fn pairing_mode_admits_only_one_unknown_key() {
+        let policy = PeerTrust::pairing([]);
+        assert_eq!(
+            policy.classify(PublicKey::new([1; 32])).unwrap(),
+            SessionTrust::Untrusted
+        );
+        assert_eq!(policy.pairing_candidate(), Some(PublicKey::new([1; 32])));
+        policy.classify(PublicKey::new([2; 32])).unwrap_err();
+    }
+
+    #[test]
+    fn existing_pin_stays_trusted_in_pairing_mode() {
+        let pinned = PublicKey::new([1; 32]);
+        let policy = PeerTrust::pairing([pinned]);
+        assert_eq!(policy.classify(pinned).unwrap(), SessionTrust::Trusted);
+        assert!(policy.pairing_candidate().is_none());
+    }
+}

--- a/crates/openlogi-flow/tests/quic_protocol.rs
+++ b/crates/openlogi-flow/tests/quic_protocol.rs
@@ -1,0 +1,515 @@
+#![expect(
+    clippy::tests_outside_test_module,
+    reason = "Cargo integration tests are test-only crates"
+)]
+
+use std::{
+    error::Error as StdError,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Instant,
+};
+
+use openlogi_flow::{
+    frame::{Envelope, FrameKind, MAX_PAYLOAD_LEN},
+    generated as proto,
+    pairing::{PairingSession, PeerKeyStore, PersistPeerKeyError},
+    sas::{PublicKey, SessionNonce},
+    transport::{
+        BulkRpcResponse, FlowConnection, FlowEndpoint, MachineIdentity, PeerTrust, RpcEvent,
+        SessionTrust, TransportError, message_envelope,
+    },
+};
+
+type TestResult<T = ()> = Result<T, Box<dyn StdError + Send + Sync>>;
+
+struct ConnectedPair {
+    _first_endpoint: Arc<FlowEndpoint>,
+    _second_endpoint: Arc<FlowEndpoint>,
+    first: FlowConnection,
+    second: FlowConnection,
+}
+
+impl ConnectedPair {
+    async fn trusted(first_range: (u32, u32), second_range: (u32, u32)) -> TestResult<Self> {
+        Self::connect(first_range, second_range, false, &[]).await
+    }
+
+    async fn pairing() -> TestResult<Self> {
+        Self::connect((1, 1), (1, 1), true, &[]).await
+    }
+
+    async fn trusted_clipboard() -> TestResult<Self> {
+        Self::connect((1, 1), (1, 1), false, &[proto::Capability::ClipboardText]).await
+    }
+
+    async fn connect(
+        first_range: (u32, u32),
+        second_range: (u32, u32),
+        pairing: bool,
+        capabilities: &[proto::Capability],
+    ) -> TestResult<Self> {
+        let first_identity = MachineIdentity::generate()?;
+        let second_identity = MachineIdentity::generate()?;
+        let first_trust = if pairing {
+            PeerTrust::pairing([])
+        } else {
+            PeerTrust::pinned([second_identity.public_key()])
+        };
+        let second_trust = if pairing {
+            PeerTrust::pairing([])
+        } else {
+            PeerTrust::pinned([first_identity.public_key()])
+        };
+        let first = Arc::new(FlowEndpoint::bind(
+            localhost(),
+            first_identity.clone(),
+            first_trust,
+            hello_with_capabilities(&first_identity, [1; 16], first_range, capabilities),
+        )?);
+        let second = Arc::new(FlowEndpoint::bind(
+            localhost(),
+            second_identity.clone(),
+            second_trust,
+            hello_with_capabilities(&second_identity, [2; 16], second_range, capabilities),
+        )?);
+        let second_acceptor = Arc::clone(&second);
+        let accept = tokio::spawn(async move { second_acceptor.accept().await });
+        let first_connection = first.connect(second.local_addr()?).await?;
+        let second_connection = accept.await??;
+        Ok(Self {
+            _first_endpoint: first,
+            _second_endpoint: second,
+            first: first_connection,
+            second: second_connection,
+        })
+    }
+}
+
+#[derive(Default)]
+struct MemoryKeyStore(Vec<PublicKey>);
+
+impl PeerKeyStore for MemoryKeyStore {
+    fn persist_peer_key(&mut self, key: PublicKey) -> Result<(), PersistPeerKeyError> {
+        self.0.push(key);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn hello_negotiates_over_mutually_pinned_quic() -> TestResult {
+    let pair = ConnectedPair::trusted((1, 3), (2, 4)).await?;
+    assert_eq!(pair.first.negotiated().version, 3);
+    assert_eq!(pair.second.negotiated().version, 3);
+    assert_eq!(pair.first.trust(), SessionTrust::Trusted);
+    assert_eq!(pair.second.trust(), SessionTrust::Trusted);
+    assert_eq!(pair.first.peer_key(), pair.first.peer_hello_key()?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn wrong_server_pin_fails_tls_authentication() -> TestResult {
+    assert_pin_failure(false, true).await
+}
+
+#[tokio::test]
+async fn wrong_client_pin_fails_tls_authentication() -> TestResult {
+    assert_pin_failure(true, false).await
+}
+
+#[tokio::test]
+async fn version_disjoint_hello_is_rejected() -> TestResult {
+    let first_identity = MachineIdentity::generate()?;
+    let second_identity = MachineIdentity::generate()?;
+    let first = Arc::new(FlowEndpoint::bind(
+        localhost(),
+        first_identity.clone(),
+        PeerTrust::pinned([second_identity.public_key()]),
+        hello(&first_identity, [1; 16], (1, 1)),
+    )?);
+    let second = Arc::new(FlowEndpoint::bind(
+        localhost(),
+        second_identity.clone(),
+        PeerTrust::pinned([first_identity.public_key()]),
+        hello(&second_identity, [2; 16], (2, 2)),
+    )?);
+    let second_acceptor = Arc::clone(&second);
+    let accepted = tokio::spawn(async move { second_acceptor.accept().await });
+
+    let dialed = first.connect(second.local_addr()?).await;
+    dialed.unwrap_err();
+    accepted.await?.unwrap_err();
+    Ok(())
+}
+
+#[tokio::test]
+async fn untrusted_session_rejects_non_pairing_rpc() -> TestResult {
+    let pair = ConnectedPair::pairing().await?;
+    assert_eq!(pair.first.trust(), SessionTrust::Untrusted);
+    assert_eq!(pair.second.trust(), SessionTrust::Untrusted);
+
+    let request = message_envelope(FrameKind::GetPeerInfo, &proto::GetPeerInfo::default())?;
+    assert!(matches!(
+        pair.first.call(request.clone()).await,
+        Err(TransportError::NotPaired(FrameKind::GetPeerInfo))
+    ));
+    let client = async {
+        let (mut send, mut receive) = pair.first.open_rpc_stream().await?;
+        request.write_to(&mut send).await?;
+        send.finish()?;
+        let response = Envelope::read_from(&mut receive).await?;
+        TestResult::Ok(response)
+    };
+    let (accepted, response) = tokio::join!(pair.second.accept_rpc(), client);
+    assert!(matches!(
+        accepted?,
+        RpcEvent::Rejected(proto::ErrorCode::NotPaired)
+    ));
+    let response = response?;
+    assert_eq!(response.kind, FrameKind::Error);
+    assert_eq!(
+        decode::<proto::Error>(&response)?.code.as_known(),
+        Some(proto::ErrorCode::NotPaired)
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn malformed_pairing_request_is_answered_invalid() -> TestResult {
+    let pair = ConnectedPair::pairing().await?;
+    let client = async {
+        let (mut send, mut receive) = pair.first.open_rpc_stream().await?;
+        Envelope::new(FrameKind::PairStart, 0, vec![0xff])?
+            .write_to(&mut send)
+            .await?;
+        send.finish()?;
+        let response = Envelope::read_from(&mut receive).await?;
+        TestResult::Ok(response)
+    };
+    let (accepted, response) = tokio::join!(pair.second.accept_rpc(), client);
+    assert!(matches!(
+        accepted?,
+        RpcEvent::Rejected(proto::ErrorCode::Invalid)
+    ));
+    let error = decode::<proto::Error>(&response?)?;
+    assert_eq!(error.code.as_known(), Some(proto::ErrorCode::Invalid));
+    Ok(())
+}
+
+#[tokio::test]
+async fn full_pairing_ceremony_agrees_on_sas_and_promotes_trust() -> TestResult {
+    let pair = ConnectedPair::pairing().await?;
+    let first_nonce = SessionNonce::try_from(pair.second.peer_hello().session_nonce.as_slice())?;
+    let second_nonce = SessionNonce::try_from(pair.first.peer_hello().session_nonce.as_slice())?;
+    let mut first_session = PairingSession::new(
+        pair.second.peer_key(),
+        pair.first.peer_key(),
+        first_nonce,
+        second_nonce,
+    );
+    let mut second_session = PairingSession::new(
+        pair.first.peer_key(),
+        pair.second.peer_key(),
+        second_nonce,
+        first_nonce,
+    );
+    assert_eq!(first_session.sas_code(), second_session.sas_code());
+    assert!(first_session.sas_code().is_some());
+
+    let start = message_envelope(FrameKind::PairStart, &first_session.start()?)?;
+    let server_side = async {
+        let RpcEvent::Request(request) = pair.second.accept_rpc().await? else {
+            return Err("PairStart was rejected".into());
+        };
+        request
+            .request()
+            .decode::<proto::PairStart>(openlogi_flow::frame::InboundRole::Request)
+            .map_err(|_| "PairStart payload was invalid")?;
+        let prompted = second_session.receive_start(Instant::now(), None)?;
+        request
+            .respond(message_envelope(FrameKind::PairPrompted, &prompted)?)
+            .await?;
+        TestResult::Ok(())
+    };
+    let (server_result, prompted) = tokio::join!(server_side, pair.first.call(start));
+    server_result?;
+    let prompted = decode::<proto::PairPrompted>(&prompted?)?;
+    first_session.receive_prompted(&prompted, Instant::now())?;
+
+    let mut first_store = MemoryKeyStore::default();
+    let mut second_store = MemoryKeyStore::default();
+    assert_eq!(
+        first_session.confirm_local(&mut first_store)?,
+        proto::PairResult::PendingLocal
+    );
+    let first_confirm = message_envelope(FrameKind::PairConfirm, &proto::PairConfirm::default())?;
+    let server_side = async {
+        let RpcEvent::Request(request) = pair.second.accept_rpc().await? else {
+            return Err("first PairConfirm was rejected".into());
+        };
+        let outcome = second_session.receive_confirm(&mut second_store)?;
+        request
+            .respond(message_envelope(FrameKind::PairOutcome, &outcome)?)
+            .await?;
+        TestResult::Ok(())
+    };
+    let (server_result, outcome) = tokio::join!(server_side, pair.first.call(first_confirm));
+    server_result?;
+    first_session.receive_outcome(&decode::<proto::PairOutcome>(&outcome?)?)?;
+
+    assert_eq!(
+        second_session.confirm_local(&mut second_store)?,
+        proto::PairResult::Paired
+    );
+    let second_confirm = message_envelope(FrameKind::PairConfirm, &proto::PairConfirm::default())?;
+    let server_side = async {
+        let RpcEvent::Request(request) = pair.first.accept_rpc().await? else {
+            return Err("second PairConfirm was rejected".into());
+        };
+        let outcome = first_session.receive_confirm(&mut first_store)?;
+        request
+            .respond(message_envelope(FrameKind::PairOutcome, &outcome)?)
+            .await?;
+        TestResult::Ok(())
+    };
+    let (server_result, outcome) = tokio::join!(server_side, pair.second.call(second_confirm));
+    server_result?;
+    second_session.receive_outcome(&decode::<proto::PairOutcome>(&outcome?)?)?;
+
+    pair.first.promote_after_pairing(&first_session)?;
+    pair.second.promote_after_pairing(&second_session)?;
+    assert_eq!(pair.first.trust(), SessionTrust::Trusted);
+    assert_eq!(pair.second.trust(), SessionTrust::Trusted);
+    assert_eq!(first_store.0, [pair.first.peer_key()]);
+    assert_eq!(second_store.0, [pair.second.peer_key()]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn trusted_get_peer_info_rpc_round_trips() -> TestResult {
+    let pair = ConnectedPair::trusted((1, 1), (1, 1)).await?;
+    let request = message_envelope(FrameKind::GetPeerInfo, &proto::GetPeerInfo::default())?;
+    let server_side = async {
+        let RpcEvent::Request(request) = pair.second.accept_rpc().await? else {
+            return Err("GetPeerInfo was rejected".into());
+        };
+        request
+            .request()
+            .decode::<proto::GetPeerInfo>(openlogi_flow::frame::InboundRole::Request)
+            .map_err(|_| "GetPeerInfo payload was invalid")?;
+        request
+            .respond(message_envelope(
+                FrameKind::PeerInfo,
+                &proto::PeerInfo {
+                    machine_name: "peer-b".to_owned(),
+                    revision: 7,
+                    ..Default::default()
+                },
+            )?)
+            .await?;
+        TestResult::Ok(())
+    };
+    let (server_result, response) = tokio::join!(server_side, pair.first.call(request));
+    server_result?;
+    let response = decode::<proto::PeerInfo>(&response?)?;
+    assert_eq!(response.machine_name, "peer-b");
+    assert_eq!(response.revision, 7);
+    Ok(())
+}
+
+#[tokio::test]
+async fn bulk_rpc_streams_head_chunks_and_terminal_frame() -> TestResult {
+    let pair = ConnectedPair::trusted_clipboard().await?;
+    let request = message_envelope(
+        FrameKind::ClipboardFetch,
+        &proto::ClipboardFetch {
+            sequence: 7,
+            mime: "text/plain".to_owned(),
+            ..Default::default()
+        },
+    )?;
+    let server_side = async {
+        let RpcEvent::Request(request) = pair.second.accept_rpc().await? else {
+            return Err("ClipboardFetch was rejected".into());
+        };
+        request
+            .respond_bulk(
+                message_envelope(
+                    FrameKind::ClipboardData,
+                    &proto::ClipboardData {
+                        sequence: 7,
+                        mime: "text/plain".to_owned(),
+                        total_size: 6,
+                        ..Default::default()
+                    },
+                )?,
+                [
+                    message_envelope(
+                        FrameKind::Chunk,
+                        &proto::Chunk {
+                            data: b"abc".to_vec(),
+                            ..Default::default()
+                        },
+                    )?,
+                    message_envelope(
+                        FrameKind::Chunk,
+                        &proto::Chunk {
+                            data: b"def".to_vec(),
+                            ..Default::default()
+                        },
+                    )?,
+                ],
+                message_envelope(FrameKind::ChunkEnd, &proto::ChunkEnd::default())?,
+            )
+            .await?;
+        TestResult::Ok(())
+    };
+    let client_side = async {
+        let BulkRpcResponse::Data(mut response) = pair.first.call_bulk(request).await? else {
+            return Err("bulk RPC returned Error".into());
+        };
+        assert_eq!(
+            decode::<proto::ClipboardData>(response.head())?.total_size,
+            6
+        );
+        let first = response
+            .next_frame()
+            .await?
+            .ok_or("bulk response ended before its first chunk")?;
+        let second = response
+            .next_frame()
+            .await?
+            .ok_or("bulk response ended before its second chunk")?;
+        let end = response
+            .next_frame()
+            .await?
+            .ok_or("bulk response omitted ChunkEnd")?;
+        assert_eq!(decode::<proto::Chunk>(&first)?.data, b"abc");
+        assert_eq!(decode::<proto::Chunk>(&second)?.data, b"def");
+        assert_eq!(end.kind, FrameKind::ChunkEnd);
+        assert_eq!(response.next_frame().await?, None);
+        TestResult::Ok(())
+    };
+    let (server_result, client_result) = tokio::join!(server_side, client_side);
+    server_result?;
+    client_result?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn oversized_rpc_frame_is_answered_too_large() -> TestResult {
+    let pair = ConnectedPair::trusted((1, 1), (1, 1)).await?;
+    let client = async {
+        let (mut send, mut receive) = pair.first.open_rpc_stream().await?;
+        let mut header = [0_u8; 8];
+        header[..2].copy_from_slice(&FrameKind::GetPeerInfo.wire_value().to_le_bytes());
+        header[4..].copy_from_slice(
+            &u32::try_from(MAX_PAYLOAD_LEN + 1)
+                .expect("test length fits u32")
+                .to_le_bytes(),
+        );
+        send.write_all(&header).await?;
+        send.finish()?;
+        let response = Envelope::read_from(&mut receive).await?;
+        TestResult::Ok(response)
+    };
+    let (accepted, response) = tokio::join!(pair.second.accept_rpc(), client);
+    assert!(matches!(
+        accepted?,
+        RpcEvent::Rejected(proto::ErrorCode::TooLarge)
+    ));
+    let error = decode::<proto::Error>(&response?)?;
+    assert_eq!(error.code.as_known(), Some(proto::ErrorCode::TooLarge));
+    Ok(())
+}
+
+fn localhost() -> SocketAddr {
+    SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
+}
+
+async fn assert_pin_failure(
+    server_pin_is_correct: bool,
+    client_pin_is_correct: bool,
+) -> TestResult {
+    let client_identity = MachineIdentity::generate()?;
+    let server_identity = MachineIdentity::generate()?;
+    let unrelated_identity = MachineIdentity::generate()?;
+    let server_pin = if server_pin_is_correct {
+        server_identity.public_key()
+    } else {
+        unrelated_identity.public_key()
+    };
+    let client_pin = if client_pin_is_correct {
+        client_identity.public_key()
+    } else {
+        unrelated_identity.public_key()
+    };
+    let client = Arc::new(FlowEndpoint::bind(
+        localhost(),
+        client_identity.clone(),
+        PeerTrust::pinned([server_pin]),
+        hello(&client_identity, [1; 16], (1, 1)),
+    )?);
+    let server = Arc::new(FlowEndpoint::bind(
+        localhost(),
+        server_identity.clone(),
+        PeerTrust::pinned([client_pin]),
+        hello(&server_identity, [2; 16], (1, 1)),
+    )?);
+    let server_acceptor = Arc::clone(&server);
+    let accepted = tokio::spawn(async move { server_acceptor.accept().await });
+
+    if client.connect(server.local_addr()?).await.is_ok() {
+        return Err("client accepted an incorrectly pinned server".into());
+    }
+    if accepted.await?.is_ok() {
+        return Err("server accepted an incorrectly pinned client".into());
+    }
+    Ok(())
+}
+
+fn hello(
+    identity: &MachineIdentity,
+    nonce: [u8; 16],
+    (proto_min, proto_max): (u32, u32),
+) -> proto::Hello {
+    proto::Hello {
+        proto_min,
+        proto_max,
+        public_key: identity.public_key().as_bytes().to_vec(),
+        session_nonce: nonce.to_vec(),
+        machine_name: "test-peer".to_owned(),
+        app_version: "test".to_owned(),
+        ..Default::default()
+    }
+}
+
+fn hello_with_capabilities(
+    identity: &MachineIdentity,
+    nonce: [u8; 16],
+    range: (u32, u32),
+    capabilities: &[proto::Capability],
+) -> proto::Hello {
+    proto::Hello {
+        capabilities: capabilities.iter().copied().map(Into::into).collect(),
+        ..hello(identity, nonce, range)
+    }
+}
+
+fn decode<M: buffa::Message>(envelope: &Envelope) -> TestResult<M> {
+    envelope
+        .decode(openlogi_flow::frame::InboundRole::Request)
+        .map_err(|decision| format!("protobuf payload rejected: {decision:?}").into())
+}
+
+trait PeerHelloKey {
+    fn peer_hello_key(&self) -> TestResult<PublicKey>;
+}
+
+impl PeerHelloKey for FlowConnection {
+    fn peer_hello_key(&self) -> TestResult<PublicKey> {
+        Ok(PublicKey::try_from(
+            self.peer_hello().public_key.as_slice(),
+        )?)
+    }
+}

--- a/crates/openlogi-flow/tests/quic_protocol.rs
+++ b/crates/openlogi-flow/tests/quic_protocol.rs
@@ -239,7 +239,7 @@ async fn full_pairing_ceremony_agrees_on_sas_and_promotes_trust() -> TestResult 
     let mut first_store = MemoryKeyStore::default();
     let mut second_store = MemoryKeyStore::default();
     assert_eq!(
-        first_session.confirm_local(&mut first_store)?,
+        first_session.confirm_local(Instant::now(), &mut first_store)?,
         proto::PairResult::PendingLocal
     );
     let first_confirm = message_envelope(FrameKind::PairConfirm, &proto::PairConfirm::default())?;
@@ -247,7 +247,7 @@ async fn full_pairing_ceremony_agrees_on_sas_and_promotes_trust() -> TestResult 
         let RpcEvent::Request(request) = pair.second.accept_rpc().await? else {
             return Err("first PairConfirm was rejected".into());
         };
-        let outcome = second_session.receive_confirm(&mut second_store)?;
+        let outcome = second_session.receive_confirm(Instant::now(), &mut second_store)?;
         request
             .respond(message_envelope(FrameKind::PairOutcome, &outcome)?)
             .await?;
@@ -258,7 +258,7 @@ async fn full_pairing_ceremony_agrees_on_sas_and_promotes_trust() -> TestResult 
     first_session.receive_outcome(&decode::<proto::PairOutcome>(&outcome?)?)?;
 
     assert_eq!(
-        second_session.confirm_local(&mut second_store)?,
+        second_session.confirm_local(Instant::now(), &mut second_store)?,
         proto::PairResult::Paired
     );
     let second_confirm = message_envelope(FrameKind::PairConfirm, &proto::PairConfirm::default())?;
@@ -266,7 +266,7 @@ async fn full_pairing_ceremony_agrees_on_sas_and_promotes_trust() -> TestResult 
         let RpcEvent::Request(request) = pair.first.accept_rpc().await? else {
             return Err("second PairConfirm was rejected".into());
         };
-        let outcome = first_session.receive_confirm(&mut first_store)?;
+        let outcome = first_session.receive_confirm(Instant::now(), &mut first_store)?;
         request
             .respond(message_envelope(FrameKind::PairOutcome, &outcome)?)
             .await?;

--- a/crates/openlogi-flow/tests/session_manager.rs
+++ b/crates/openlogi-flow/tests/session_manager.rs
@@ -1,0 +1,412 @@
+#![expect(
+    clippy::tests_outside_test_module,
+    reason = "Cargo integration tests are test-only crates"
+)]
+
+use std::{
+    error::Error as StdError,
+    net::{Ipv4Addr, SocketAddr},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use openlogi_flow::{
+    discovery::{CandidateFuture, CandidateSource, ManualCandidateSource},
+    frame::FrameKind,
+    generated as proto,
+    sas::PublicKey,
+    session::{
+        LinkState, PeerConfig, PeerSessionHandle, SessionManager, SessionPolicy,
+        TrustedInitialState, TrustedStateProvider,
+    },
+    transport::{
+        ConnectionDirection, FlowConnection, FlowEndpoint, MachineIdentity, NotificationEvent,
+        PeerTrust,
+    },
+};
+use tokio::sync::Barrier;
+
+type TestResult<T = ()> = Result<T, Box<dyn StdError + Send + Sync>>;
+
+#[derive(Debug)]
+struct CountingProvider {
+    calls: AtomicUsize,
+    revision: u64,
+}
+
+impl CountingProvider {
+    fn new(revision: u64) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            revision,
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::Acquire)
+    }
+}
+
+impl TrustedStateProvider for CountingProvider {
+    fn initial_state(&self, _peer_key: PublicKey) -> TrustedInitialState {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        TrustedInitialState {
+            announce_devices: proto::AnnounceDevices {
+                revision: self.revision,
+                ..Default::default()
+            },
+            peer_state: proto::PeerState {
+                flow_enabled: true,
+                revision: self.revision,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+struct BarrierSource {
+    address: SocketAddr,
+    barrier: Arc<Barrier>,
+}
+
+impl CandidateSource for BarrierSource {
+    fn candidates(&self, _peer_key: PublicKey) -> CandidateFuture<'_> {
+        Box::pin(async move {
+            self.barrier.wait().await;
+            Ok(vec![self.address])
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn managers_establish_a_session_and_send_trusted_initial_state() -> TestResult {
+    let first_identity = MachineIdentity::generate()?;
+    let second_identity = MachineIdentity::generate()?;
+    let first = endpoint(&first_identity, second_identity.public_key(), [1; 16])?;
+    let second = endpoint(&second_identity, first_identity.public_key(), [2; 16])?;
+    let first_provider = Arc::new(CountingProvider::new(11));
+    let second_provider = Arc::new(CountingProvider::new(22));
+
+    let first_manager = SessionManager::start(
+        Arc::clone(&first),
+        [peer_with_address(
+            second_identity.public_key(),
+            second.local_addr()?,
+        )],
+        first_provider.clone(),
+        test_policy(),
+    )?;
+    let second_manager = SessionManager::start(
+        Arc::clone(&second),
+        [incoming_only_peer(first_identity.public_key())],
+        second_provider.clone(),
+        test_policy(),
+    )?;
+    let first_handle = first_manager
+        .peer(second_identity.public_key())
+        .ok_or("first manager omitted its peer handle")?
+        .clone();
+    let second_handle = second_manager
+        .peer(first_identity.public_key())
+        .ok_or("second manager omitted its peer handle")?
+        .clone();
+
+    wait_for_state(&first_handle, LinkState::Connected).await?;
+    wait_for_state(&second_handle, LinkState::Connected).await?;
+    let second_connection = wait_for_connection(&second_handle).await?;
+    assert_eq!(
+        next_notification_kind(&second_connection).await?,
+        FrameKind::AnnounceDevices
+    );
+    assert_eq!(
+        next_notification_kind(&second_connection).await?,
+        FrameKind::PeerState
+    );
+    wait_for_calls(&first_provider, 1).await?;
+    wait_for_calls(&second_provider, 1).await?;
+    assert_eq!(first_provider.calls(), 1);
+    assert_eq!(second_provider.calls(), 1);
+
+    first_manager.shutdown().await;
+    second_manager.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn simultaneous_dial_converges_on_the_key_order_tiebreak() -> TestResult {
+    let first_identity = MachineIdentity::generate()?;
+    let second_identity = MachineIdentity::generate()?;
+    let first = endpoint(&first_identity, second_identity.public_key(), [7; 16])?;
+    let second = endpoint(&second_identity, first_identity.public_key(), [8; 16])?;
+    let barrier = Arc::new(Barrier::new(2));
+    let first_manager = SessionManager::start(
+        Arc::clone(&first),
+        [barrier_peer(
+            second_identity.public_key(),
+            second.local_addr()?,
+            Arc::clone(&barrier),
+        )],
+        Arc::new(CountingProvider::new(1)),
+        test_policy(),
+    )?;
+    let second_manager = SessionManager::start(
+        Arc::clone(&second),
+        [barrier_peer(
+            first_identity.public_key(),
+            first.local_addr()?,
+            barrier,
+        )],
+        Arc::new(CountingProvider::new(2)),
+        test_policy(),
+    )?;
+    let first_handle = first_manager
+        .peer(second_identity.public_key())
+        .ok_or("first manager omitted its peer handle")?
+        .clone();
+    let second_handle = second_manager
+        .peer(first_identity.public_key())
+        .ok_or("second manager omitted its peer handle")?
+        .clone();
+    let first_direction = if first_identity.public_key() < second_identity.public_key() {
+        ConnectionDirection::Incoming
+    } else {
+        ConnectionDirection::Outgoing
+    };
+    let second_direction = if second_identity.public_key() < first_identity.public_key() {
+        ConnectionDirection::Incoming
+    } else {
+        ConnectionDirection::Outgoing
+    };
+
+    wait_for_direction(&first_handle, first_direction).await?;
+    wait_for_direction(&second_handle, second_direction).await?;
+    assert_eq!(first_handle.state(), LinkState::Connected);
+    assert_eq!(second_handle.state(), LinkState::Connected);
+
+    first_manager.shutdown().await;
+    second_manager.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn manager_reconnects_after_peer_session_is_dropped() -> TestResult {
+    let first_identity = MachineIdentity::generate()?;
+    let second_identity = MachineIdentity::generate()?;
+    let first = endpoint(&first_identity, second_identity.public_key(), [3; 16])?;
+    let second = endpoint(&second_identity, first_identity.public_key(), [4; 16])?;
+    let first_provider = Arc::new(CountingProvider::new(1));
+    let second_provider = Arc::new(CountingProvider::new(2));
+    let first_manager = SessionManager::start(
+        Arc::clone(&first),
+        [peer_with_address(
+            second_identity.public_key(),
+            second.local_addr()?,
+        )],
+        first_provider.clone(),
+        test_policy(),
+    )?;
+    let second_manager = SessionManager::start(
+        Arc::clone(&second),
+        [incoming_only_peer(first_identity.public_key())],
+        second_provider.clone(),
+        test_policy(),
+    )?;
+    let first_handle = first_manager
+        .peer(second_identity.public_key())
+        .ok_or("first manager omitted its peer handle")?
+        .clone();
+    wait_for_state(&first_handle, LinkState::Connected).await?;
+
+    second_manager.shutdown().await;
+    wait_for_state(&first_handle, LinkState::Lost).await?;
+
+    let restarted_second_manager = SessionManager::start(
+        Arc::clone(&second),
+        [incoming_only_peer(first_identity.public_key())],
+        second_provider.clone(),
+        test_policy(),
+    )?;
+    let restarted_handle = restarted_second_manager
+        .peer(first_identity.public_key())
+        .ok_or("restarted manager omitted its peer handle")?
+        .clone();
+    wait_for_state(&first_handle, LinkState::Connected).await?;
+    wait_for_state(&restarted_handle, LinkState::Connected).await?;
+    wait_for_calls(&first_provider, 2).await?;
+
+    first_manager.shutdown().await;
+    restarted_second_manager.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn missing_pong_degrades_then_transport_close_marks_lost() -> TestResult {
+    let managed_identity = MachineIdentity::generate()?;
+    let silent_identity = MachineIdentity::generate()?;
+    let managed = endpoint(&managed_identity, silent_identity.public_key(), [5; 16])?;
+    let silent = endpoint(&silent_identity, managed_identity.public_key(), [6; 16])?;
+    let silent_acceptor = Arc::clone(&silent);
+    let accepted = tokio::spawn(async move { silent_acceptor.accept().await });
+    let provider = Arc::new(CountingProvider::new(1));
+    let sessions = SessionManager::start(
+        Arc::clone(&managed),
+        [peer_with_address(
+            silent_identity.public_key(),
+            silent.local_addr()?,
+        )],
+        provider,
+        test_policy(),
+    )?;
+    let handle = sessions
+        .peer(silent_identity.public_key())
+        .ok_or("manager omitted its peer handle")?
+        .clone();
+    let silent_connection = accepted.await??;
+
+    wait_for_state(&handle, LinkState::Connected).await?;
+    wait_for_state(&handle, LinkState::Degraded).await?;
+    silent_connection.close();
+    wait_for_state(&handle, LinkState::Lost).await?;
+
+    sessions.shutdown().await;
+    Ok(())
+}
+
+fn endpoint(
+    identity: &MachineIdentity,
+    peer_key: PublicKey,
+    nonce: [u8; 16],
+) -> TestResult<Arc<FlowEndpoint>> {
+    Ok(Arc::new(FlowEndpoint::bind(
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        identity.clone(),
+        PeerTrust::pinned([peer_key]),
+        proto::Hello {
+            proto_min: 1,
+            proto_max: 1,
+            public_key: identity.public_key().as_bytes().to_vec(),
+            session_nonce: nonce.to_vec(),
+            machine_name: "session-test".to_owned(),
+            app_version: "test".to_owned(),
+            ..Default::default()
+        },
+    )?))
+}
+
+fn peer_with_address(public_key: PublicKey, address: SocketAddr) -> PeerConfig {
+    let source: Arc<dyn CandidateSource> =
+        Arc::new(ManualCandidateSource::new([address.to_string()]));
+    PeerConfig {
+        public_key,
+        sources: vec![source],
+    }
+}
+
+fn barrier_peer(public_key: PublicKey, address: SocketAddr, barrier: Arc<Barrier>) -> PeerConfig {
+    PeerConfig {
+        public_key,
+        sources: vec![Arc::new(BarrierSource { address, barrier })],
+    }
+}
+
+fn incoming_only_peer(public_key: PublicKey) -> PeerConfig {
+    PeerConfig {
+        public_key,
+        sources: Vec::new(),
+    }
+}
+
+fn test_policy() -> SessionPolicy {
+    SessionPolicy {
+        retry_base: Duration::from_millis(20),
+        retry_max: Duration::from_millis(100),
+        ping_interval: Duration::from_millis(25),
+        degraded_after: Duration::from_millis(100),
+    }
+}
+
+async fn wait_for_state(handle: &PeerSessionHandle, expected: LinkState) -> TestResult {
+    let mut state = handle.subscribe_state();
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if *state.borrow_and_update() == expected {
+                return Ok::<_, Box<dyn StdError + Send + Sync>>(());
+            }
+            state
+                .changed()
+                .await
+                .map_err(|_| "session state channel closed")?;
+        }
+    })
+    .await
+    .map_err(|_| format!("timed out waiting for {expected:?}"))??;
+    Ok(())
+}
+
+async fn wait_for_connection(handle: &PeerSessionHandle) -> TestResult<Arc<FlowConnection>> {
+    let mut connection = handle.subscribe_connection();
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if let Some(connection) = connection.borrow_and_update().clone() {
+                return Ok::<_, Box<dyn StdError + Send + Sync>>(connection);
+            }
+            connection
+                .changed()
+                .await
+                .map_err(|_| "session connection channel closed")?;
+        }
+    })
+    .await
+    .map_err(|_| "timed out waiting for a live session connection")?
+}
+
+async fn wait_for_direction(
+    handle: &PeerSessionHandle,
+    expected: ConnectionDirection,
+) -> TestResult {
+    let mut connection = handle.subscribe_connection();
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if connection
+                .borrow_and_update()
+                .as_ref()
+                .is_some_and(|connection| connection.direction() == expected)
+            {
+                return Ok::<_, Box<dyn StdError + Send + Sync>>(());
+            }
+            connection
+                .changed()
+                .await
+                .map_err(|_| "session connection channel closed")?;
+        }
+    })
+    .await
+    .map_err(|_| format!("timed out waiting for {expected:?} connection"))??;
+    Ok(())
+}
+
+async fn next_notification_kind(connection: &FlowConnection) -> TestResult<FrameKind> {
+    let event = tokio::time::timeout(Duration::from_secs(3), connection.accept_notification())
+        .await
+        .map_err(|_| "timed out waiting for initial state notification")??;
+    match event {
+        NotificationEvent::Notification(envelope) => Ok(envelope.kind),
+        NotificationEvent::Dropped(code) => {
+            Err(format!("initial state notification was dropped: {code:?}").into())
+        }
+    }
+}
+
+async fn wait_for_calls(provider: &CountingProvider, expected: usize) -> TestResult {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while provider.calls() < expected {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .map_err(|_| format!("timed out waiting for {expected} provider calls"))?;
+    Ok(())
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -45,6 +45,8 @@ in
     [
       git
       cmake
+      # Buffa generates the Flow protocol types from protobuf at build time.
+      protobuf
       sccache
       prek
       typos

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,6 +6,8 @@ build instructions, see the [README](../README.md).
 ## Toolchain
 
 - Stable Rust (Edition 2024, MSRV 1.98 — the floor tracks current stable)
+- Protocol Buffers compiler (`protoc` 21.12 or newer), used by `buffa-build`
+  to generate the `openlogi-flow` wire types from its authoritative schema
 - macOS: Xcode 26+ with the optional **Metal Toolchain** component. The Metal
   Toolchain is what GPUI's `gpui_macos` build script compiles shaders with; the
   version floor is `actool`, which packaging uses to compile the app icon from
@@ -27,7 +29,7 @@ Nix/devenv is optional. A normal Rust toolchain is enough.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # macOS: full Xcode 26+ with the Metal Toolchain (not only Command Line Tools)
 # Linux: see system libraries under Toolchain above
-# optional helpers: brew install cmake create-dmg sccache
+# macOS build tools: brew install cmake protobuf create-dmg sccache
 git clone https://github.com/AprilNEA/OpenLogi
 cd OpenLogi
 cargo run -p openlogi --release -- list
@@ -40,7 +42,7 @@ and keep working.
 
 ### With devenv (optional)
 
-`devenv.nix` provisions sccache, the stable Rust toolchain, platform libraries,
+`devenv.nix` provisions sccache, protoc, the stable Rust toolchain, platform libraries,
 nfpm on Linux, and the macOS packaging/env helpers GPUI needs
 (`create-dmg`, `DEVELOPER_DIR`, and `SDKROOT`). Tasks:
 
@@ -180,6 +182,7 @@ crates/
   openlogi-hid/     device discovery, HID++ reads/writes, and control capture over async-hid
   openlogi-assets/  device-render registry schema + cached HTTP fetch from OpenLogi asset mirrors
   openlogi-cli/     CLI implementation: command tree + `run()`, called by the `openlogi` binary
+  openlogi-flow/    Flow protobuf protocol, framing, pairing, identity, and QUIC transport
   openlogi-agent-core/  shared orchestration + the agent/GUI IPC contract
   openlogi-agent/   the `openlogi-agent` binary — background agent owning device I/O and the hook
   openlogi-hook/    OS mouse hook: macOS CGEventTap, Linux evdev/uinput, Windows WH_MOUSE_LL

--- a/docs/FLOW-DESIGN.md
+++ b/docs/FLOW-DESIGN.md
@@ -9,8 +9,9 @@ ground. Once milestones land, durable decisions graduate into
 The peer protocol itself is specified normatively in
 [FLOW-PROTOCOL.md](FLOW-PROTOCOL.md) (framing, stream binding, state
 machines, evolution rules) with the message schema in
-[flow.v1.proto](flow.v1.proto); both move into `crates/openlogi-flow` when it
-exists.
+[`flow.v1.proto`](../crates/openlogi-flow/proto/flow.v1.proto). The normative
+specification remains in `docs/`; the schema lives with its code generator in
+`openlogi-flow`.
 
 ## What Flow is
 
@@ -283,7 +284,7 @@ corroborating, not binding.)
 
 Three layers, the outer ones frozen forever (normative details:
 [FLOW-PROTOCOL.md](FLOW-PROTOCOL.md); message schema:
-[flow.v1.proto](flow.v1.proto)):
+[`flow.v1.proto`](../crates/openlogi-flow/proto/flow.v1.proto)):
 
 ```
 ┌─ layer 0: envelope (frozen; any version can decode) ─────────────┐

--- a/docs/FLOW-DESIGN.md
+++ b/docs/FLOW-DESIGN.md
@@ -358,7 +358,9 @@ milestone 2 onward:
    peer may list hostnames or IPs, resolved through the OS resolver so
    `/etc/hosts`, ordinary DNS, and overlay magic-DNS names all work
    (lan-mouse precedent). mDNS is an optimization for the flat-LAN case,
-   never a requirement for a link to form.
+   never a requirement for a link to form. An omitted port uses Flow's
+   default UDP port, **42424**; an explicit `host:port` overrides it, while
+   mDNS always uses the port in the resolved service record.
 2. **Trust never derives from reachability.** Identity is the pinned key and
    the session is mutually authenticated E2E, so a shared or hostile overlay
    network adds no risk and no trusted party.

--- a/docs/FLOW-DESIGN.md
+++ b/docs/FLOW-DESIGN.md
@@ -1,0 +1,499 @@
+# Flow — cross-machine device handoff (design)
+
+Status: **proposal** — nothing here is implemented yet. This document records
+the intended architecture, the protocol decisions and their rationale, and the
+prior-art research they rest on, so implementation can start from settled
+ground. Once milestones land, durable decisions graduate into
+[DECISIONS.md](DECISIONS.md).
+
+The peer protocol itself is specified normatively in
+[FLOW-PROTOCOL.md](FLOW-PROTOCOL.md) (framing, stream binding, state
+machines, evolution rules) with the message schema in
+[flow.v1.proto](flow.v1.proto); both move into `crates/openlogi-flow` when it
+exists.
+
+## What Flow is
+
+Logitech Flow (a Logi Options+ feature) lets one mouse and keyboard roam
+between up to three computers: move the cursor to the edge of one screen and
+the devices hop to the next machine, with clipboard contents following. The
+mechanism is **not** input forwarding over the network (Synergy/Deskflow/
+lan-mouse style). The device itself is paired to each machine on a separate
+Easy-Switch channel; the software merely commands the device to switch
+channels (HID++ `ChangeHost`, feature `0x1814`) and uses the network only for
+coordination and clipboard transfer. That distinction is the product:
+
+- input never crosses the network — no keystroke sniffing surface, no added
+  input latency;
+- devices keep working on whatever host they are switched to even when the
+  other machines are off;
+- the radio link (receiver or Bluetooth) does what it already does; software
+  only chooses *which* link is live.
+
+OpenLogi Flow is the same model, between machines running OpenLogi.
+
+### Goals
+
+- Edge-of-screen handoff of a mouse (and linked keyboard) between two or three
+  machines running OpenLogi, across macOS / Windows / Linux.
+- Peer discovery, pairing, and transport that are LAN-only, encrypted, and
+  mutually authenticated — no account, no cloud, no telemetry, consistent with
+  the rest of OpenLogi.
+- Clipboard sync (text first, files later) over the same peer link.
+- Keyboard-follows-mouse via the existing host-switch link machinery.
+
+### Non-goals
+
+- **Interoperability with Logi Options+ Flow.** See
+  [Options+ protocol compatibility](#options-protocol-compatibility) — the
+  protocol is undocumented, encrypted, partly cloud-dependent, and a moving
+  target. Both machines must run OpenLogi.
+- Input forwarding to machines that have no channel paired (that is a software
+  KVM, a different product).
+- Rendezvous or relay infrastructure of any kind, vendor or self-hosted.
+  Options+ uploads node info to `datapipeline.logitech.io` ("NodeStore") as a
+  discovery assist; OpenLogi will never phone a vendor endpoint, and it also
+  does not ship its own server. Machines that cannot see each other's
+  broadcasts are connected by the user's own network — see
+  [Non-LAN connectivity](#non-lan-connectivity-bring-your-own-network).
+
+## Prior art
+
+Research summary; links are the sources this design leans on.
+
+**Official Logitech material.** The
+[Options+ Flow port documentation](https://support.logi.com/hc/articles/17498487100055-Flow-for-Logi-Options-Port-Information)
+shows the network footprint: fixed UDP 59870 subnet broadcast for discovery, a
+TCP presence port (default 59869) advertised inside discovery messages, UDP
+59871 for the NodeStore cloud-assisted path (legacy Options used TCP 59866,
+UDP 59867/59868). The
+[official FAQ](https://support.logi.com/hc/en-us/articles/1500005634742)
+confirms: same-subnet UDP broadcast reachability is a hard requirement, up to
+three computers (= Easy-Switch channel count), and a "hold Ctrl to cross"
+option guards against accidental edge crossings (worth copying as a setting).
+
+**Solaar** ([issue #672](https://github.com/pwr-Solaar/Solaar/issues/672)):
+the community has never reverse-engineered Flow's network protocol ("the
+communications protocol that is used is unknown"). The issue also articulates
+the channel-switch-vs-input-forwarding distinction above.
+
+**[logitech-flow-kvm](https://github.com/coddingtonbear/logitech-flow-kvm)**
+(Python, Linux) is the closest working third-party Flow. Its key insight is
+the **positive-evidence model for "where did the device land"**: a device
+*disconnect* only proves departure; the machine that receives the device's
+*connect* notification (HID++ 1.0 connection notification, sub-ID `0x41`,
+link-status bit) has positive evidence of arrival, and that machine reports
+the authoritative new host. Followers are moved with `0x1814` fn `0x10`,
+written without awaiting a reply (the device leaves before it could answer) —
+matching our existing `ChangeHostFeature::set_current_host`. Its weaknesses
+(central server topology, no discovery, non-cryptographic pairing-code RNG,
+one-way trust, text-only clipboard) are things this design deliberately does
+differently.
+
+**[lan-mouse](https://github.com/feschber/lan-mouse)** (Rust) is an input
+forwarder — a different model — but the best reference for the platform layer:
+
+- macOS edge detection via `CGEventTap` + display bounds, clamping the cursor
+  1 px inside the edge on crossing. Known flaw to avoid: it tests against the
+  *union bounding rectangle* of all displays, so irregular monitor
+  arrangements misdetect; per-display exposed-edge segments are the correct
+  geometry from day one (its own Windows backend already does this).
+- Wayland edge detection is possible and shipped, two ways: wlroots
+  layer-shell 1 px edge surfaces + pointer constraints, or the freedesktop
+  InputCapture portal + libei. Wayland is therefore a later milestone, not a
+  permanent exclusion.
+- Its DTLS trust is one-way (the outbound side sets `insecure_skip_verify`) —
+  a concrete cautionary example; our transport must authenticate both
+  directions.
+- Its `Enter` message carries only a four-way side, no coordinate, so entry
+  position is not preserved across machines. Our handoff message carries the
+  normalized entry point.
+
+**Local Easy-Switch synchronizers**
+([LogiKMSwitch](https://github.com/Larry57/LogiKMSwitch),
+[Lunaar](https://github.com/NSHenry/Lunaar)) prove the observe-one-device,
+switch-the-others pattern that OpenLogi's existing host-switch link already
+implements.
+
+**[Options+ agent IPC reverse engineering](https://github.com/saimanish1/logitech-ipc-protocol/blob/master/logi-options-ipc-reverse-engineering.md)**:
+Options+ internally drives `ChangeHost` through its agent over a protobuf IPC
+(`logi.protocol.devices.ChangeHost`), and macOS kernel policy blocks raw HID
+access to Bluetooth input devices for everyone — confirming that Bluetooth
+device switching must be executed by the resident agent, which OpenLogi's
+architecture already guarantees (the agent owns all device I/O).
+
+## Building blocks already in the tree
+
+| Piece | Where | State |
+|---|---|---|
+| `ChangeHost` (`0x1814`), fire-and-forget `set_current_host` | `crates/openlogi-hidpp/src/feature/change_host.rs` | done |
+| `HostsInfo` (`0x1815`) host slots/names | `crates/openlogi-hidpp/src/feature/hosts_info.rs` | done |
+| Keyboard→pointer host-switch links (keyboard-follow) | `crates/openlogi-device/src/session/host_switch.rs`, `crates/openlogi-agent-core/src/watchers/host_switch.rs` | done |
+| Global cursor position + mouse event stream | `crates/openlogi-hook` | done |
+| Cursor/synthesis injection (entry-point warp) | `crates/openlogi-inject` | done |
+| Versioned local IPC with observation cells | `crates/openlogi-ipc`, `crates/openlogi-agent-core/src/observable.rs` | done |
+
+What is missing is the network layer and the orchestration on top.
+
+## Architecture
+
+Two machines, each running the standard OpenLogi agent. The GUI stays a pure
+IPC client; nothing about the three-process model changes.
+
+```
+┌────────────── machine A ──────────────┐      ┌────────────── machine B ─────────────┐
+│ hook: cursor hits configured edge     │      │                                      │
+│   ↓                                   │ LAN  │                                      │
+│ flow orchestrator ──"handoff(entry)"──┼─────▶│ flow orchestrator                    │
+│   ↓                                   │(QUIC)│   ↓ awaits 0x41 connect notification │
+│ ChangeHost.set_current_host(B's slot) │      │   ↓ inject: warp cursor to entry pt  │
+│ (device departs A; A is now blind)    │      │   ↓ confirms ──▶ A (timeout ⇒ abort) │
+└───────────────────────────────────────┘      └──────────────────────────────────────┘
+```
+
+| Component | Crate | Responsibility |
+|---|---|---|
+| Peer networking | `openlogi-flow` (new) | Discovery, pairing, encrypted transport, peer message protocol. Pure network — knows no HID, no hook. |
+| Flow orchestration | `openlogi-agent-core/src/flow/` (new) | Edge detection, device↔channel mapping, the handoff state machine, keyboard-follow linkage. Bridges `openlogi-flow` to device I/O and the hook. |
+| Config | `openlogi-core` | `[flow]` TOML section: enabled, peer trust store reference, edge layout. |
+| IPC surface | `openlogi-ipc` | Appended RPCs + snapshot fields for status, pairing, layout (see [IPC integration](#ipc-integration)). |
+| GUI | `openlogi-desktop` | Settings page: discovered peers, pairing confirmation, screen-arrangement editor. |
+
+`openlogi-flow` and `openlogi-ipc` must not depend on each other; all
+conversion happens in `openlogi-agent-core`. The GUI never speaks the peer
+protocol.
+
+### Device↔channel mapping
+
+Both machines see the same physical device (matched by serial / unit id) on
+different Easy-Switch channels. During setup each peer reports, for every
+shared device, the channel index the device uses to reach *it* (its own
+`current_host` reading while it holds the device, cross-checked against
+`HostsInfo`). The mapping `{device, peer} → channel` is exchanged over the
+peer link and stored in config. Handoff then means: look up the target peer's
+channel for each device being moved and write it with `set_current_host`.
+
+### Handoff ordering and confirmation
+
+One ordering law governs everything: **once `set_current_host` takes effect,
+this machine's HID++ channel to the device is gone.** (The same law is already
+documented in `session/host_switch.rs` for keyboard-initiated switches.)
+Therefore:
+
+1. Sender detects edge crossing, sends `Handoff { device_set, entry_edge,
+   normalized_entry_point }` to the target peer, and only *after* that message
+   is on the wire issues `set_current_host` for the pointer (keyboard follows
+   via the existing link machinery).
+2. Receiver arms a watch for the devices' arrival. Arrival is detected by the
+   **positive-evidence signal**: the receiver-side HID++ connection
+   notification (`0x41`, link established) or the transport-level equivalent
+   for Bluetooth/direct devices — not by assuming the switch worked.
+3. On arrival, the receiver warps the cursor to the entry point
+   (`openlogi-inject`) and sends `HandoffComplete`.
+4. If the sender gets no `HandoffComplete` within the deadline it surfaces a
+   diagnostic; recovery paths are the device's own enhanced-host-switch
+   fallback cookie (`0x1814` capability bit), the user pressing an Easy-Switch
+   key, or the receiving side commanding the device back.
+
+An anti-accident option ("hold Ctrl to cross", mirroring Options+) gates step
+1 in config.
+
+## Peer protocol
+
+### Why not the local IPC stack
+
+The local agent↔GUI IPC (tarpc + positional bincode, strict version equality,
+golden byte tests) is correct **because** GUI, agent, and overlay ship
+atomically in one bundle — a version mismatch is transient by construction, so
+"strict equal or refuse" is the whole contract. None of that holds across two
+machines: version skew is the *normal* state. The peer protocol therefore
+shares neither the encoding, nor the version philosophy, nor any serde types
+with `openlogi-ipc`/`openlogi-core`. Duplicating a few field definitions is
+cheaper than turning every innocent core-type edit into a cross-machine
+compatibility hazard that no golden test covers.
+
+### Transport: QUIC (`quinn` + `rustls`), pinned-key identity
+
+- One long-lived QUIC connection per peer pair. Multiplexed streams mean the
+  latency-critical handoff exchange never queues behind a clipboard/file
+  transfer (no head-of-line blocking); connection migration and fast resume
+  cover the daily realities of laptops (sleep/wake, Wi-Fi roam, IP change).
+- Identity is a persistent per-machine Ed25519 key. TLS uses self-signed
+  certificates carrying that key; a custom `rustls` verifier accepts exactly
+  the pinned peer keys from the trust store, **in both directions** (mutual
+  authentication — lan-mouse's one-way trust is the counterexample).
+- Pairing: peers exchange keys over the first (unauthenticated) connection and
+  the user confirms a short code derived from both keys on both screens; on
+  confirmation each side persists the other's key. The code authorizes the
+  pinning, it is not key material.
+- Discovery: mDNS (`mdns-sd` crate — pure Rust, no Avahi/Bonjour daemon
+  dependency), service `_openlogi-flow._udp.local`, TXT records carrying
+  instance id and supported protocol range so incompatible peers are filtered
+  before any connection attempt. Internally, discovery is a *list of candidate
+  sources* (mDNS and manually configured addresses, tried concurrently), each
+  yielding candidate addresses for a peer key; the session layer authenticates
+  whoever answers. Addresses are hints, never identity — which is also what
+  makes user-provided overlay networks work (see
+  [Non-LAN connectivity](#non-lan-connectivity-bring-your-own-network)).
+- The alternative considered and kept as fallback: TCP + Noise (`snow`).
+  Smaller dependency footprint, but hand-rolled framing/rekey/replay
+  protection, a second connection to avoid HOL blocking, and no migration.
+  Migration between the two later touches only `openlogi-flow` internals.
+
+### Encoding: protobuf (`buffa`)
+
+Cross-machine messages must survive version skew. Candidates weighed:
+
+| Option | Evolution story | Verdict |
+|---|---|---|
+| protobuf ([`buffa`](https://github.com/anthropics/buffa)) | field tags, unknown fields preserved, `optional` semantics, open enums | **chosen** — the `.proto` file doubles as the protocol document |
+| protobuf (`prost`) | same wire format; enum fields are `i32` with accessors that silently fold unknown values to the default | runner-up — see below |
+| serde + CBOR (named fields) | self-describing, but renames break silently; discipline lives in review, not tooling | viable fallback |
+| positional bincode across machines | append-only + send-gating done entirely by hand; every mistake is silent byte-level corruption | rejected — it works locally only because skew cannot happen there |
+| Cap'n Proto / FlatBuffers | good evolution, rough Rust ergonomics | overkill for this message volume |
+| gRPC (`tonic`) | protobuf's evolution, but drags in HTTP/2 alongside QUIC | protobuf without gRPC |
+
+Within protobuf, `buffa` over `prost`, for fit against rules this design has
+already committed to:
+
+- **Open enums.** FLOW-PROTOCOL.md's evolution rule #3 requires an unknown or
+  `UNSPECIFIED` enum value to surface as an error, never a silent default.
+  buffa's `EnumValue<T>` (Known/Unknown) makes the violating code
+  unwritable; prost's generated accessors fold unknown values into the
+  default, so the same rule would live in review discipline instead of the
+  type system — the exact trade that favored protobuf over CBOR in the
+  first place.
+- **Unknown-field preservation** by default, and zero-copy `MessageView<'a>`
+  decode for `Chunk` frames. Nice, not decisive.
+- Same codegen shape (`buffa-build` + `protoc` on PATH, like `prost-build`),
+  and it deliberately ships no schema-less `#[derive(Message)]` — the
+  `.proto` file stays the only contract, which is this design's stance.
+- The accepted risk: buffa is pre-1.0 (breaking changes on minor versions)
+  and young (2026), versus prost's decade of production use. The wire format
+  is standard protobuf either way, so the codec is swappable: churn or a
+  forced migration is contained inside `openlogi-flow`'s generated-code
+  layer, and the crate pins `buffa = "0.x"` to a minor version.
+
+`buffa`/`buffa-build` will be the workspace's first codegen dependency; this
+section is the deliberate justification the root AGENTS.md asks for.
+(Options+ itself speaks protobuf internally — see prior art — which is
+corroborating, not binding.)
+
+### Version negotiation
+
+Three layers, the outer ones frozen forever (normative details:
+[FLOW-PROTOCOL.md](FLOW-PROTOCOL.md); message schema:
+[flow.v1.proto](flow.v1.proto)):
+
+```
+┌─ layer 0: envelope (frozen; any version can decode) ─────────────┐
+│ Frame { kind: u16, flags: u16 = 0, len: u32, payload: bytes }    │
+│ → unknown kind: skip len bytes; decode failure never desyncs     │
+├─ layer 1: Hello (kind = 0x0001, encoding frozen) ────────────────┤
+│ Hello { proto_min, proto_max, public_key, session_nonce,         │
+│         machine_name, platform, app_version, capabilities }      │
+├─ layer 2: negotiated messages ───────────────────────────────────┤
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- Both sides send `Hello`; `agreed = min(max_A, max_B)`. If
+  `agreed < max(min_A, min_B)`, reply `HelloReject { reason }` and disconnect;
+  the GUI names which side is stale.
+- **Decode compatibility comes from append-only message evolution** (protobuf
+  tags absorb the field-level cases). **Send compatibility comes from
+  gating**: knowing the peer speaks version N, never send message kinds or
+  semantics introduced after N. Gating is the discipline the local IPC never
+  needed (strict equality made it moot) and the one that must be enforced in
+  review here.
+- `capabilities` is an open list (repeated enum, not a u64 bitset — no
+  64-feature ceiling to patch around later) carrying orthogonal optional
+  features (clipboard, file transfer, …) so an optional module never forces
+  a version bump across the fleet.
+- `proto_min` is raised only as an explicit product decision to drop old
+  versions, never casually.
+
+Two frozen invariants, restated as evolution rule #1 in FLOW-PROTOCOL.md: the
+envelope layout, and `Hello`'s encoding — the same principle that keeps
+`protocol_version` as method 0 of the local IPC forever. (`Hello` is kind
+0x0001, not 0, so an all-zero header is invalid rather than a valid frame.)
+
+### RPC shape: QUIC-native, no framework
+
+Half of Flow's traffic is request/response (pairing steps, mapping exchange,
+handoff-with-ack, clipboard fetch). QUIC provides the RPC primitive directly —
+**one bidirectional stream per request**: open, write request, read response,
+close. Correlation (the stream), cancellation (stream reset), and concurrency
+(independent streams) come free. Fire-and-forget state notices ride
+unidirectional streams; heartbeats ride datagrams; bulk clipboard/file data
+gets its own streams. `openlogi-flow` needs a thin `call<Req, Resp>()` helper,
+not an RPC framework. tarpc specifically is not reused here: its generated
+request enum hides message layout inside a macro, while the peer contract
+must be explicit (the `.proto` file) to keep the gating discipline auditable,
+and its deadline/cancellation semantics assume a reliable local transport.
+
+### Non-LAN connectivity: bring your own network
+
+First, the use case, precisely: Flow's physical precondition is that the
+device's radio reaches every participating machine, so the machines are
+always within a few meters of each other. "Not on the same LAN" therefore
+never means "in different places" — it means **same desk, segregated
+networks**: a work laptop force-tunneled through a corporate VPN, a personal
+desktop on home Wi-Fi, a machine on a guest VLAN or a 5G hotspot. Broadcast
+and mDNS are dead across those boundaries (Logitech's own FAQ tells users to
+involve their network admin), while the mouse hops between the machines just
+fine. Genuinely remote machines are out of reach of the device and therefore
+out of scope: that product is remote control / software KVM, a non-goal
+above.
+
+The stance: OpenLogi does not build or ship rendezvous/relay infrastructure
+for this. The same philosophy that makes config sync the user's business
+(plain TOML, sync it with whatever you already use) applies to connectivity:
+**users who need cross-segment reach bring their own network** — WireGuard,
+Tailscale/Headscale, ZeroTier, or any routed path. Flow's obligation is only
+to *work over such networks*, which reduces to four requirements binding from
+milestone 2 onward:
+
+1. **Manual peer addresses are first-class config**, not a debug fallback: a
+   peer may list hostnames or IPs, resolved through the OS resolver so
+   `/etc/hosts`, ordinary DNS, and overlay magic-DNS names all work
+   (lan-mouse precedent). mDNS is an optimization for the flat-LAN case,
+   never a requirement for a link to form.
+2. **Trust never derives from reachability.** Identity is the pinned key and
+   the session is mutually authenticated E2E, so a shared or hostile overlay
+   network adds no risk and no trusted party.
+3. **The protocol stays path-agnostic**, and the transport must tolerate
+   overlay realities: clamped MTUs (WireGuard 1420, Tailscale 1280 — keep
+   quinn's conservative initial MTU / path-MTU discovery defaults) and NAT
+   bindings that need keepalives.
+4. **Pairing works over any reachable path.** The confirmation-code ceremony
+   carries the trust, not network locality, so there is nothing special about
+   pairing across an overlay.
+
+Peer/layout config is deliberately syncable by the user (it contains only
+public keys and names); the machine's own private key is per-machine state
+stored outside `config.toml` and must never travel with a config sync.
+
+Should real demand for a built-in rendezvous/relay ever materialize anyway,
+Syncthing is the proven template (key-derived device IDs, self-hostable
+`stdiscosrv` discovery and untrusted `strelaysrv` relays, direct →
+hole-punched → relayed degradation), with `iroh` as an off-the-shelf
+alternative — but BYON is the default answer, and it ships first by shipping
+nothing.
+
+## IPC integration
+
+Everything Flow needs from the local IPC is ordinary appending under the
+existing rules (`.claude/rules/ipc-protocol.md`): bump `PROTOCOL_VERSION`,
+append methods/fields, regenerate the golden tests.
+
+- RPCs: manual `switch_host(route, host)` (also the milestone-1 deliverable),
+  flow enable/disable, pairing confirm/reject, layout set.
+- State: a `flow` field appended to `AgentSnapshot` — enabled, peers with
+  **coarse** link state, pairing session as `FlowPairingPhase { Discovering,
+  ConfirmCode(..), Paired, Failed(..) }` following the `PairingPhase`
+  "state, not stream" precedent (agent-restart self-healing comes with it).
+- Churn rule: `Agent::observe` re-sends the whole snapshot on every generation
+  bump, so per-heartbeat facts (RTT, last-seen timestamps) must not live in
+  `AgentSnapshot`. Quantize link state to `Connected/Degraded/Lost`. If Flow
+  ever needs high-frequency observation, give it its own cell following the
+  `RingObservation` precedent (and extract the generic cell then, not before).
+
+## Edge detection
+
+Per-platform, in `openlogi-hook`'s existing cfg-gated style; the orchestrator
+consumes a platform-neutral "crossed edge E at normalized position p" event.
+
+- Geometry is **per-display exposed-edge segments**, never the union bounding
+  rectangle of all displays (lan-mouse's macOS flaw). Edges adjacent to
+  another local display are not handoff edges.
+- macOS: cursor stream from the existing `CGEventTap` + display bounds via CG
+  APIs; display-reconfiguration callbacks refresh the geometry.
+- Windows: `WH_MOUSE_LL` positions + per-monitor rectangles.
+- Linux X11: cursor position polling/XInput + XRandR geometry.
+- Linux Wayland: no global cursor, but two proven routes exist (wlroots
+  layer-shell 1 px edge surfaces + pointer constraints; InputCapture portal +
+  libei) — deferred to its own milestone, not excluded.
+
+## Config sketch
+
+```toml
+[flow]
+enabled = true
+# require Ctrl held while crossing an edge (accident guard, mirrors Options+)
+require_modifier = false
+
+[[flow.peers]]
+name = "work-laptop"
+public_key = "ed25519:…"          # pinned at pairing time
+# optional; needed when mDNS cannot reach the peer (VPN/VLAN/overlay).
+# Hostnames go through the OS resolver, so overlay magic-DNS names work.
+addresses = ["work-laptop.tailnet.example", "10.0.0.7"]
+
+[[flow.layout]]
+edge = "right"                     # this machine's right edge
+peer = "work-laptop"
+
+[[flow.devices]]
+key = "unit:0f1e2d3c"              # existing device identity key
+peer_channels = { self = 0, "work-laptop" = 1 }
+```
+
+Exact shapes to be settled against `openlogi-core`'s config conventions when
+milestone 2 lands.
+
+## Milestones (demo-first)
+
+1. **Software-initiated host switch.** IPC `switch_host(route, host)` + a CLI
+   diag command, reusing `ChangeHostFeature`. Proof: command the device away,
+   Easy-Switch it back. Device-side only, no network.
+2. **Peer link.** `openlogi-flow`: discovery, pairing (code confirmation),
+   encrypted session, Hello negotiation, device-mapping exchange. Proof:
+   `openlogi flow peers` lists the other machine with a verified identity.
+3. **Edge handoff, macOS first.** Edge detect → `Handoff` → switch → arrival
+   evidence → cursor warp → `HandoffComplete`, with the timeout diagnostics.
+   First end-to-end Flow demo.
+4. **Keyboard follow + GUI.** Reuse the host-switch link machinery; settings
+   page, layout editor, pairing UI.
+5. **Clipboard sync.** Text first; files later over dedicated streams
+   (capability-gated, no version bump).
+6. **Windows / Linux-X11 edge detection**, then **Wayland** via layer-shell or
+   InputCapture portal.
+
+## Options+ protocol compatibility
+
+Considered and **rejected** as a goal, for now:
+
+- **Nothing to build against.** The protocol has never been publicly
+  documented or reverse-engineered (Solaar #672); it is encrypted, and the
+  discovery path is partly cloud-assisted (NodeStore). Interop would begin
+  with a from-scratch RE effort of TLS-wrapped traffic between signed
+  binaries.
+- **A moving target with no contract.** Logitech can and does change the
+  protocol with any Options+ release; an interop layer would break silently
+  and repeatedly, and each breakage restarts the RE work.
+- **Legal and positioning risk.** RE of an encrypted proprietary protocol for
+  a shipping competitor-adjacent product is a different legal posture than
+  implementing published HID++ specs (which is what the rest of OpenLogi
+  does). It also drags OpenLogi toward Logitech's cloud endpoints, against the
+  no-account/no-telemetry stance.
+- **The payoff is thin.** The only won scenario is a mixed fleet (OpenLogi on
+  one machine, Options+ on another). The hardware-level story already works
+  there: the device is just paired to both machines, Easy-Switch keys and
+  OpenLogi's own host switching keep functioning. Only the automatic
+  edge-crossing handshake is lost, and installing OpenLogi on the second
+  machine restores it.
+
+Revisit only if the protocol is ever publicly documented or a maintained
+third-party implementation appears; the decision then still weighs the
+moving-target and positioning costs, not just feasibility.
+
+## Open questions
+
+- Bluetooth-direct devices: the arrival signal equivalent to the receiver's
+  `0x41` notification needs verification per transport during milestone 3.
+- Three-machine topologies: full mesh of pairwise links, or transitive trust?
+  (Leaning full mesh; pairwise pairing is three codes at worst.)
+- Clipboard formats beyond text (images, file lists) and their per-OS
+  representations — deliberately deferred to milestone 5.
+- Where the per-machine private key lives on each OS (keychain/keyring vs a
+  mode-0600 file beside the config) — decided in milestone 2.

--- a/docs/FLOW-PROTOCOL.md
+++ b/docs/FLOW-PROTOCOL.md
@@ -1,0 +1,255 @@
+# Flow peer protocol v1 — wire specification
+
+Companion to [FLOW-DESIGN.md](FLOW-DESIGN.md), which records *why* this
+protocol looks the way it does (transport choice, encoding choice, BYON,
+no-relay). This document is the *what*: the normative contract two OpenLogi
+agents implement. The authoritative message schema is
+[flow.v1.proto](flow.v1.proto); this file defines everything protobuf cannot
+express — framing, stream binding, state machines, canonical byte forms,
+timeouts, and the evolution rules.
+
+Both files move verbatim into `crates/openlogi-flow` when that crate lands
+(proto under `proto/`, this spec as the crate-level docs). Until then, edits
+to either are reviewed against the evolution rules at the bottom.
+
+## Transport binding
+
+- **QUIC** via `quinn` + `rustls`, mutual authentication with pinned Ed25519
+  keys (design doc §Transport). ALPN: **`olf/1`**. The ALPN versions the
+  *envelope*, not the message set — it changes only if the frame layout
+  itself ever has to change, which the design intends never to happen.
+- One connection per peer pair. Either side may initiate; if two connections
+  race (simultaneous dial), the side with the lexicographically smaller
+  public key closes its *outgoing* connection and keeps the incoming one.
+- **Control stream**: the connection initiator opens one bidirectional
+  stream immediately; each side writes exactly one `Hello` frame and reads
+  the peer's. This stream carries nothing else and stays open for the
+  connection's lifetime (its closure is equivalent to connection close).
+- **RPC**: one bidirectional stream per request — open, write one request
+  frame, read one response, close. The stream is the correlation and the
+  cancellation token (reset = cancelled). Responses are the request's paired
+  response kind or `Error`.
+- **Notifications**: one unidirectional stream per notification, one frame,
+  FIN. QUIC makes short streams cheap; one-shot streams avoid inventing an
+  ordering relationship between unrelated notices.
+- **Bulk data**: rides the same bidirectional stream as the fetch that asked
+  for it (`ClipboardData` head, `Chunk`*, `ChunkEnd`).
+- **Datagrams**: `Ping`/`Pong` only (RTT + application liveness; QUIC
+  keepalive only proves the transport). Datagram loss is acceptable by
+  definition; anything that must arrive rides a stream.
+
+| Frame family | Carried on |
+|---|---|
+| `Hello`, `HelloReject` | control stream |
+| `PairStart→Prompted`, `PairConfirm→Outcome`, `GetPeerInfo→PeerInfo`, `HandoffRequest→Accept/Reject`, `ClipboardFetch`/`FileFetch`→`ClipboardData`+`Chunk`*+`ChunkEnd` | one bi-stream per request |
+| `PairAbort`, `AnnounceDevices`, `PeerState`, `HandoffResult`, `HandoffCancel`, `ClipboardAnnounce` | one uni-stream each |
+| `Ping`, `Pong` | datagrams |
+| `Error` | response position on any bi-stream |
+
+## Framing
+
+Every stream payload and datagram is a sequence of frames:
+
+```
+┌──────────┬───────────┬──────────┬─────────────────┐
+│ kind u16 │ flags u16 │ len u32  │ payload (len B) │
+│   LE     │ LE, =0    │   LE     │ protobuf bytes  │
+└──────────┴───────────┴──────────┴─────────────────┘
+```
+
+- `kind`: a `FrameKind` value. The all-zero header is invalid by
+  construction (`Hello` is 0x0001), so a zeroed buffer can never parse as a
+  meaningful frame.
+- `flags`: reserved, must be sent as 0. A receiver seeing unknown flag bits
+  must not guess: drop the frame if it is a notification, answer
+  `Error UNSUPPORTED_FLAGS` if it is a request. (Future use: e.g. payload
+  compression — a capability would gate *sending* it, the flag would mark
+  the frame.)
+- `len`: payload byte length. Caps: **1 MiB** general, **64 KiB** for
+  `Chunk`. Oversized: close the offending stream, answer
+  `Error TOO_LARGE` where a response is expected. The caps bound memory per
+  frame; bulk payloads of any size are sequences of capped chunks.
+- Unknown `kind`: on a uni-stream, skip `len` bytes and ignore (this is what
+  makes new notifications backward-deployable); as a request on a bi-stream,
+  answer `Error UNSUPPORTED_KIND`. Decode never desyncs: the envelope always
+  says how much to skip.
+- Payloads are protobuf (`openlogi.flow.v1`); a payload that fails to decode
+  as its kind's message is `Error INVALID` / frame-drop by the same
+  notification-vs-request rule.
+
+## Connection lifecycle & negotiation
+
+```
+dial ──► TLS (pinned-key verifier) ──► Hello exchange ──► trusted session
+                    │                        │
+                    │ unknown key            │ version disjoint / key mismatch
+                    ▼                        ▼
+             untrusted session          HelloReject + close
+             (pairing family only)
+```
+
+1. TLS: the verifier accepts a pinned peer key → session starts *trusted*;
+   accepts an unknown key only while pairing mode is active → session starts
+   *untrusted*.
+2. Both sides send `Hello`. `agreed = min(proto_max_A, proto_max_B)`; if
+   `agreed < max(proto_min_A, proto_min_B)` → `HelloReject VERSION_DISJOINT`
+   and close (the GUI names which side is stale). `Hello.public_key` must
+   equal the TLS identity → else `HelloReject KEY_MISMATCH`.
+3. On an **untrusted** session, only link-family and pairing-family frames
+   are legal; anything else is answered `Error NOT_PAIRED` and ignored.
+4. On becoming trusted (pinned key, or pairing just completed): each side
+   sends `AnnounceDevices` and `PeerState` unsolicited. Reconnect repeats
+   them — every state notification is the *whole* current state with a
+   revision, so a lost notice heals on the next.
+
+Send-gating: after `Hello`, a peer never sends a frame kind, field, or
+semantic introduced later than `agreed`, and never sends a
+capability-gated family the peer did not list. Decode tolerance (unknown
+kinds/fields skipped) is the safety net, gating is the contract.
+
+## Pairing
+
+Trust ceremony (design doc §Transport chose pinned keys; this is how pins
+are created). Runs on an untrusted session:
+
+```
+A                                   B
+│ ──── PairStart ────────────────► │  B shows prompt: name, code, fingerprint
+│ ◄─── PairPrompted{timeout} ───── │  A shows its prompt
+│        (users compare the 6-digit code on both screens)
+│ ──── PairConfirm ──────────────► │
+│ ◄─── PairOutcome{PENDING_LOCAL} ─│  (B's user hasn't confirmed yet)
+│ ◄─── PairConfirm ─────────────── │  (B confirms; roles are symmetric)
+│ ──── PairOutcome{PAIRED} ──────► │  both persist the peer key; session
+│                                  │  becomes trusted in place
+```
+
+- Completion condition: a side considers pairing complete when it has both
+  **sent and received** a `PairConfirm`; it persists the peer's key and
+  answers/expects `PairOutcome{PAIRED}`.
+- **Code derivation (SAS)**: both sides compute
+  `HKDF-SHA256(ikm = min(pkA,pkB) ‖ max(pkA,pkB), salt = min(nA,nB) ‖ max(nA,nB), info = "openlogi-flow-sas-v1")`,
+  take the first 4 output bytes as a big-endian integer, `mod 1_000_000`,
+  render as 6 digits. `pk` = the 32-byte Ed25519 keys, `n` = the 16-byte
+  `session_nonce`s from the two `Hello`s; `min`/`max` byte-lexicographic. A
+  man-in-the-middle necessarily terminates two distinct sessions and shows
+  two different codes — the human comparison is the authentication.
+- Abort paths: `PairAbort{USER_CANCELLED | CODE_MISMATCH}` from either side;
+  `PairOutcome{TIMEOUT}` after `PairPrompted.timeout_ms` (default 120 s);
+  `PairOutcome{REJECTED}` if a user declines. All abort paths discard the
+  session nonces; retry starts a fresh connection with fresh nonces.
+
+## Device identity
+
+Two `DeviceIdentity` values denote the same physical device iff their
+`ids` sets intersect on any entry (kind + canonical bytes equal). Canonical
+byte forms:
+
+| `IdentifierKind` | canonical `value` |
+|---|---|
+| `SERIAL` | the serial string's UTF-8 bytes, no padding/case folding |
+| `UNIT_ID` | HID++ 0x0003 unitId, 4 bytes big-endian |
+| `BLUETOOTH_ADDRESS` | 6 bytes, transmission order (MSB first) |
+
+A peer announces every identifier it can obtain for a device; correlation
+strengthens as transports contribute more identifiers. Bluetooth-direct
+devices may expose only `UNIT_ID` + `BLUETOOTH_ADDRESS`; receiver-paired
+devices typically expose `SERIAL` + `UNIT_ID`. `name`, `category`, `models`
+are presentation/diagnostics and never correlate.
+
+## Handoff
+
+State machine, sender view (receiver mirrors it):
+
+```
+IDLE ──edge trigger──► REQUESTED ──Accept──► SWITCHING ──0x41 at receiver──► DONE
+                          │                     │    ▲
+                          │ Reject/timeout      │    │ HandoffResult
+                          ▼                     │    │ (uni, by transfer_id)
+                        IDLE ◄── set_current_host failed:
+                                 send HandoffCancel{SWITCH_FAILED}
+```
+
+- The sender **never** issues `set_current_host` before `HandoffAccept`.
+  After issuing it the sender is blind to the device (the radio has left);
+  everything after that point is the receiver's to report.
+- The receiver arms an arrival watch on `Accept` (HID++ 1.0 connection
+  notification sub-ID 0x41, or the equivalent arrival evidence for
+  Bluetooth-direct — open question in the design doc) and reports
+  `HandoffResult` per device: `ARRIVED`, `PARTIAL`, `TIMEOUT`.
+- `transfer_id` is random per attempt and is the idempotency key: a
+  duplicate `HandoffRequest` (sender retry after a lost response) is
+  answered from the existing transfer's state, never double-armed.
+  `ALREADY_PENDING` rejects a *different* transfer while one is armed.
+- Multiple devices (keyboard-follow) ride one request; per-device outcomes
+  come back in `HandoffResult.arrivals`. Partial arrival is reported, not
+  rolled back — the devices that moved are usable, the UI says what stalled.
+- Defaults: `arm_timeout_ms` 3000; sender give-up = accept's
+  `arm_timeout_ms` + 2000 of network slack. A sender that gives up late
+  simply logs a stale `HandoffResult`.
+- `EntryPoint.side` is pre-translated to the **receiver's** frame by the
+  sender's layout config; `t` is normalized 0..1 along the sender's exiting
+  edge; the receiver maps proportionally onto its own exposed edge segments
+  (per-display segments, not a union bounding rect) and clamps to the
+  nearest valid point.
+
+## Clipboard & files
+
+Lazy, pull-based: bytes move only on paste. Every target OS supports
+promised/delayed clipboard rendering (NSPasteboard promises, Windows delayed
+rendering, X11/Wayland are lazy by construction).
+
+- On local clipboard change: `ClipboardAnnounce{sequence, formats}` to every
+  connected trusted peer that listed `CLIPBOARD_TEXT`. `sequence` is a
+  monotonic per-peer generation; announces for stale sequences are ignored,
+  fetches quoting a superseded sequence are answered `Error INVALID`.
+- On paste at a peer: `ClipboardFetch{sequence, mime, offset}` →
+  `ClipboardData` + `Chunk`* + `ChunkEnd`. `offset` resumes an interrupted
+  transfer; `ChunkEnd.sha256` (when present) covers the assembled bytes from
+  the requested offset.
+- Files (`CLIPBOARD_FILES`): the announce lists mime
+  `application/x-openlogi-files`; its fetched payload decodes as `FileList`;
+  each file then streams via `FileFetch{sequence, file_index, offset}` with
+  the identical bulk shape. `relative_path` must be relative, `/`-separated,
+  free of `..` — the receiver rejects violations and places files under its
+  own download directory.
+
+## Robustness rules
+
+- **Revisions**: every state notification (`PeerInfo`, `AnnounceDevices`,
+  `PeerState`) carries a monotonic per-peer `revision`; receivers drop
+  anything older than what they have. Notifications are whole-state, never
+  deltas — loss heals on the next send, reconnect resends current state.
+- **Idempotency**: `transfer_id` dedupes handoffs; `sequence` versions
+  clipboard generations; pairing confirms are idempotent (re-received
+  `PairConfirm` re-answers current `PairOutcome`).
+- **Timeouts** are receiver-declared where one side waits on the other
+  (`PairPrompted.timeout_ms`, `HandoffAccept.arm_timeout_ms`) so the two
+  sides never disagree about who gave up first.
+- **Wall-clock time is diagnostics-only** (`sent_at_ms`, `modified_at_ms`);
+  no protocol decision compares clocks across machines. Durations are
+  relative milliseconds.
+- **Path-agnostic** (BYON): nothing above assumes LAN — no broadcast, no
+  MTU assumptions beyond QUIC's own, keepalive tolerant of high-RTT links,
+  addresses are hints and identity is only ever the pinned key.
+- Three-machine mesh: every exchange is strictly pairwise; `channel_to_me`
+  is relative to the announcing peer, so N peers form N·(N−1)/2 independent
+  sessions with no shared state.
+
+## Evolution rules (the contract)
+
+1. The envelope layout and the link family (kinds 0x0001–0x000F, `Hello`'s
+   existing fields foremost) are **frozen forever**. New ALPN only if the
+   envelope itself must change — intended never.
+2. protobuf field numbers are never reused or renumbered; removal is
+   `reserved N;`. `FrameKind` values are never reused; new kinds go at the
+   end of their family range, new families take a fresh 0x10-aligned range.
+3. Every enum keeps `*_UNSPECIFIED = 0`; receiving it (or an unknown value)
+   where a decision is required is `Error INVALID`, never a silent default.
+4. New frame kinds, fields with new *semantics*, and behavioral changes are
+   introduced under a version bump (send-gated on `agreed`) or under a
+   `Capability` (send-gated on the peer's list). Purely additive
+   informational fields may ride the existing version — old peers skip them.
+5. `proto_min` rises only as an explicit product decision, never casually.
+6. Every kind and field carries a `since:` note in the proto file from v2
+   onward; v1 is the baseline.

--- a/docs/FLOW-PROTOCOL.md
+++ b/docs/FLOW-PROTOCOL.md
@@ -4,13 +4,14 @@ Companion to [FLOW-DESIGN.md](FLOW-DESIGN.md), which records *why* this
 protocol looks the way it does (transport choice, encoding choice, BYON,
 no-relay). This document is the *what*: the normative contract two OpenLogi
 agents implement. The authoritative message schema is
-[flow.v1.proto](flow.v1.proto); this file defines everything protobuf cannot
-express — framing, stream binding, state machines, canonical byte forms,
-timeouts, and the evolution rules.
+[`flow.v1.proto`](../crates/openlogi-flow/proto/flow.v1.proto); this file
+defines everything protobuf cannot express — framing, stream binding, state
+machines, canonical byte forms, timeouts, and the evolution rules.
 
-Both files move verbatim into `crates/openlogi-flow` when that crate lands
-(proto under `proto/`, this spec as the crate-level docs). Until then, edits
-to either are reviewed against the evolution rules at the bottom.
+The schema lives under `crates/openlogi-flow/proto/` so code generation and
+the wire contract cannot drift apart. This normative specification remains in
+`docs/`; edits to either are reviewed against the evolution rules at the
+bottom.
 
 ## Transport binding
 

--- a/docs/flow.v1.proto
+++ b/docs/flow.v1.proto
@@ -1,0 +1,532 @@
+// OpenLogi Flow peer protocol, version 1.
+//
+// This file is the authoritative wire contract between two OpenLogi agents
+// (see FLOW-PROTOCOL.md for framing, stream binding, state machines, and the
+// evolution rules that bind every edit to this file). It lives in docs/ until
+// crates/openlogi-flow exists, then moves there verbatim.
+//
+// Ground rules (enforced in review, restated from FLOW-PROTOCOL.md):
+//   - Field numbers and FrameKind values are never reused or renumbered.
+//     Removal means `reserved`, never deletion.
+//   - Every enum has an UNSPECIFIED = 0 entry. Receiving UNSPECIFIED or an
+//     unknown value where a decision is required is an error, never a silent
+//     default (same rule as the HID++ crate).
+//   - New messages/fields are usable only after version or capability
+//     negotiation permits sending them (send-gating).
+//   - No type in this file is shared with openlogi-core / openlogi-ipc.
+//     Conversion happens in openlogi-agent-core.
+
+syntax = "proto3";
+
+package openlogi.flow.v1;
+
+// ---------------------------------------------------------------------------
+// Frame kinds
+// ---------------------------------------------------------------------------
+
+// Discriminator carried in the frame envelope (see FLOW-PROTOCOL.md §Framing).
+// Values are the wire u16. Ranges are partitioned by family; allocate new
+// kinds at the end of their family range.
+enum FrameKind {
+  FRAME_KIND_UNSPECIFIED = 0x0000;  // never sent; Hello is 0x0001 so that an
+                                    // all-zero header is invalid, not a Hello
+
+  // Link family, 0x0001-0x000F — frozen forever (pre-negotiation).
+  FRAME_KIND_HELLO = 0x0001;
+  FRAME_KIND_HELLO_REJECT = 0x0002;
+  FRAME_KIND_ERROR = 0x0003;
+  FRAME_KIND_PING = 0x0004;
+  FRAME_KIND_PONG = 0x0005;
+
+  // Pairing family, 0x0010-0x001F — allowed on untrusted sessions.
+  FRAME_KIND_PAIR_START = 0x0010;
+  FRAME_KIND_PAIR_PROMPTED = 0x0011;
+  FRAME_KIND_PAIR_CONFIRM = 0x0012;
+  FRAME_KIND_PAIR_OUTCOME = 0x0013;
+  FRAME_KIND_PAIR_ABORT = 0x0014;
+
+  // Peer info / state family, 0x0020-0x002F.
+  FRAME_KIND_GET_PEER_INFO = 0x0020;
+  FRAME_KIND_PEER_INFO = 0x0021;
+  FRAME_KIND_ANNOUNCE_DEVICES = 0x0022;
+  FRAME_KIND_PEER_STATE = 0x0023;
+
+  // Handoff family, 0x0030-0x003F.
+  FRAME_KIND_HANDOFF_REQUEST = 0x0030;
+  FRAME_KIND_HANDOFF_ACCEPT = 0x0031;
+  FRAME_KIND_HANDOFF_REJECT = 0x0032;
+  FRAME_KIND_HANDOFF_RESULT = 0x0033;
+  FRAME_KIND_HANDOFF_CANCEL = 0x0034;
+
+  // Clipboard family, 0x0040-0x004F — capability-gated.
+  FRAME_KIND_CLIPBOARD_ANNOUNCE = 0x0040;
+  FRAME_KIND_CLIPBOARD_FETCH = 0x0041;
+  FRAME_KIND_CLIPBOARD_DATA = 0x0042;
+  FRAME_KIND_CHUNK = 0x0043;
+  FRAME_KIND_CHUNK_END = 0x0044;
+  FRAME_KIND_FILE_FETCH = 0x0045;
+}
+
+// ---------------------------------------------------------------------------
+// Link family (frozen)
+// ---------------------------------------------------------------------------
+
+// First frame on the control stream, both directions. Its encoding is frozen:
+// existing fields never change meaning or number; new fields may be appended
+// (old peers ignore them by protobuf rules).
+message Hello {
+  // Inclusive range of protocol versions this peer speaks. Version 1 peers
+  // send [1, 1]. agreed = min(max_a, max_b); reject if agreed < max(min_a,
+  // min_b).
+  uint32 proto_min = 1;
+  uint32 proto_max = 2;
+
+  // Raw 32-byte Ed25519 public key. MUST match the key in the TLS
+  // certificate; mismatch closes the connection (Error INVALID).
+  bytes public_key = 3;
+
+  // 16 random bytes per connection, consumed by the pairing-code derivation
+  // (FLOW-PROTOCOL.md §Pairing). Fresh on every connection.
+  bytes session_nonce = 4;
+
+  // Presentation for pairing prompts and peer lists.
+  string machine_name = 5;
+  Platform platform = 6;
+
+  // Diagnostics only. Logic MUST NOT parse or branch on it; versioned
+  // behavior hangs off proto_min/max and capabilities exclusively.
+  string app_version = 7;
+
+  // Optional message families this peer implements (packed varints).
+  // Orthogonal to the protocol version: a capability never requires a
+  // version bump, a version bump never implies a capability.
+  repeated Capability capabilities = 8;
+}
+
+enum Platform {
+  PLATFORM_UNSPECIFIED = 0;
+  PLATFORM_MACOS = 1;
+  PLATFORM_WINDOWS = 2;
+  PLATFORM_LINUX_X11 = 3;
+  PLATFORM_LINUX_WAYLAND = 4;
+  PLATFORM_OTHER = 5;
+}
+
+enum Capability {
+  CAPABILITY_UNSPECIFIED = 0;
+  CAPABILITY_CLIPBOARD_TEXT = 1;
+  CAPABILITY_CLIPBOARD_FILES = 2;
+}
+
+message HelloReject {
+  RejectReason reason = 1;
+  // The rejecting side's own range, so the stale side can be named in UI.
+  uint32 proto_min = 2;
+  uint32 proto_max = 3;
+  string detail = 4;
+}
+
+enum RejectReason {
+  REJECT_REASON_UNSPECIFIED = 0;
+  REJECT_REASON_VERSION_DISJOINT = 1;
+  REJECT_REASON_KEY_MISMATCH = 2;   // Hello.public_key ≠ TLS identity
+  REJECT_REASON_MALFORMED = 3;
+}
+
+// Generic failure response. Valid as the response frame on any RPC stream;
+// the stream itself is the correlation, so no request id is needed.
+message Error {
+  ErrorCode code = 1;
+  string detail = 2;
+  // Whether retrying the same request later can succeed (BUSY yes,
+  // UNSUPPORTED_KIND no).
+  bool retryable = 3;
+}
+
+enum ErrorCode {
+  ERROR_CODE_UNSPECIFIED = 0;
+  ERROR_CODE_UNSUPPORTED_KIND = 1;   // unknown FrameKind in a request
+  ERROR_CODE_UNSUPPORTED_FLAGS = 2;  // unknown envelope flag bits
+  ERROR_CODE_NOT_PAIRED = 3;         // non-pairing frame on untrusted session
+  ERROR_CODE_BUSY = 4;
+  ERROR_CODE_INVALID = 5;            // semantically invalid payload
+  ERROR_CODE_TOO_LARGE = 6;          // frame exceeds the size cap
+  ERROR_CODE_DISABLED = 7;           // flow disabled on this peer
+  ERROR_CODE_INTERNAL = 8;
+}
+
+// Application-level liveness/RTT probe (QUIC keepalive proves the transport,
+// Ping/Pong proves the agent). Sent as datagrams.
+message Ping {
+  uint64 seq = 1;
+}
+
+message Pong {
+  uint64 seq = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Pairing family (allowed pre-trust)
+// ---------------------------------------------------------------------------
+//
+// Both sides derive the same 6-digit code from the two public keys and the
+// two session nonces (exact derivation: FLOW-PROTOCOL.md §Pairing). A
+// man-in-the-middle terminates two different sessions and therefore produces
+// two different codes; the user comparing screens is the authentication.
+
+// Request: begin pairing. The responder shows its prompt (key fingerprint,
+// machine name, the code) to its user.
+message PairStart {}
+
+// Response to PairStart: the prompt is on screen; the requester may now show
+// its own prompt and both users compare codes.
+message PairPrompted {
+  // How long the responder will keep the session pending before it aborts.
+  uint32 timeout_ms = 1;
+}
+
+// Request: this side's user confirmed the code matches. Pairing completes
+// when each side has both sent and received a confirm.
+message PairConfirm {}
+
+// Response to PairConfirm.
+message PairOutcome {
+  PairResult result = 1;
+}
+
+enum PairResult {
+  PAIR_RESULT_UNSPECIFIED = 0;
+  PAIR_RESULT_PAIRED = 1;           // both confirms present; keys persisted
+  PAIR_RESULT_PENDING_LOCAL = 2;    // your confirm recorded; mine still absent
+  PAIR_RESULT_REJECTED = 3;         // user declined
+  PAIR_RESULT_TIMEOUT = 4;
+}
+
+// Notification: abandon the pairing session (user cancelled, code mismatch).
+message PairAbort {
+  PairAbortReason reason = 1;
+}
+
+enum PairAbortReason {
+  PAIR_ABORT_REASON_UNSPECIFIED = 0;
+  PAIR_ABORT_REASON_USER_CANCELLED = 1;
+  PAIR_ABORT_REASON_CODE_MISMATCH = 2;
+  PAIR_ABORT_REASON_TIMEOUT = 3;
+}
+
+// ---------------------------------------------------------------------------
+// Peer info / state family
+// ---------------------------------------------------------------------------
+
+// Request the peer's descriptive state (for the GUI's layout editor and peer
+// list). Also delivered unsolicited-fresh via PeerState revisions.
+message GetPeerInfo {}
+
+message PeerInfo {
+  string machine_name = 1;
+  Platform platform = 2;
+  // Display arrangement in the peer's own virtual coordinate space.
+  // Informational: handoff never carries absolute peer coordinates.
+  repeated Display displays = 3;
+  // Monotonic per-peer counter; a PeerInfo with a lower revision than one
+  // already seen is stale and discarded.
+  uint64 revision = 4;
+}
+
+message Display {
+  uint64 id = 1;
+  Rect bounds_px = 2;
+  // Backing-store scale (e.g. 2.0 on Retina), for rendering the layout
+  // editor faithfully.
+  double scale = 3;
+  bool primary = 4;
+}
+
+message Rect {
+  sint32 x = 1;
+  sint32 y = 2;
+  uint32 width = 3;
+  uint32 height = 4;
+}
+
+// Notification: the complete set of Flow-relevant devices as seen by the
+// announcing peer — sent when a session becomes trusted and again on every
+// inventory change (level-triggered whole state, never a delta, so a lost or
+// reordered announce heals on the next one).
+message AnnounceDevices {
+  repeated DeviceView devices = 1;
+  // Monotonic per-peer counter, same staleness rule as PeerInfo.revision.
+  uint64 revision = 2;
+}
+
+// One device as seen from the announcing peer.
+message DeviceView {
+  DeviceIdentity identity = 1;
+  // Easy-Switch slot (0-based, as in HID++ 0x1814) the device uses to reach
+  // the ANNOUNCING peer. This is the field the receiver of this message
+  // stores as "to hand off to that peer, command the device to this slot".
+  uint32 channel_to_me = 2;
+  // Whether the device is currently live on that slot (present and awake).
+  bool connected = 3;
+  // Total host slots, from 0x1814 get_host_info.
+  uint32 host_count = 4;
+  // Slot metadata from 0x1815 HostsInfo, informational (setup UI).
+  repeated HostSlot host_slots = 5;
+}
+
+message HostSlot {
+  uint32 index = 1;
+  string name = 2;
+  bool paired = 3;
+}
+
+// Cross-peer device identity. Two DeviceIdentity values denote the same
+// physical device iff their identifier sets intersect on any single entry.
+// The set form keeps identity open-ended: a transport whose best identifier
+// we have not modeled yet becomes a new IdentifierKind, not a schema change.
+message DeviceIdentity {
+  repeated DeviceIdentifier ids = 1;
+  // Presentation only — never used for correlation.
+  string name = 2;
+  DeviceCategory category = 3;
+  // Model numbers per transport, presentation/diagnostics only (model ids
+  // are model-scoped: two identical mice share them).
+  repeated ModelId models = 4;
+}
+
+message DeviceIdentifier {
+  IdentifierKind kind = 1;
+  // Canonical bytes for that kind (FLOW-PROTOCOL.md §Device identity):
+  // SERIAL = UTF-8 string bytes, UNIT_ID = big-endian u32,
+  // BLUETOOTH_ADDRESS = 6 bytes.
+  bytes value = 2;
+}
+
+enum IdentifierKind {
+  IDENTIFIER_KIND_UNSPECIFIED = 0;
+  IDENTIFIER_KIND_SERIAL = 1;
+  IDENTIFIER_KIND_UNIT_ID = 2;
+  IDENTIFIER_KIND_BLUETOOTH_ADDRESS = 3;
+}
+
+enum DeviceCategory {
+  DEVICE_CATEGORY_UNSPECIFIED = 0;
+  DEVICE_CATEGORY_MOUSE = 1;
+  DEVICE_CATEGORY_KEYBOARD = 2;
+  DEVICE_CATEGORY_TRACKBALL = 3;
+  DEVICE_CATEGORY_TOUCHPAD = 4;
+  DEVICE_CATEGORY_PRESENTER = 5;
+  DEVICE_CATEGORY_OTHER = 6;
+}
+
+message ModelId {
+  DeviceTransport transport = 1;
+  uint32 vendor_id = 2;
+  uint32 product_id = 3;
+}
+
+enum DeviceTransport {
+  DEVICE_TRANSPORT_UNSPECIFIED = 0;
+  DEVICE_TRANSPORT_RECEIVER = 1;
+  DEVICE_TRANSPORT_BLUETOOTH = 2;
+  DEVICE_TRANSPORT_USB = 3;
+}
+
+// Notification: coarse peer state for remote GUIs. Quantized on purpose —
+// never per-heartbeat facts (the same churn rule as the local IPC snapshot).
+message PeerState {
+  bool flow_enabled = 1;
+  // Devices this peer currently holds (is the live host of).
+  repeated DeviceIdentity held = 2;
+  uint64 revision = 3;
+}
+
+// ---------------------------------------------------------------------------
+// Handoff family
+// ---------------------------------------------------------------------------
+//
+// Sequence (FLOW-PROTOCOL.md §Handoff has the full state machine):
+//   sender  --HandoffRequest-->  receiver          (bi-stream)
+//   sender  <--HandoffAccept--   receiver          (same stream)
+//   sender: ChangeHost.set_current_host(...)       (the point of no return)
+//   receiver: positive arrival evidence (0x41)     (or arm-timeout)
+//   sender  <--HandoffResult--   receiver          (uni-stream, by transfer_id)
+// The sender NEVER switches before Accept. HandoffCancel (either direction)
+// disarms a transfer that Accept has opened but the switch cannot complete.
+
+message HandoffRequest {
+  // Random per attempt; the dedupe key. A retransmitted request with a known
+  // transfer_id is answered from existing state, not re-armed.
+  uint64 transfer_id = 1;
+  // Devices being moved; the pointing device first, linked devices after.
+  repeated DeviceIdentity devices = 2;
+  EntryPoint entry = 3;
+  // Sender wall clock, unix milliseconds. Diagnostics only.
+  uint64 sent_at_ms = 4;
+}
+
+// Where the cursor should materialize on the receiver.
+message EntryPoint {
+  // The RECEIVER's edge being entered (already translated by the sender's
+  // layout: exiting my right edge toward you = entering your left edge).
+  Side side = 1;
+  // Normalized 0..1 along that edge (top→bottom for vertical edges,
+  // left→right for horizontal), measured on the sender's exiting edge. The
+  // receiver maps it proportionally onto its own exposed edge segments and
+  // clamps to the nearest valid point.
+  double t = 2;
+  // Cursor velocity at exit, in normalized edge lengths per second
+  // (perpendicular, parallel). Optional; enables entry momentum.
+  optional Vec2 velocity = 3;
+}
+
+enum Side {
+  SIDE_UNSPECIFIED = 0;
+  SIDE_LEFT = 1;
+  SIDE_RIGHT = 2;
+  SIDE_TOP = 3;
+  SIDE_BOTTOM = 4;
+}
+
+message Vec2 {
+  double x = 1;
+  double y = 2;
+}
+
+message HandoffAccept {
+  uint64 transfer_id = 1;
+  // How long the receiver will watch for device arrival before reporting
+  // HANDOFF_OUTCOME_TIMEOUT. The sender sizes its own give-up deadline as
+  // arm_timeout_ms plus network slack.
+  uint32 arm_timeout_ms = 2;
+}
+
+message HandoffReject {
+  uint64 transfer_id = 1;
+  HandoffRejectReason reason = 2;
+  string detail = 3;
+}
+
+enum HandoffRejectReason {
+  HANDOFF_REJECT_REASON_UNSPECIFIED = 0;
+  HANDOFF_REJECT_REASON_DISABLED = 1;        // flow off on the receiver
+  HANDOFF_REJECT_REASON_UNKNOWN_DEVICE = 2;  // no identity intersection
+  HANDOFF_REJECT_REASON_ALREADY_PENDING = 3; // a transfer is already armed
+  HANDOFF_REJECT_REASON_NOT_READY = 4;       // e.g. receiver's HID stack down
+}
+
+// Notification: terminal outcome of an accepted transfer.
+message HandoffResult {
+  uint64 transfer_id = 1;
+  HandoffOutcome outcome = 2;
+  repeated DeviceArrival arrivals = 3;
+}
+
+enum HandoffOutcome {
+  HANDOFF_OUTCOME_UNSPECIFIED = 0;
+  HANDOFF_OUTCOME_ARRIVED = 1;    // every requested device arrived
+  HANDOFF_OUTCOME_PARTIAL = 2;    // some arrived (per-device detail attached)
+  HANDOFF_OUTCOME_TIMEOUT = 3;    // nothing arrived within arm_timeout_ms
+  HANDOFF_OUTCOME_CANCELLED = 4;  // a HandoffCancel disarmed it
+}
+
+message DeviceArrival {
+  DeviceIdentity device = 1;
+  bool arrived = 2;
+  // Milliseconds from Accept to this device's arrival evidence.
+  uint32 elapsed_ms = 3;
+}
+
+// Notification, either direction: disarm/abort a transfer after Accept.
+message HandoffCancel {
+  uint64 transfer_id = 1;
+  HandoffCancelReason reason = 2;
+}
+
+enum HandoffCancelReason {
+  HANDOFF_CANCEL_REASON_UNSPECIFIED = 0;
+  HANDOFF_CANCEL_REASON_SWITCH_FAILED = 1;  // sender's HID++ write failed
+  HANDOFF_CANCEL_REASON_SUPERSEDED = 2;     // a newer transfer replaces it
+  HANDOFF_CANCEL_REASON_SHUTDOWN = 3;
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard family (capability-gated)
+// ---------------------------------------------------------------------------
+//
+// Lazy model: an announce names what is available; bytes move only when the
+// holder of the announce actually pastes (every target OS supports promised/
+// delayed clipboard rendering). CLIPBOARD_TEXT gates text mimes;
+// CLIPBOARD_FILES additionally gates the file-list mime and FileFetch.
+
+// Notification: my clipboard changed; these representations are available.
+message ClipboardAnnounce {
+  // Monotonic per-peer clipboard generation. Fetches quote it; a fetch for a
+  // superseded sequence is answered with Error INVALID (the data is gone).
+  uint64 sequence = 1;
+  repeated ClipboardFormat formats = 2;
+}
+
+message ClipboardFormat {
+  // IANA media type, e.g. "text/plain;charset=utf-8", "image/png", or the
+  // private "application/x-openlogi-files" whose payload is FileList.
+  // An open set by design: a new representation is a new mime string, not a
+  // schema change.
+  string mime = 1;
+  uint64 size_bytes = 2;
+  // Content hash, when cheap to compute; lets an unchanged re-announce be
+  // deduplicated by the fetcher.
+  optional bytes sha256 = 3;
+}
+
+// Request: send me one representation of clipboard generation `sequence`.
+message ClipboardFetch {
+  uint64 sequence = 1;
+  string mime = 2;
+  // Resume offset in bytes (0 for a fresh fetch); lets an interrupted bulk
+  // transfer continue instead of restarting.
+  uint64 offset = 3;
+}
+
+// Response head, followed on the same stream by Chunk frames and ChunkEnd.
+message ClipboardData {
+  uint64 sequence = 1;
+  string mime = 2;
+  uint64 total_size = 3;
+}
+
+// One slice of a bulk payload. Ordering is the stream's; size cap is
+// CHUNK_MAX (FLOW-PROTOCOL.md §Framing).
+message Chunk {
+  bytes data = 1;
+}
+
+// Terminates a bulk payload; integrity check for the assembled bytes
+// starting at the requested offset.
+message ChunkEnd {
+  optional bytes sha256 = 1;
+}
+
+// The decoded payload of "application/x-openlogi-files".
+message FileList {
+  repeated FileEntry files = 1;
+}
+
+message FileEntry {
+  // Relative path using '/' separators; no absolute paths, no "..". The
+  // receiver places files under its own download location.
+  string relative_path = 1;
+  uint64 size_bytes = 2;
+  // Unix milliseconds; 0 when unknown.
+  uint64 modified_at_ms = 3;
+}
+
+// Request: stream one file from the announced file list.
+// Response: ClipboardData head (mime "application/octet-stream"), Chunks,
+// ChunkEnd — identical shape to any other bulk fetch.
+message FileFetch {
+  uint64 sequence = 1;
+  // Index into the FileList of that sequence.
+  uint32 file_index = 2;
+  uint64 offset = 3;
+}

--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -31,6 +31,7 @@
   git,
   pkg-config,
   patchelf,
+  protobuf,
   versionCheckHook,
   fontconfig,
   freetype,
@@ -140,6 +141,7 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     pkg-config
     patchelf
+    protobuf # openlogi-flow generates its wire types during the build
     rustPlatform.bindgenHook # `media` (a gpui dep) runs bindgen — needs libclang
   ];
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -126,6 +126,11 @@ release = false
 publish = false
 
 [[package]]
+name = "openlogi-flow"
+release = false
+publish = false
+
+[[package]]
 name = "openlogi-agent"
 release = false
 publish = false


### PR DESCRIPTION
## Summary

Layer 1 of the Flow stack. Add the platform-neutral protocol and networking substrate for secure peer discovery, pairing, and long-lived sessions. This layer does not connect Flow to the agent or HID switching yet.

## Changes

- `openlogi-flow`: protobuf framing, typed negotiation, SAS pairing, and persistent Ed25519 peer identities.
- `openlogi-flow`: mutually pinned QUIC transport with RPC, notifications, liveness, retry backoff, and deterministic simultaneous-dial convergence.
- `openlogi-flow`: mDNS and manual-address discovery with candidate deduplication.
- Workspace/CI: protobuf code generation, `protoc` provisioning, dependency policy, and release metadata.
- Documentation: Flow architecture, protocol state machines, trust boundaries, and failure behavior.

## Testing

Run on the fully integrated stack tip:

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 11 passed, 0 failed, 1 skipped (`tests (macos)`)

The multicast live test remains ignored because the orb does not provide multicast-capable host networking. No real multi-host network or hardware test was run.

Part of #253

Co-authored-by: Xuan Zhang <xuan@arcbox.dev>