### PR TITLE
feat(core): add Flow configuration

### DIFF
--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 mod device;
 #[cfg(feature = "fs")]
 mod file;
+mod flow;
 mod identity;
 mod key_trigger;
 mod settings;
@@ -28,6 +29,7 @@ pub use device::{DeviceConfig, DeviceIdentity, LinkConfig, LinkOverrides};
 pub use file::{ConfigError, ConfigFile};
 #[cfg(all(test, feature = "fs"))]
 use file::{backup_existing_config, config_backup_path};
+pub use flow::{FlowConfig, FlowDevice, FlowEdge, FlowLayout, FlowPeer};
 pub use identity::canonical_device_key;
 pub use key_trigger::{KeyModifiers, KeyTrigger, KeyboardConfig, ParseTriggerError};
 pub use settings::LightSettings;
@@ -50,6 +52,9 @@ use settings::GestureOwner;
 /// before consuming the rest of the file.
 ///
 /// v6 adds threshold-based `{ short = ..., long = ... }` button bindings.
+///
+/// Flow is an additive, default-empty section and does not require a schema
+/// migration; configs without it continue to deserialize to disabled Flow.
 ///
 /// v5 also drops the transport prefix from `direct:` keys: `direct:046d:c08d:unit:6be9d300`
 /// names the mouse *and the cable it was plugged into*, so a device moved to a
@@ -104,6 +109,9 @@ pub struct Config {
     /// first paired device. `None` means "fall back to the first device".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_device: Option<String>,
+    /// Cross-machine Flow handoff configuration.
+    #[serde(default, skip_serializing_if = "FlowConfig::is_default")]
+    pub flow: FlowConfig,
     /// When set (see [`Self::ephemeral`]), [`Self::save_atomic`] is a no-op:
     /// this config never writes the on-disk file. Never true for a loaded or
     /// default-constructed config.
@@ -136,6 +144,7 @@ impl Default for Config {
             schema_version: SCHEMA_VERSION,
             app_settings: AppSettings::default(),
             selected_device: None,
+            flow: FlowConfig::default(),
             devices: BTreeMap::new(),
             ephemeral: false,
             keyboard: KeyboardConfig::default(),

--- a/crates/openlogi-core/src/config/flow.rs
+++ b/crates/openlogi-core/src/config/flow.rs
@@ -1,0 +1,89 @@
+//! Flow config for cross-machine device handoff.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Cross-machine Flow settings.
+///
+/// This is persisted configuration only. Discovery, transport, and device
+/// handoff live outside `openlogi-core`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlowConfig {
+    /// Whether Flow handoff is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Whether the Control modifier must be held while crossing a configured
+    /// screen edge.
+    #[serde(default)]
+    pub require_modifier: bool,
+    /// Trusted peer machines.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub peers: Vec<FlowPeer>,
+    /// Mappings from this machine's screen edges to peers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub layout: Vec<FlowLayout>,
+    /// Devices that participate in Flow and their per-machine host channels.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub devices: Vec<FlowDevice>,
+}
+
+impl FlowConfig {
+    /// Whether this value is exactly the implicit default and can be omitted
+    /// from `config.toml`.
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+/// One trusted Flow peer and its optional manual address hints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlowPeer {
+    /// User-visible peer name, also referenced by layout and channel mappings.
+    pub name: String,
+    /// Peer's pinned Ed25519 public key, encoded as `"ed25519:"` followed by
+    /// 64 lowercase hexadecimal digits.
+    pub public_key: String,
+    /// Manual hostnames or IP addresses used when mDNS cannot reach this peer.
+    /// Hostnames are kept intact for resolution by the networking layer.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub addresses: Vec<String>,
+}
+
+/// One screen-edge mapping from this machine to a Flow peer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlowLayout {
+    /// Edge of this machine's screen that leads to the peer.
+    pub edge: FlowEdge,
+    /// Name of the peer reached through this edge.
+    pub peer: String,
+}
+
+/// Screen edge that can trigger a Flow handoff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowEdge {
+    /// Left edge of the screen.
+    Left,
+    /// Right edge of the screen.
+    Right,
+    /// Top edge of the screen.
+    Top,
+    /// Bottom edge of the screen.
+    Bottom,
+}
+
+/// One device participating in Flow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FlowDevice {
+    /// Existing stable physical-device config key, such as `"unit:0f1e2d3c"`.
+    pub key: String,
+    /// Easy-Switch host channel for this machine (`"self"`) and each peer,
+    /// keyed by peer name.
+    pub peer_channels: BTreeMap<String, u8>,
+}

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -27,6 +27,85 @@ fn canonical_configuration_example_parses() {
 }
 
 #[test]
