### PR TITLE
feat(hid): add host switching IPC and diagnostic CLI

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -22,13 +22,14 @@ use std::time::Duration;
 
 use openlogi_core::config::Lighting;
 use openlogi_hid::{
-    CaptureChannel, ChannelRegistry, DeviceRoute, Dpi, HidppOperation, ScrollResolution,
-    SharedChannel, SmartShiftStatus, WriteError,
+    CaptureChannel, ChannelRegistry, DeviceRoute, Dpi, HidppOperation, HostSwitchError,
+    ScrollResolution, SharedChannel, SmartShiftStatus, WriteError,
 };
+use openlogi_ipc::SwitchHostError;
 use tokio::time::error::Elapsed;
 use tracing::{debug, warn};
 
-use crate::receiver_access::ReceiverAccess;
+use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess};
 
 mod light;
 
@@ -128,6 +129,28 @@ impl<'a> DeviceOp<'a> {
         timed(op, f(shared)).await
     }
 
+    /// Switch this device to a zero-based host slot through its authoritative
+    /// shared channel.
+    ///
+    /// The ChangeHost write is fire-and-forget because the device leaves this
+    /// radio channel when it takes effect. Success therefore means the write
+    /// was issued (or the device was already on that host), not that arrival at
+    /// the destination was confirmed.
+    pub async fn switch_host(self, host: u8) -> Result<(), SwitchHostError> {
+        let _lease = self
+            .receiver_access
+            .acquire_exclusive(ExclusiveAccessReason::HostTransition)
+            .await;
+        let shared = self.resolve().map_err(map_route_error)?;
+        tokio::time::timeout(WRITE_BUDGET, openlogi_hid::switch_host_on(&shared, host))
+            .await
+            .map_err(|_| SwitchHostError::TimedOut {
+                operation: "switching host".into(),
+            })?
+            .map(|_changed| ())
+            .map_err(map_host_switch_error)
+    }
+
     /// Fire-and-forget `f` on its own OS thread and one-shot runtime, with the
     /// standard three-arm outcome logging: a completed write and a failed
     /// write both log at their own level, keyed by `label`; a device that
@@ -188,6 +211,38 @@ impl<'a> DeviceOp<'a> {
             });
             log(result);
         });
+    }
+}
+
+fn map_route_error(error: WriteError) -> SwitchHostError {
+    match error {
+        WriteError::DeviceNotFound => SwitchHostError::DeviceNotFound,
+        error => SwitchHostError::Hid {
+            message: error.to_string(),
+        },
+    }
+}
+
+fn map_host_switch_error(error: HostSwitchError) -> SwitchHostError {
+    match error {
+        HostSwitchError::Hid(error) => SwitchHostError::Hid {
+            message: error.to_string(),
+        },
+        HostSwitchError::KeyboardNotFound | HostSwitchError::TargetNotFound => {
+            SwitchHostError::DeviceNotFound
+        }
+        HostSwitchError::Hidpp(message) => SwitchHostError::Hidpp { message },
+        HostSwitchError::FeatureUnsupported => SwitchHostError::FeatureUnsupported,
+        HostSwitchError::TimedOut { operation } => SwitchHostError::TimedOut {
+            operation: operation.into(),
+        },
+        HostSwitchError::UnsupportedKeyboard => SwitchHostError::Hidpp {
+            message: error.to_string(),
+        },
+        HostSwitchError::HostSlotEmpty { host } => SwitchHostError::HostSlotEmpty { host },
+        HostSwitchError::HostOutOfRange { host, host_count } => {
+            SwitchHostError::HostOutOfRange { host, host_count }
+        }
     }
 }
 
@@ -585,6 +640,20 @@ mod tests {
             !called.load(Ordering::SeqCst),
             "f must not run when the route can't be resolved"
         );
+    }
+
+    #[tokio::test]
+    async fn switch_host_on_a_registry_miss_returns_device_not_found() {
+        let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
+        let registry = ChannelRegistry::default();
+        let receiver_access = ReceiverAccess::default();
+        let route = unresolvable_route();
+
+        let result = DeviceOp::new(&capture, &registry, &receiver_access, &route)
+            .switch_host(1)
+            .await;
+
+        assert!(matches!(result, Err(SwitchHostError::DeviceNotFound)));
     }
 
     /// `DeviceOp::detach` resolves before spawning, so a registry miss must

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -58,7 +58,7 @@ use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus, ClientKind,
     ConfigReloadError, ForegroundApps, FoundDevice, Generation, Identity, InventoryHealth,
     MonitorEvent, OBSERVE_HOLD, Observation, PROTOCOL_VERSION, PairingCommandError, PairingFailure,