+fn full_flow_section_roundtrips() {
+    let source = r#"
+schema_version = 6
+
+[flow]
+enabled = true
+require_modifier = false
+
+[[flow.peers]]
+name = "work-laptop"
+public_key = "ed25519:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+addresses = ["work-laptop.tailnet.example", "10.0.0.7"]
+
+[[flow.layout]]
+edge = "right"
+peer = "work-laptop"
+
+[[flow.devices]]
+key = "unit:0f1e2d3c"
+peer_channels = { self = 0, "work-laptop" = 1 }
+"#;
+
+    let config: Config = toml::from_str(source).expect("full Flow config must parse");
+    let flow = FlowConfig {
+        enabled: true,
+        require_modifier: false,
+        peers: vec![FlowPeer {
+            name: "work-laptop".into(),
+            public_key: "ed25519:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .into(),
+            addresses: vec!["work-laptop.tailnet.example".into(), "10.0.0.7".into()],
+        }],
+        layout: vec![FlowLayout {
+            edge: FlowEdge::Right,
+            peer: "work-laptop".into(),
+        }],
+        devices: vec![FlowDevice {
+            key: "unit:0f1e2d3c".into(),
+            peer_channels: BTreeMap::from([("self".into(), 0), ("work-laptop".into(), 1)]),
+        }],
+    };
+    assert_eq!(config.flow, flow);
+
+    let written = toml::to_string_pretty(&config).expect("serialize Flow config");
+    let reparsed: Config = toml::from_str(&written).expect("reparse Flow config");
+    assert_eq!(reparsed.flow, flow);
+}
+
+#[test]
+fn empty_flow_section_uses_defaults() {
+    for source in ["schema_version = 6\n", "schema_version = 6\n\n[flow]\n"] {
+        let config: Config = toml::from_str(source).expect("empty Flow config must parse");
+        assert_eq!(config.flow, FlowConfig::default());
+        assert!(
+            !toml::to_string_pretty(&config)
+                .expect("serialize default Flow config")
+                .contains("[flow]"),
+            "default Flow config should be omitted"
+        );
+    }
+}
+
+#[test]
+fn malformed_flow_entries_are_rejected() {
+    for source in [
+        "schema_version = 6\n[flow]\nunknown = true\n",
+        "schema_version = 6\n[[flow.peers]]\nname = \"peer\"\n",
+        "schema_version = 6\n[[flow.peers]]\nname = \"peer\"\npublic_key = \"ed25519:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"\naddresses = \"peer.example\"\n",
+        "schema_version = 6\n[[flow.layout]]\nedge = \"diagonal\"\npeer = \"peer\"\n",
+        "schema_version = 6\n[[flow.devices]]\nkey = \"unit:0f1e2d3c\"\npeer_channels = { self = \"zero\" }\n",
+    ] {
+        assert!(
+            toml::from_str::<Config>(source).is_err(),
+            "accepted malformed Flow config: {source}"
+        );
+    }
+}
+
+#[test]
 fn first_save_preserves_the_previous_config_for_recovery() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -70,8 +70,7 @@ peer_channels = { self = 0, "work-laptop" = 1 }
     };
     assert_eq!(config.flow, flow);
 
-    let written = toml::to_string_pretty(&config).expect("serialize Flow config");
-    let reparsed: Config = toml::from_str(&written).expect("reparse Flow config");
+    let reparsed = write_and_read(&config);
     assert_eq!(reparsed.flow, flow);
 }
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -20,6 +20,25 @@ device_view_mode = "grid"
 # macOS only: "openlogi" (the signed icon) or "prism".
 app_icon = "openlogi"
 
+# Cross-machine device handoff. Pairing writes the peer's pinned public key;
+# manual addresses keep Flow usable across VPNs, VLANs, and overlay networks.
+# [flow]
+# enabled = true
+# require_modifier = false
+#
+# [[flow.peers]]
+# name = "work-laptop"
+# public_key = "ed25519:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+# addresses = ["work-laptop.tailnet.example", "10.0.0.7"]
+#
+# [[flow.layout]]
+# edge = "right"
+# peer = "work-laptop"
+#
+# [[flow.devices]]
+# key = "unit:0f1e2d3c"
+# peer_channels = { self = 0, "work-laptop" = 1 }
+
 [devices."receiver:aabbccdd:slot:1"]
 custom_name = "Office mouse"
 dpi = 1600


### PR DESCRIPTION
## Summary

Layer 2 of the Flow stack, on top of #1100. Add the persisted `[flow]` configuration schema without introducing IPC or runtime behavior.

## Changes

- `openlogi-core`: Flow enablement, local host identity, pinned peers, discovery addresses, edge mappings, and trigger policy.
- Root config integration with serde defaults that preserve existing configurations.
- TOML round-trip and validation coverage.
- Example configuration for a manually pinned two-host setup.

## Testing

Run on the fully integrated stack tip:

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `cargo xtask ci` — 11 passed, 0 failed, 1 skipped (`tests (macos)`)

This layer is configuration-only and was not runtime-tested on hardware.

Part of #253

Co-authored-by: Xuan Zhang <xuan@arcbox.dev>