-    PairingPhase, PairingUpdate, RingObservation,
+    PairingPhase, PairingUpdate, RingObservation, SwitchHostError,
 };
 use succession::Compat;
 use tarpc::context::Context;
@@ -911,6 +911,21 @@ impl Agent for MockAgent {
             .ok_or(WriteError::FeatureUnsupported {
                 feature_hex: 0x2110,
             })
+    }
+
+    async fn switch_host(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        host: u8,
+    ) -> Result<(), SwitchHostError> {
+        self.state
+            .lock()
+            .await
+            .settings_for(&route)
+            .map_err(|_error| SwitchHostError::DeviceNotFound)?;
+        info!(%route, host, "switch_host (no-op in the mock)");
+        Ok(())
     }
 
     async fn request_accessibility_prompt(self, _: Context) {

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -26,7 +26,7 @@ use openlogi_ipc::transport;
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus, ClientKind,
     ConfigReloadError, Generation, Identity, MonitorEvent, Observation, PROTOCOL_VERSION,
-    PairingCommandError, PairingUpdate, RingObservation,
+    PairingCommandError, PairingUpdate, RingObservation, SwitchHostError,
 };
 use succession::Compat;
 
@@ -207,6 +207,15 @@ impl Agent for AgentServer {
                 openlogi_hid::get_smartshift_status_on(&c).await
             })
             .await
+    }
+
+    async fn switch_host(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        host: u8,
+    ) -> Result<(), SwitchHostError> {
+        self.shared.device(&route).switch_host(host).await
     }
 
     async fn request_accessibility_prompt(self, _: Context) {

--- a/crates/openlogi-cli/src/cmd/diag.rs
+++ b/crates/openlogi-cli/src/cmd/diag.rs
@@ -109,11 +109,18 @@ fn no_match_err(devices: &[Candidate], query: Option<&str>) -> anyhow::Error {
 
 fn select_named_device(devices: &[Candidate], query: &str) -> Result<(DeviceRoute, String)> {
     let needle = query.to_lowercase();
-    devices
+    let mut matches = devices
         .iter()
-        .find(|candidate| candidate.name.to_lowercase().contains(&needle))
-        .map(|candidate| (candidate.route.clone(), candidate.name.clone()))
-        .ok_or_else(|| no_match_err(devices, Some(query)))
+        .filter(|candidate| candidate.name.to_lowercase().contains(&needle));
+    let candidate = matches
+        .next()
+        .ok_or_else(|| no_match_err(devices, Some(query)))?;
+    if matches.next().is_some() {
+        return Err(anyhow!(
+            "multiple online devices match `--device {query}`; use a more specific value"
+        ));
+    }
+    Ok((candidate.route.clone(), candidate.name.clone()))
 }
 
 /// Select an online device from an agent-provided inventory by name substring.
@@ -128,8 +135,8 @@ pub(crate) fn select_inventory_device(
 /// Pick the device a diag should run against.
 ///
 /// Selection order:
-/// 1. If `query` is set, the first online device whose name contains it
-///    (case-insensitive) — lets the user disambiguate explicitly.
+/// 1. If `query` is set, the single online device whose name contains it
+///    (case-insensitive); ambiguous matches are rejected.
 /// 2. Else, if `required_features` is non-empty, the first online device whose
 ///    HID++ feature table exposes *any* of them. This is what stops a
 ///    mouse-only diag (DPI, SmartShift) from picking a paired keyboard when
@@ -181,7 +188,7 @@ pub(crate) async fn select_device(
 mod no_match_err_tests {
     use openlogi_hid::DeviceRoute;
 
-    use super::{Candidate, no_match_err};
+    use super::{Candidate, no_match_err, select_named_device};
 
     fn candidate(name: &str) -> Candidate {
         Candidate {
@@ -230,5 +237,17 @@ mod no_match_err_tests {
         assert!(err.contains("could not pick a device automatically"));
         assert!(err.contains("pass --device <name> to choose one"));
         assert!(err.contains("MX Master 3S"));
+    }
+
+    #[test]
+    fn ambiguous_query_is_rejected() {
+        let devices = vec![candidate("MX Master 3S"), candidate("MX Mechanical")];
+
+        let err = select_named_device(&devices, "mx").unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "multiple online devices match `--device mx`; use a more specific value"
+        );
     }
 }

--- a/crates/openlogi-cli/src/cmd/diag.rs
+++ b/crates/openlogi-cli/src/cmd/diag.rs
@@ -1,19 +1,21 @@
 //! `openlogi diag` — real-device smoke tests for the HID++ write path.
 //!
-//! Subcommands exercise direct HID++ reads and verified writes. The intent is
-//! diagnosis, not persistent configuration: nothing here
-//! touches `config.toml` or talks to the GUI; everything runs through the
-//! same `openlogi_hid` API the GPUI app uses, so a green diag means the
-//! GUI's write path works on this host.
+//! Most subcommands exercise direct HID++ reads and verified writes. The intent
+//! is diagnosis, not persistent configuration: nothing here touches
+//! `config.toml` or talks to the GUI. `host-switch` deliberately goes through
+//! the running agent because the device leaves its current radio link after
+//! the write, and the agent owns the authoritative HID channel.
 
 use anyhow::{Result, anyhow};
 use clap::Subcommand;
+use openlogi_core::device::DeviceInventory;
 use openlogi_hid::{DeviceRoute, dump_features};
 
 pub mod battery;
 pub mod controls;
 pub mod dpi;
 pub mod features;
+pub mod host_switch;
 pub mod lighting;
 pub mod smartshift;
 pub mod wheel;
@@ -34,6 +36,8 @@ pub enum DiagCmd {
     Lighting(lighting::LightingArgs),
     /// Read or set the HID++ 0x2121 wheel reporting resolution.
     Wheel(wheel::WheelArgs),
+    /// Switch a multi-host device through the running agent (HID++ 0x1814).
+    HostSwitch(host_switch::HostSwitchArgs),
 }
 
 impl DiagCmd {
@@ -46,6 +50,7 @@ impl DiagCmd {
             Self::Smartshift(args) => smartshift::run(args).await,
             Self::Lighting(args) => lighting::run(args).await,
             Self::Wheel(args) => wheel::run(args).await,
+            Self::HostSwitch(args) => host_switch::run(args).await,
         }
     }
 }
@@ -61,6 +66,10 @@ struct Candidate {
 /// Enumerate inventories and resolve every *online* paired device to a route.
 async fn online_devices() -> Result<Vec<Candidate>> {
     let inventories = openlogi_hid::enumerate().await?;
+    Ok(online_devices_from(inventories))
+}
+
+fn online_devices_from(inventories: Vec<DeviceInventory>) -> Vec<Candidate> {
     let mut out = Vec::new();
     for inv in inventories {
         for paired in inv.paired.iter().filter(|p| p.online) {
@@ -76,7 +85,7 @@ async fn online_devices() -> Result<Vec<Candidate>> {
             out.push(Candidate { route, name });
         }
     }
-    Ok(out)
+    out
 }
 
 /// Build a helpful "couldn't pick a device" error that lists what *is* online.
@@ -98,6 +107,24 @@ fn no_match_err(devices: &[Candidate], query: Option<&str>) -> anyhow::Error {
     }
 }
 
+fn select_named_device(devices: &[Candidate], query: &str) -> Result<(DeviceRoute, String)> {
+    let needle = query.to_lowercase();
+    devices
+        .iter()
+        .find(|candidate| candidate.name.to_lowercase().contains(&needle))
+        .map(|candidate| (candidate.route.clone(), candidate.name.clone()))
+        .ok_or_else(|| no_match_err(devices, Some(query)))
+}
+
+/// Select an online device from an agent-provided inventory by name substring.
+pub(crate) fn select_inventory_device(
+    inventories: Vec<DeviceInventory>,
+    query: &str,
+) -> Result<(DeviceRoute, String)> {
+    let devices = online_devices_from(inventories);
+    select_named_device(&devices, query)
+}
+
 /// Pick the device a diag should run against.
 ///
 /// Selection order:
@@ -116,12 +143,7 @@ pub(crate) async fn select_device(
     let devices = online_devices().await?;
 
     if let Some(q) = query {
-        let needle = q.to_lowercase();
-        return devices
-            .iter()
-            .find(|c| c.name.to_lowercase().contains(&needle))
-            .map(|c| (c.route.clone(), c.name.clone()))
-            .ok_or_else(|| no_match_err(&devices, query));
+        return select_named_device(&devices, q);
     }
 
     if !required_features.is_empty() {

--- a/crates/openlogi-cli/src/cmd/diag/host_switch.rs
+++ b/crates/openlogi-cli/src/cmd/diag/host_switch.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+use clap::Args;
+use openlogi_ipc::{ClientKind, PROTOCOL_VERSION, client};
+use tarpc::context;
+
+use super::select_inventory_device;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(5);
+const SWITCH_TIMEOUT: Duration = Duration::from_secs(7);
+
+/// Arguments for a software-initiated multi-host device switch.
+#[derive(Debug, Args)]
+pub struct HostSwitchArgs {
+    /// Device name substring from `openlogi list`.
+    #[arg(long)]
+    pub device: String,
+    /// Zero-based host slot reported by the device (usually 0, 1, or 2).
+    #[arg(long)]
+    pub host: u8,
+}
+
+/// Ask the running agent to switch one device to another paired host slot.
+pub async fn run(args: HostSwitchArgs) -> Result<()> {
+    let connection = tokio::time::timeout(CONNECT_TIMEOUT, client::connect())
+        .await
+        .context("timed out connecting to the OpenLogi agent")?
+        .context("could not connect to the running OpenLogi agent")?;
+    if connection.version != PROTOCOL_VERSION {
+        bail!(
+            "the agent speaks protocol v{}, but this CLI expects v{PROTOCOL_VERSION}; restart OpenLogi so both binaries match",
+            connection.version
+        );
+    }
+
+    tokio::time::timeout(
+        CONNECT_TIMEOUT,
+        connection
+            .client
+            .declare_client(context::current(), ClientKind::Cli),
+    )
+    .await
+    .context("timed out declaring the CLI to the OpenLogi agent")?
+    .context("the OpenLogi agent dropped the CLI declaration")?;
+
+    let snapshot = tokio::time::timeout(
+        SNAPSHOT_TIMEOUT,
+        connection.client.snapshot(context::current()),
+    )
+    .await
+    .context("timed out reading the OpenLogi agent's device inventory")?
+    .context("the OpenLogi agent dropped the inventory request")?;
+    let (route, name) = select_inventory_device(snapshot.inventory, &args.device)?;
+
+    let result = tokio::time::timeout(
+        SWITCH_TIMEOUT,
+        connection
+            .client
+            .switch_host(context::current(), route.clone(), args.host),
+    )
+    .await
+    .context("timed out waiting for the OpenLogi agent's host-switch result")?
+    .context("the OpenLogi agent dropped the host-switch request")?;
+    result.with_context(|| {
+        format!(
+            "could not switch {name} ({route}) to zero-based host {}",
+            args.host
+        )
+    })?;
+
+    println!(
+        "Host switch command completed for {name} ({route}) to zero-based host {}.",
+        args.host
+    );
+    println!(
+        "The ChangeHost write is fire-and-forget; this does not confirm arrival at the destination."
+    );
+    Ok(())
+}

--- a/crates/openlogi-cli/src/lib.rs
+++ b/crates/openlogi-cli/src/lib.rs
@@ -191,4 +191,29 @@ mod tests {
             other => panic!("expected Diag(Wheel), got {other:?}"),
         }
     }
+
+    #[test]
+    fn host_switch_requires_a_device_and_maps_the_zero_based_host() {
+        Cli::try_parse_from(["openlogi", "diag", "host-switch", "--host", "1"])
+            .expect_err("host-switch without --device must be rejected");
+
+        let cli = Cli::try_parse_from([
+            "openlogi",
+            "diag",
+            "host-switch",
+            "--device",
+            "MX Master 3S",
+            "--host",
+            "1",
+        ])
+        .expect("valid host-switch invocation parses");
+
+        match cli.cmd.expect("subcommand present") {
+            Command::Diag(DiagCmd::HostSwitch(args)) => {
+                assert_eq!(args.device, "MX Master 3S");
+                assert_eq!(args.host, 1);
+            }
+            other => panic!("expected Diag(HostSwitch), got {other:?}"),
+        }
+    }
 }

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -50,7 +50,8 @@ pub use pairing::{
 };
 pub use session::gesture::{CaptureChannel, CapturedInput, GestureError, run_capture_session};
 pub use session::host_switch::{
-    HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
+    HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_host_on,
+    switch_linked_hosts,
 };
 pub use session::keyboard::{
     KEYBOARD_KEY_CIDS, run_keyboard_capture_session, run_keyboard_capture_session_with_registry,

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -26,7 +26,7 @@ use tokio::{
 use tracing::{debug, info};
 
 use crate::{
-    ChannelPool, DeviceRoute,
+    ChannelPool, DeviceRoute, SharedChannel,
     backend::BackendError,
     reprog_controls::{self, ReprogControlsV4},
 };
@@ -81,6 +81,9 @@ pub enum HostSwitchError {
     /// A required HID++ operation failed.
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
+    /// The device does not expose the ChangeHost feature.
+    #[error("device does not expose HID++ ChangeHost feature 0x1814")]
+    FeatureUnsupported,
     /// A required HID++ operation did not complete within its budget.
     #[error("HID++ operation timed out while {operation}")]
     TimedOut {
@@ -96,6 +99,14 @@ pub enum HostSwitchError {
     HostSlotEmpty {
         /// The zero-based host slot that has no pairing.
         host: u8,
+    },
+    /// The requested host does not exist on this device.
+    #[error("host {host} is outside device host count {host_count}")]
+    HostOutOfRange {
+        /// The zero-based host slot that was requested.
+        host: u8,
+        /// Number of host slots reported by the device.
+        host_count: u8,
     },
 }
 
@@ -202,6 +213,19 @@ pub async fn switch_linked_hosts(
         debug!(host, route = %keyboard, "keyboard host switched");
     }
     Ok(changed)
+}
+
+/// Switch one device on an already-open shared channel to the zero-based `host`.
+///
+/// The device's reported host count is validated before writing, and an
+/// explicitly empty slot is refused when the optional HostsInfo feature can
+/// report one. A `true` result means the fire-and-forget write was issued; it
+/// cannot confirm that the device arrived at the destination because the
+/// device leaves this channel as soon as the write takes effect. `false`
+/// means the device already reported `host` as current, so no write was needed.
+pub async fn switch_host_on(shared: &SharedChannel, host: u8) -> Result<bool, HostSwitchError> {
+    let change = prepare_host_change_on(shared.channel(), shared.device_index(), host).await?;
+    apply_host_change(change).await
 }
 
 async fn arm_host_controls(
@@ -363,7 +387,7 @@ async fn prepare_host_change_on(
         device.root().get_feature(ChangeHostFeature::ID),
     )
     .await?
-    .ok_or_else(|| HostSwitchError::Hidpp("ChangeHost is unsupported".into()))?;
+    .ok_or(HostSwitchError::FeatureUnsupported)?;
     let change_host = device.add_feature::<ChangeHostFeature>(info.index);
     let state = timed_hidpp("reading current host", change_host.get_host_info()).await?;
     let required = host_change_required(state.current_host, state.host_count, host)?;
@@ -468,9 +492,10 @@ fn host_change_required(
     requested_host: u8,
 ) -> Result<bool, HostSwitchError> {
     if requested_host >= host_count {
-        return Err(HostSwitchError::Hidpp(format!(
-            "host {requested_host} is outside device host count {host_count}"
-        )));
+        return Err(HostSwitchError::HostOutOfRange {
+            host: requested_host,
+            host_count,
+        });
     }
     Ok(current_host != requested_host)
 }
@@ -523,7 +548,7 @@ mod tests {
 
     use super::{
         ArmedControl, HostSwitchError, ReportingMode, event_host, host_change_required,
-        host_channel, prepare_host_change_on, restoration_change, shares_channel,
+        host_channel, prepare_host_change_on, restoration_change, shares_channel, switch_host_on,
     };
     use crate::DeviceRoute;
     use crate::channel::scripted::{ScriptedRawHidChannel, feature_error};
@@ -646,6 +671,32 @@ mod tests {
             .expect("a paired slot must be switchable");
 
         assert!(change.required, "host 1 differs from the current host 0");
+    }
+
+    #[tokio::test]
+    async fn switching_one_device_issues_the_fire_and_forget_write() {
+        let (raw, handle) =
+            ScriptedRawHidChannel::with_responder(keyboard_with_an_empty_third_slot);
+        let channel = crate::channel::scripted::scripted_channel(raw).await;
+        let shared = crate::SharedChannel::new(
+            channel,
+            DeviceRoute::Bolt {
+                receiver_uid: "AABB".into(),
+                slot: 1,
+            },
+        );
+
+        let changed = switch_host_on(&shared, 1)
+            .await
+            .expect("a paired slot must be switchable");
+
+        assert!(changed);
+        assert!(handle.written_reports().iter().any(|report| {
+            report.len() >= 5
+                && report[2] == CHANGE_HOST_INDEX
+                && report[3] >> 4 == 1
+                && report[4] == 1
+        }));
     }
 
     #[tokio::test]
@@ -781,10 +832,15 @@ mod tests {
 
     #[test]
     fn host_outside_device_range_is_rejected() {
-        assert!(
-            host_change_required(0, 2, 2).is_err(),
-            "host 2 is outside a device that reports 2 hosts and must be rejected"
-        );
+        let error = host_change_required(0, 2, 2).expect_err("host 2 must be rejected");
+
+        assert!(matches!(
+            error,
+            HostSwitchError::HostOutOfRange {
+                host: 2,
+                host_count: 2
+            }
+        ));
     }
 
     #[test]

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -61,7 +61,9 @@ pub use succession::Identity;
 /// v28: `Action::HoldShortcut` appended for lifecycle-held keyboard output.
 /// v29: `Agent::declare_client` + [`ClientKind`] appended — typed demand for
 ///      the macOS dormancy gate.
-pub const PROTOCOL_VERSION: u32 = 29;
+/// v30: `Agent::switch_host` + [`SwitchHostError`] appended — software-initiated
+///      multi-host device switching.
+pub const PROTOCOL_VERSION: u32 = 30;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -419,6 +421,55 @@ pub enum ActionRingCommandError {
     SlotEmpty,
 }
 
+/// Why [`Agent::switch_host`] could not issue a device host switch.
+///
+/// A successful call means either the device was already on the requested
+/// host or its fire-and-forget ChangeHost write was issued. It cannot confirm
+/// arrival because a switching device leaves the sender's radio channel.
+///
+/// Variants are append-only because this enum crosses bincode IPC.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]
+pub enum SwitchHostError {
+    /// No currently connected device matched the requested route.
+    #[error("no connected device matched the route")]
+    DeviceNotFound,
+    /// The device does not expose the HID++ ChangeHost feature.
+    #[error("device does not expose HID++ ChangeHost feature 0x1814")]
+    FeatureUnsupported,
+    /// The requested zero-based host index is outside the device's host count.
+    #[error("host {host} is outside device host count {host_count}")]
+    HostOutOfRange {
+        /// The zero-based host slot that was requested.
+        host: u8,
+        /// Number of host slots reported by the device.
+        host_count: u8,
+    },
+    /// The device explicitly reports that the requested host slot is unpaired.
+    #[error("host {host} is not paired on this device")]
+    HostSlotEmpty {
+        /// The zero-based host slot that has no pairing.
+        host: u8,
+    },
+    /// HID transport-level failure serialized as text.
+    #[error("HID transport error: {message}")]
+    Hid {
+        /// Transport error detail.
+        message: String,
+    },
+    /// HID++ protocol failure serialized as text.
+    #[error("HID++ protocol error: {message}")]
+    Hidpp {
+        /// Protocol error detail, including the failed operation.
+        message: String,
+    },
+    /// A required HID++ operation exceeded its time budget.
+    #[error("HID++ operation timed out while {operation}")]
+    TimedOut {
+        /// Description of the operation that exceeded its budget.
+        operation: String,
+    },
+}
+
 /// What kind of client a connection is, declared through
 /// [`Agent::declare_client`] right after the version handshake.
 ///
@@ -560,4 +611,12 @@ pub trait Agent {
     /// arms only on [`ClientKind::Gui`]. The takeover probe never declares —
     /// it speaks only [`Agent::protocol_version`] — and so never arms.
     async fn declare_client(kind: ClientKind);
+    /// Switch `route` to the zero-based host slot `host` through HID++
+    /// ChangeHost (`0x1814`). The agent validates the device-reported host
+    /// count and, when available, rejects a slot reported as unpaired.
+    ///
+    /// A successful fire-and-forget write means the command was issued, not
+    /// that the device arrived: once it takes effect, this host is blind to the
+    /// device because its radio link has moved.
+    async fn switch_host(route: DeviceRoute, host: u8) -> Result<(), SwitchHostError>;
 }

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -47,7 +47,7 @@ use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, ActionRingPresentation, AgentRequest,
     AgentSnapshot, AgentStatus, ClientKind, ConfigReloadError, ForegroundApps, FoundDevice,
     Identity, InventoryHealth, MonitorEvent, Observation, PROTOCOL_VERSION, PairingCommandError,
-    PairingFailure, PairingPhase, PairingUpdate, RingObservation,
+    PairingFailure, PairingPhase, PairingUpdate, RingObservation, SwitchHostError,
 };
 use succession::{Compat, Run};
 
@@ -101,7 +101,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 29);
+    assert_eq!(PROTOCOL_VERSION, 30);
 }
 
 #[test]
@@ -205,6 +205,48 @@ fn request_variant_order() {
             kind: ClientKind::Overlay,
         },
         "1902",
+    );
+    assert_wire(
+        &AgentRequest::SwitchHost {
+            route: DeviceRoute::Bolt {
+                receiver_uid: "F00DCAFE".into(),
+                slot: 1,
+            },
+            host: 2,
+        },
+        "1a000846303044434146450102",
+    );
+}
+
+#[test]
+fn switch_host_errors() {
+    assert_wire(&SwitchHostError::DeviceNotFound, "00");
+    assert_wire(&SwitchHostError::FeatureUnsupported, "01");
+    assert_wire(
+        &SwitchHostError::HostOutOfRange {
+            host: 2,
+            host_count: 2,
+        },
+        "020202",
+    );
+    assert_wire(&SwitchHostError::HostSlotEmpty { host: 2 }, "0302");
+    assert_wire(
+        &SwitchHostError::Hid {
+            message: "gone".into(),
+        },
+        "0404676f6e65",
+    );
+    assert_wire(
+        &SwitchHostError::Hidpp {
+            message: "busy".into(),
+        },
+        "050462757379",
+    );
+    assert_wire(
+        &SwitchHostError::TimedOut {
+            operation: "reading current host".into(),
+        },
+        "061472656164696e672063757272656e7420686f7374",
     );
 }
 


### PR DESCRIPTION
## Summary

Layer 3 of the Flow stack, on top of #1101. Expose software-initiated Easy-Switch through the device layer, agent IPC, and a diagnostic CLI command.

## Changes

- `openlogi-device`: select and switch a single device to a paired HID++ host slot.
- `openlogi-ipc`: append the host-switch request and typed errors; bump the wire protocol from v29 to v30 and update golden bytes.
- `openlogi-agent`: route the request through the agent-owned HID session and mock server.
- `openlogi-cli`: add `openlogi diag host-switch` for explicit device/host diagnostics.

## Testing

Run on the fully integrated stack tip:

- `RUSTFLAGS='-D warnings' cargo test --workspace` — includes host-switch unit coverage and 16/16 IPC wire-format tests.
- `RUSTFLAGS='-D warnings' cargo clippy --target x86_64-pc-windows-gnu -p openlogi-hook -p openlogi-inject -p openlogi-agent-core -p openlogi-agent -p openlogi-device -p openlogi-hid -p openlogi-ipc --all-targets -- -D warnings`
- `cargo xtask ci` — 11 passed, 0 failed, 1 skipped (`tests (macos)`)

Not runtime-tested with real Easy-Switch hardware. A successful sender-side call means the HID++ write was issued; receiver-side arrival evidence is added by the top integration layer.

Relates to #650
Part of #253

Co-authored-by: Xuan Zhang <xuan@arcbox.dev>