### PR TITLE
feat(hook): add platform-neutral Flow edge detection

### DIFF
--- a/crates/openlogi-hook/src/edge.rs
+++ b/crates/openlogi-hook/src/edge.rs
@@ -1,0 +1,35 @@
+//! Platform-neutral screen-edge geometry for Flow.
+//!
+//! Platform code supplies display rectangles; this module computes the exposed
+//! handoff edges. It performs no display enumeration or input I/O.
+
+mod geometry;
+
+pub use geometry::{DisplayGeometryProvider, DisplayRect, EdgeSegment, ExposedEdges};
+
+/// A side of a display in a coordinate space where x increases rightward and y
+/// increases downward.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EdgeSide {
+    /// The minimum-x side.
+    Left,
+    /// The maximum-x side.
+    Right,
+    /// The minimum-y side.
+    Top,
+    /// The maximum-y side.
+    Bottom,
+}
+
+impl EdgeSide {
+    pub(super) const ALL: [Self; 4] = [Self::Left, Self::Right, Self::Top, Self::Bottom];
+
+    pub(super) const fn index(self) -> usize {
+        match self {
+            Self::Left => 0,
+            Self::Right => 1,
+            Self::Top => 2,
+            Self::Bottom => 3,
+        }
+    }
+}

--- a/crates/openlogi-hook/src/edge.rs
+++ b/crates/openlogi-hook/src/edge.rs
@@ -1,10 +1,13 @@
-//! Platform-neutral screen-edge geometry for Flow.
+//! Platform-neutral screen-edge geometry and crossing detection for Flow.
 //!
-//! Platform code supplies display rectangles; this module computes the exposed
-//! handoff edges. It performs no display enumeration or input I/O.
+//! Platform code supplies display rectangles and timestamped cursor positions;
+//! this module computes the handoff edges and turns a sustained or fast approach
+//! into one crossing event. It performs no display enumeration or input I/O.
 
+mod detector;
 mod geometry;
 
+pub use detector::{ArmedSides, EdgeCrossing, EdgeDetector, EdgeDetectorParams, Velocity};
 pub use geometry::{DisplayGeometryProvider, DisplayRect, EdgeSegment, ExposedEdges};
 
 /// A side of a display in a coordinate space where x increases rightward and y

--- a/crates/openlogi-hook/src/edge/detector.rs
+++ b/crates/openlogi-hook/src/edge/detector.rs
@@ -1,0 +1,387 @@
+use std::cmp::Ordering;
+use std::time::Duration;
+
+use crate::CursorPosition;
+
+use super::{EdgeSegment, EdgeSide, ExposedEdges};
+
+/// Set of display sides enabled for Flow handoff.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ArmedSides(u8);
+
+impl ArmedSides {
+    /// No sides armed.
+    pub const NONE: Self = Self(0);
+    /// Every side armed.
+    pub const ALL: Self = Self(0b1111);
+
+    /// Construct a set from side values.
+    #[must_use]
+    pub fn from_sides(sides: impl IntoIterator<Item = EdgeSide>) -> Self {
+        sides
+            .into_iter()
+            .fold(Self::NONE, |set, side| Self(set.0 | (1 << side.index())))
+    }
+
+    /// Whether one side is armed.
+    #[must_use]
+    pub const fn contains(self, side: EdgeSide) -> bool {
+        self.0 & (1 << side.index()) != 0
+    }
+}
+
+/// Cursor velocity in logical pixels per second.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Velocity {
+    /// Horizontal velocity; positive points right.
+    pub x: f64,
+    /// Vertical velocity; positive points down.
+    pub y: f64,
+}
+
+impl EdgeSide {
+    fn outward_velocity(self, velocity: Velocity) -> f64 {
+        match self {
+            Self::Left => -velocity.x,
+            Self::Right => velocity.x,
+            Self::Top => -velocity.y,
+            Self::Bottom => velocity.y,
+        }
+    }
+}
+
+/// One screen-edge crossing reported to the Flow orchestrator.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EdgeCrossing {
+    /// Exiting side.
+    pub side: EdgeSide,
+    /// Position in `0..=1` over the cumulative exposed length of this side.
+    ///
+    /// Disconnected segments are traversed in [`ExposedEdges::for_side`] order;
+    /// physical gaps consume no range. A receiver can apply the same cumulative
+    /// length rule to map this value proportionally onto its own exposed segments.
+    pub t: f64,
+    /// Finite-difference velocity when this approach first touched the edge.
+    pub velocity: Velocity,
+}
+
+/// Tunable thresholds for [`EdgeDetector`].
+///
+/// Distance and speed fields are expected to be finite and non-negative. A
+/// zero dwell or velocity threshold permits immediate contact triggering; a
+/// zero cooldown disables rate limiting.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EdgeDetectorParams {
+    /// Maximum normal distance from a segment that counts as edge contact.
+    /// Default: 1 logical pixel.
+    pub edge_tolerance: f64,
+    /// Continuous edge contact required for a low-speed crossing.
+    /// Default: 250 ms.
+    pub dwell_time: Duration,
+    /// Outward approach velocity that triggers immediately, in logical pixels
+    /// per second. Default: 900 px/s.
+    pub arrival_velocity_threshold: f64,
+    /// Distance from every armed exposed segment required before another
+    /// approach can trigger. Default: 12 logical pixels.
+    pub rearm_distance: f64,
+    /// Minimum interval between crossing events, even after leaving the edge.
+    /// Default: 500 ms.
+    pub cooldown: Duration,
+}
+
+impl Default for EdgeDetectorParams {
+    fn default() -> Self {
+        Self {
+            edge_tolerance: 1.0,
+            dwell_time: Duration::from_millis(250),
+            arrival_velocity_threshold: 900.0,
+            rearm_distance: 12.0,
+            cooldown: Duration::from_millis(500),
+        }
+    }
+}
+
+/// Stateful detector that turns timestamped cursor samples into edge crossings.
+///
+/// Timestamps are durations from any monotonic caller-owned epoch. A fast
+/// outward arrival or a continuous dwell triggers. Afterward, the detector
+/// remains latched until the cursor moves at least `rearm_distance` from every
+/// armed edge; `cooldown` independently limits event frequency.
+pub struct EdgeDetector {
+    edges: ExposedEdges,
+    armed_sides: ArmedSides,
+    params: EdgeDetectorParams,
+    previous: Option<TimedPosition>,
+    contact: Option<Contact>,
+    latched: bool,
+    last_crossing: Option<Duration>,
+}
+
+impl EdgeDetector {
+    /// Construct a detector for one display layout and configured side set.
+    #[must_use]
+    pub const fn new(
+        edges: ExposedEdges,
+        armed_sides: ArmedSides,
+        params: EdgeDetectorParams,
+    ) -> Self {
+        Self {
+            edges,
+            armed_sides,
+            params,
+            previous: None,
+            contact: None,
+            latched: false,
+            last_crossing: None,
+        }
+    }
+
+    /// Replace display geometry after a platform reconfiguration notification.
+    ///
+    /// Any in-progress contact is discarded; a prior crossing's latch and
+    /// cooldown are retained so refreshing unchanged bounds cannot retrigger
+    /// while the cursor remains pinned.
+    pub fn set_edges(&mut self, edges: ExposedEdges) {
+        self.edges = edges;
+        self.previous = None;
+        self.contact = None;
+    }
+
+    /// Consume one cursor sample and return at most one crossing.
+    ///
+    /// At a corner, an existing contact remains selected. A new contact chooses
+    /// the side with the greater outward velocity; an exact tie uses the stable
+    /// priority Left, Right, Top, Bottom.
+    pub fn update(
+        &mut self,
+        position: CursorPosition,
+        timestamp: Duration,
+    ) -> Option<EdgeCrossing> {
+        let velocity = self
+            .previous
+            .and_then(|previous| velocity_between(previous, position, timestamp))
+            .unwrap_or_default();
+        self.previous = Some(TimedPosition {
+            position,
+            timestamp,
+        });
+
+        if self.latched {
+            if !is_near_armed_edge(
+                &self.edges,
+                position,
+                self.params.rearm_distance,
+                self.armed_sides,
+            ) {
+                self.latched = false;
+            }
+            self.contact = None;
+            return None;
+        }
+
+        let candidates = candidates(
+            &self.edges,
+            position,
+            self.params.edge_tolerance,
+            self.armed_sides,
+        );
+        let preferred_segment = self.contact.map(|contact| contact.segment_index);
+        let Some(candidate) = select_candidate(&candidates, preferred_segment, velocity) else {
+            self.contact = None;
+            return None;
+        };
+
+        let is_new_contact = self
+            .contact
+            .is_none_or(|contact| contact.segment_index != candidate.segment_index);
+        if is_new_contact {
+            self.contact = Some(Contact {
+                segment_index: candidate.segment_index,
+                started_at: timestamp,
+                approach_velocity: velocity,
+            });
+        }
+        let contact = self.contact?;
+        let dwell_reached = timestamp
+            .checked_sub(contact.started_at)
+            .is_some_and(|elapsed| elapsed >= self.params.dwell_time);
+        let fast_arrival = is_new_contact
+            && candidate.side.outward_velocity(contact.approach_velocity)
+                >= self.params.arrival_velocity_threshold;
+        let cooldown_finished = self.last_crossing.is_none_or(|last_crossing| {
+            timestamp
+                .checked_sub(last_crossing)
+                .is_some_and(|elapsed| elapsed >= self.params.cooldown)
+        });
+        if !(cooldown_finished && (fast_arrival || dwell_reached)) {
+            return None;
+        }
+
+        let crossing = EdgeCrossing {
+            side: candidate.side,
+            t: normalized_position(&self.edges, candidate.segment_index, position),
+            velocity: contact.approach_velocity,
+        };
+        self.contact = None;
+        self.latched = true;
+        self.last_crossing = Some(timestamp);
+        Some(crossing)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TimedPosition {
+    position: CursorPosition,
+    timestamp: Duration,
+}
+
+fn velocity_between(
+    previous: TimedPosition,
+    position: CursorPosition,
+    timestamp: Duration,
+) -> Option<Velocity> {
+    let seconds = timestamp.checked_sub(previous.timestamp)?.as_secs_f64();
+    (seconds > 0.0).then_some(Velocity {
+        x: (position.x - previous.position.x) / seconds,
+        y: (position.y - previous.position.y) / seconds,
+    })
+}
+
+#[derive(Clone, Copy)]
+struct Contact {
+    segment_index: usize,
+    started_at: Duration,
+    approach_velocity: Velocity,
+}
+
+#[derive(Clone, Copy)]
+struct Candidate {
+    segment_index: usize,
+    side: EdgeSide,
+    normal_distance: f64,
+}
+
+fn candidates(
+    edges: &ExposedEdges,
+    position: CursorPosition,
+    tolerance: f64,
+    armed_sides: ArmedSides,
+) -> Vec<Candidate> {
+    edges
+        .segments()
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|(_, segment)| {
+            armed_sides.contains(segment.side())
+                && contains_with_tolerance(*segment, position, tolerance)
+        })
+        .map(|(segment_index, segment)| Candidate {
+            segment_index,
+            side: segment.side(),
+            normal_distance: (normal_coordinate(segment, position) - segment.coordinate()).abs(),
+        })
+        .collect()
+}
+
+fn select_candidate(
+    candidates: &[Candidate],
+    preferred_segment: Option<usize>,
+    velocity: Velocity,
+) -> Option<Candidate> {
+    if let Some(preferred) = preferred_segment
+        && let Some(candidate) = candidates
+            .iter()
+            .find(|candidate| candidate.segment_index == preferred)
+    {
+        return Some(*candidate);
+    }
+
+    candidates.iter().copied().min_by(|left, right| {
+        let left_outward = left.side.outward_velocity(velocity).max(0.0);
+        let right_outward = right.side.outward_velocity(velocity).max(0.0);
+        match right_outward.total_cmp(&left_outward) {
+            Ordering::Equal => left
+                .side
+                .index()
+                .cmp(&right.side.index())
+                .then_with(|| left.normal_distance.total_cmp(&right.normal_distance))
+                .then_with(|| left.segment_index.cmp(&right.segment_index)),
+            ordering => ordering,
+        }
+    })
+}
+
+fn normalized_position(
+    edges: &ExposedEdges,
+    segment_index: usize,
+    position: CursorPosition,
+) -> f64 {
+    let segment = edges.segments()[segment_index];
+    let total_length: f64 = edges
+        .for_side(segment.side())
+        .copied()
+        .map(segment_length)
+        .sum();
+    let preceding_length: f64 = edges.segments()[..segment_index]
+        .iter()
+        .copied()
+        .filter(|part| part.side() == segment.side())
+        .map(segment_length)
+        .sum();
+    let local =
+        along_coordinate(segment, position).clamp(segment.start(), segment.end()) - segment.start();
+    ((preceding_length + local) / total_length).clamp(0.0, 1.0)
+}
+
+fn is_near_armed_edge(
+    edges: &ExposedEdges,
+    position: CursorPosition,
+    distance: f64,
+    armed_sides: ArmedSides,
+) -> bool {
+    edges.segments().iter().copied().any(|segment| {
+        armed_sides.contains(segment.side()) && distance_to(segment, position) < distance
+    })
+}
+
+fn segment_length(segment: EdgeSegment) -> f64 {
+    segment.end() - segment.start()
+}
+
+fn along_coordinate(segment: EdgeSegment, position: CursorPosition) -> f64 {
+    match segment.side() {
+        EdgeSide::Left | EdgeSide::Right => position.y,
+        EdgeSide::Top | EdgeSide::Bottom => position.x,
+    }
+}
+
+fn normal_coordinate(segment: EdgeSegment, position: CursorPosition) -> f64 {
+    match segment.side() {
+        EdgeSide::Left | EdgeSide::Right => position.x,
+        EdgeSide::Top | EdgeSide::Bottom => position.y,
+    }
+}
+
+fn contains_with_tolerance(segment: EdgeSegment, position: CursorPosition, tolerance: f64) -> bool {
+    let along = along_coordinate(segment, position);
+    (normal_coordinate(segment, position) - segment.coordinate()).abs() <= tolerance
+        && along >= segment.start()
+        && along <= segment.end()
+}
+
+fn distance_to(segment: EdgeSegment, position: CursorPosition) -> f64 {
+    let normal = (normal_coordinate(segment, position) - segment.coordinate()).abs();
+    let along = along_coordinate(segment, position);
+    let along_distance = if along < segment.start() {
+        segment.start() - along
+    } else if along > segment.end() {
+        along - segment.end()
+    } else {
+        0.0
+    };
+    normal.hypot(along_distance)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-hook/src/edge/detector/tests.rs
+++ b/crates/openlogi-hook/src/edge/detector/tests.rs
@@ -1,0 +1,317 @@
+use super::*;
+use crate::edge::DisplayRect;
+
+fn rect(x: f64, y: f64, width: f64, height: f64) -> DisplayRect {
+    DisplayRect::new(x, y, width, height).expect("test rectangles are valid")
+}
+
+fn point(x: f64, y: f64) -> CursorPosition {
+    CursorPosition { x, y }
+}
+
+fn assert_near(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1e-9,
+        "expected {expected}, got {actual}"
+    );
+}
+
+fn dwell_params() -> EdgeDetectorParams {
+    EdgeDetectorParams {
+        dwell_time: Duration::from_millis(100),
+        arrival_velocity_threshold: 10_000.0,
+        cooldown: Duration::from_millis(500),
+        ..EdgeDetectorParams::default()
+    }
+}
+
+#[test]
+fn defaults_define_dwell_velocity_hysteresis_and_cooldown() {
+    let params = EdgeDetectorParams::default();
+
+    assert_near(params.edge_tolerance, 1.0);
+    assert_eq!(params.dwell_time, Duration::from_millis(250));
+    assert_near(params.arrival_velocity_threshold, 900.0);
+    assert_near(params.rearm_distance, 12.0);
+    assert_eq!(params.cooldown, Duration::from_millis(500));
+}
+
+#[test]
+fn normalization_uses_cumulative_exposed_length_and_skips_gaps() {
+    let edges = ExposedEdges::from_displays(&[
+        rect(0.0, 0.0, 100.0, 100.0),
+        rect(0.0, 200.0, 100.0, 100.0),
+    ]);
+    let mut detector = EdgeDetector::new(
+        edges,
+        ArmedSides::from_sides([EdgeSide::Left]),
+        EdgeDetectorParams {
+            arrival_velocity_threshold: 1.0,
+            ..EdgeDetectorParams::default()
+        },
+    );
+
+    assert!(
+        detector
+            .update(point(10.0, 250.0), Duration::ZERO)
+            .is_none()
+    );
+    let crossing = detector
+        .update(point(0.0, 250.0), Duration::from_millis(10))
+        .expect("fast arrival should cross");
+
+    assert_near(crossing.t, 0.75);
+}
+
+#[test]
+fn unarmed_side_never_starts_a_crossing() {
+    let edges = ExposedEdges::from_displays(&[rect(0.0, 0.0, 100.0, 100.0)]);
+    let mut detector = EdgeDetector::new(
+        edges,
+        ArmedSides::from_sides([EdgeSide::Right]),
+        EdgeDetectorParams {
+            dwell_time: Duration::ZERO,
+            ..EdgeDetectorParams::default()
+        },
+    );
+
+    assert!(detector.update(point(0.0, 50.0), Duration::ZERO).is_none());
+}
+
+#[test]
+fn fast_arrival_reports_side_position_and_velocity() {
+    let edges = ExposedEdges::from_displays(&[rect(0.0, 0.0, 100.0, 100.0)]);
+    let mut detector = EdgeDetector::new(
+        edges,
+        ArmedSides::from_sides([EdgeSide::Left]),
+        EdgeDetectorParams {
+            arrival_velocity_threshold: 900.0,
+            ..EdgeDetectorParams::default()
+        },
+    );
+
+    assert!(detector.update(point(10.0, 25.0), Duration::ZERO).is_none());
+    let crossing = detector
+        .update(point(0.0, 50.0), Duration::from_millis(10))
+        .expect("1,000 px/s outward arrival should cross");
+
+    assert_eq!(crossing.side, EdgeSide::Left);
+    assert_near(crossing.t, 0.5);
+    assert_near(crossing.velocity.x, -1_000.0);
+    assert_near(crossing.velocity.y, 2_500.0);
+}
+
+#[test]
+fn dwell_triggers_once_and_edge_jitter_does_not_retrigger() {
+    let edges = ExposedEdges::from_displays(&[rect(0.0, 0.0, 100.0, 100.0)]);
+    let mut detector = EdgeDetector::new(edges, ArmedSides::ALL, dwell_params());
+
+    assert!(detector.update(point(0.0, 40.0), Duration::ZERO).is_none());
+    assert!(
+        detector
+            .update(point(0.5, 40.0), Duration::from_millis(99))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 40.0), Duration::from_millis(100))
+            .is_some()
+    );
+    assert!(
+        detector
+            .update(point(0.5, 40.0), Duration::from_millis(700))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 40.0), Duration::from_millis(1_500))
+            .is_none()
+    );
+}
+
+#[test]
+fn hysteresis_and_cooldown_both_gate_a_second_approach() {
+    let edges = ExposedEdges::from_displays(&[rect(0.0, 0.0, 100.0, 100.0)]);
+    let mut detector = EdgeDetector::new(edges, ArmedSides::ALL, dwell_params());
+
+    assert!(detector.update(point(0.0, 50.0), Duration::ZERO).is_none());
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(100))
+            .is_some()
+    );
+
+    // Five pixels is inside the 12 px hysteresis band, so this does not re-arm.
+    assert!(
+        detector
+            .update(point(5.0, 50.0), Duration::from_millis(150))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(300))
+            .is_none()
+    );
+
+    // Leaving the band re-arms, but the 500 ms cooldown still applies.
+    assert!(
+        detector
+            .update(point(20.0, 50.0), Duration::from_millis(350))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(400))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(500))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(600))
+            .is_some()
+    );
+}
+
+#[test]
+fn leaving_hysteresis_band_rearms_fast_arrival() {
+    let edges = ExposedEdges::from_displays(&[rect(0.0, 0.0, 100.0, 100.0)]);
+    let mut detector = EdgeDetector::new(
+        edges,
+        ArmedSides::from_sides([EdgeSide::Right]),
+        EdgeDetectorParams {
+            arrival_velocity_threshold: 500.0,
+            cooldown: Duration::from_millis(200),
+            ..EdgeDetectorParams::default()
+        },
+    );
+
+    assert!(detector.update(point(90.0, 50.0), Duration::ZERO).is_none());
+    assert!(
+        detector
+            .update(point(100.0, 50.0), Duration::from_millis(10))
+            .is_some()
+    );
+    assert!(
+        detector
+            .update(point(80.0, 50.0), Duration::from_millis(20))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(90.0, 50.0), Duration::from_millis(210))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(100.0, 50.0), Duration::from_millis(220))
+            .is_some()
+    );
+}
+
+#[test]
+fn corner_prefers_greater_outward_velocity() {
+    let edges = ExposedEdges::from_displays(&[rect(0.0, 0.0, 100.0, 100.0)]);
+    let mut detector = EdgeDetector::new(
+        edges,
+        ArmedSides::ALL,
+        EdgeDetectorParams {
+            arrival_velocity_threshold: 500.0,
+            ..EdgeDetectorParams::default()
+        },
+    );
+
+    assert!(detector.update(point(10.0, 20.0), Duration::ZERO).is_none());
+    let crossing = detector
+        .update(point(0.0, 0.0), Duration::from_millis(10))
+        .expect("corner arrival should cross");
+
+    assert_eq!(crossing.side, EdgeSide::Top);
+    assert_near(crossing.t, 0.0);
+}
+
+#[test]
+fn corner_exact_velocity_tie_uses_left_first_priority() {
+    let edges = ExposedEdges::from_displays(&[rect(0.0, 0.0, 100.0, 100.0)]);
+    let mut detector = EdgeDetector::new(
+        edges,
+        ArmedSides::ALL,
+        EdgeDetectorParams {
+            arrival_velocity_threshold: 500.0,
+            ..EdgeDetectorParams::default()
+        },
+    );
+
+    assert!(detector.update(point(10.0, 10.0), Duration::ZERO).is_none());
+    let crossing = detector
+        .update(point(0.0, 0.0), Duration::from_millis(10))
+        .expect("corner arrival should cross");
+
+    assert_eq!(crossing.side, EdgeSide::Left);
+    assert_near(crossing.t, 0.0);
+}
+
+#[test]
+fn geometry_replacement_discards_in_progress_dwell() {
+    let display = rect(0.0, 0.0, 100.0, 100.0);
+    let mut detector = EdgeDetector::new(
+        ExposedEdges::from_displays(&[display]),
+        ArmedSides::ALL,
+        dwell_params(),
+    );
+
+    assert!(detector.update(point(0.0, 50.0), Duration::ZERO).is_none());
+    detector.set_edges(ExposedEdges::from_displays(&[display]));
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(100))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(200))
+            .is_some()
+    );
+}
+
+#[test]
+fn geometry_replacement_preserves_crossing_latch_until_rearm() {
+    let display = rect(0.0, 0.0, 100.0, 100.0);
+    let mut detector = EdgeDetector::new(
+        ExposedEdges::from_displays(&[display]),
+        ArmedSides::ALL,
+        dwell_params(),
+    );
+
+    assert!(detector.update(point(0.0, 50.0), Duration::ZERO).is_none());
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(100))
+            .is_some()
+    );
+    detector.set_edges(ExposedEdges::from_displays(&[display]));
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(700))
+            .is_none()
+    );
+
+    assert!(
+        detector
+            .update(point(20.0, 50.0), Duration::from_millis(750))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(800))
+            .is_none()
+    );
+    assert!(
+        detector
+            .update(point(0.0, 50.0), Duration::from_millis(900))
+            .is_some()
+    );
+}

--- a/crates/openlogi-hook/src/edge/geometry.rs
+++ b/crates/openlogi-hook/src/edge/geometry.rs
@@ -1,0 +1,241 @@
+use super::EdgeSide;
+
+/// A validated display rectangle in global logical-pixel coordinates.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DisplayRect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
+impl DisplayRect {
+    /// Construct a finite rectangle with positive width and height.
+    ///
+    /// Returns `None` for non-finite coordinates or non-positive dimensions.
+    #[must_use]
+    pub fn new(x: f64, y: f64, width: f64, height: f64) -> Option<Self> {
+        (x.is_finite()
+            && y.is_finite()
+            && width.is_finite()
+            && height.is_finite()
+            && width > 0.0
+            && height > 0.0)
+            .then_some(Self {
+                x,
+                y,
+                width,
+                height,
+            })
+    }
+
+    /// Minimum x coordinate.
+    #[must_use]
+    pub const fn x(self) -> f64 {
+        self.x
+    }
+
+    /// Minimum y coordinate.
+    #[must_use]
+    pub const fn y(self) -> f64 {
+        self.y
+    }
+
+    /// Rectangle width.
+    #[must_use]
+    pub const fn width(self) -> f64 {
+        self.width
+    }
+
+    /// Rectangle height.
+    #[must_use]
+    pub const fn height(self) -> f64 {
+        self.height
+    }
+
+    const fn max_x(self) -> f64 {
+        self.x + self.width
+    }
+
+    const fn max_y(self) -> f64 {
+        self.y + self.height
+    }
+
+    const fn side_span(self, side: EdgeSide) -> (f64, f64, f64) {
+        match side {
+            EdgeSide::Left => (self.x, self.y, self.max_y()),
+            EdgeSide::Right => (self.max_x(), self.y, self.max_y()),
+            EdgeSide::Top => (self.y, self.x, self.max_x()),
+            EdgeSide::Bottom => (self.max_y(), self.x, self.max_x()),
+        }
+    }
+
+    fn blocks_side(self, other: Self, side: EdgeSide) -> bool {
+        match side {
+            EdgeSide::Left => other.x < self.x && other.max_x() >= self.x,
+            EdgeSide::Right => other.x <= self.max_x() && other.max_x() > self.max_x(),
+            EdgeSide::Top => other.y < self.y && other.max_y() >= self.y,
+            EdgeSide::Bottom => other.y <= self.max_y() && other.max_y() > self.max_y(),
+        }
+    }
+
+    const fn overlap_span(other: Self, side: EdgeSide) -> (f64, f64) {
+        match side {
+            EdgeSide::Left | EdgeSide::Right => (other.y, other.max_y()),
+            EdgeSide::Top | EdgeSide::Bottom => (other.x, other.max_x()),
+        }
+    }
+}
+
+/// Integration seam for platform display enumeration.
+///
+/// Platform implementations should convert native monitor bounds into the
+/// coordinate convention used by [`DisplayRect`]. The engine itself consumes
+/// only the returned rectangles, so enumeration and reconfiguration callbacks
+/// remain outside this module.
+pub trait DisplayGeometryProvider {
+    /// Platform-specific enumeration error.
+    type Error;
+
+    /// Return the current display rectangles in global logical-pixel coordinates.
+    fn display_rects(&self) -> Result<Vec<DisplayRect>, Self::Error>;
+}
+
+/// One exposed portion of a display edge.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EdgeSegment {
+    side: EdgeSide,
+    coordinate: f64,
+    start: f64,
+    end: f64,
+}
+
+impl EdgeSegment {
+    /// Side this segment belongs to.
+    #[must_use]
+    pub const fn side(self) -> EdgeSide {
+        self.side
+    }
+
+    /// Fixed coordinate: x for left/right, y for top/bottom.
+    #[must_use]
+    pub const fn coordinate(self) -> f64 {
+        self.coordinate
+    }
+
+    /// Inclusive lower coordinate along the edge.
+    #[must_use]
+    pub const fn start(self) -> f64 {
+        self.start
+    }
+
+    /// Inclusive upper coordinate along the edge.
+    #[must_use]
+    pub const fn end(self) -> f64 {
+        self.end
+    }
+}
+
+/// Exposed per-display edge segments for one virtual desktop layout.
+///
+/// A neighboring display removes only the overlapping interval of the side it
+/// touches. Gaps remain exposed. Segments are ordered by side, then by their
+/// along-edge start and perpendicular coordinate.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ExposedEdges {
+    segments: Vec<EdgeSegment>,
+}
+
+impl ExposedEdges {
+    /// Compute exposed segments from the current display layout.
+    #[must_use]
+    pub fn from_displays(displays: &[DisplayRect]) -> Self {
+        let mut unique_displays = Vec::with_capacity(displays.len());
+        for display in displays {
+            if !unique_displays.contains(display) {
+                unique_displays.push(*display);
+            }
+        }
+
+        let mut segments = Vec::new();
+        for (display_index, display) in unique_displays.iter().copied().enumerate() {
+            for side in EdgeSide::ALL {
+                let (coordinate, start, end) = display.side_span(side);
+                let covered = unique_displays
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter(|(other_index, other)| {
+                        *other_index != display_index && display.blocks_side(*other, side)
+                    })
+                    .map(|(_, other)| DisplayRect::overlap_span(other, side));
+
+                segments.extend(exposed_intervals(start, end, covered).map(
+                    |(segment_start, segment_end)| EdgeSegment {
+                        side,
+                        coordinate,
+                        start: segment_start,
+                        end: segment_end,
+                    },
+                ));
+            }
+        }
+        segments.sort_by(|left, right| {
+            left.side
+                .index()
+                .cmp(&right.side.index())
+                .then_with(|| left.start.total_cmp(&right.start))
+                .then_with(|| left.coordinate.total_cmp(&right.coordinate))
+                .then_with(|| left.end.total_cmp(&right.end))
+        });
+        Self { segments }
+    }
+
+    /// Every exposed segment in deterministic side order.
+    #[must_use]
+    pub fn segments(&self) -> &[EdgeSegment] {
+        &self.segments
+    }
+
+    /// Exposed segments for one side, in normalization order.
+    pub fn for_side(&self, side: EdgeSide) -> impl Iterator<Item = &EdgeSegment> {
+        self.segments
+            .iter()
+            .filter(move |segment| segment.side == side)
+    }
+}
+
+fn exposed_intervals(
+    start: f64,
+    end: f64,
+    covered: impl IntoIterator<Item = (f64, f64)>,
+) -> impl Iterator<Item = (f64, f64)> {
+    let mut covered: Vec<_> = covered
+        .into_iter()
+        .map(|(covered_start, covered_end)| (covered_start.max(start), covered_end.min(end)))
+        .filter(|(covered_start, covered_end)| covered_start < covered_end)
+        .collect();
+    covered.sort_by(|left, right| left.0.total_cmp(&right.0));
+
+    let mut exposed = Vec::new();
+    let mut cursor = start;
+    for (covered_start, covered_end) in covered {
+        if covered_end <= cursor {
+            continue;
+        }
+        if covered_start > cursor {
+            exposed.push((cursor, covered_start));
+        }
+        cursor = cursor.max(covered_end);
+        if cursor >= end {
+            break;
+        }
+    }
+    if cursor < end {
+        exposed.push((cursor, end));
+    }
+    exposed.into_iter()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-hook/src/edge/geometry/tests.rs
+++ b/crates/openlogi-hook/src/edge/geometry/tests.rs
@@ -1,0 +1,124 @@
+use super::*;
+
+fn rect(x: f64, y: f64, width: f64, height: f64) -> DisplayRect {
+    DisplayRect::new(x, y, width, height).expect("test rectangles are valid")
+}
+
+fn side_segments(edges: &ExposedEdges, side: EdgeSide) -> Vec<(f64, f64, f64)> {
+    edges
+        .for_side(side)
+        .map(|segment| (segment.coordinate, segment.start, segment.end))
+        .collect()
+}
+
+#[test]
+fn display_rect_rejects_invalid_geometry() {
+    assert!(DisplayRect::new(0.0, 0.0, 100.0, 100.0).is_some());
+    assert!(DisplayRect::new(0.0, 0.0, 0.0, 100.0).is_none());
+    assert!(DisplayRect::new(0.0, 0.0, -1.0, 100.0).is_none());
+    assert!(DisplayRect::new(f64::NAN, 0.0, 100.0, 100.0).is_none());
+}
+
+#[test]
+fn single_display_exposes_all_four_sides() {
+    let edges = ExposedEdges::from_displays(&[rect(-100.0, -50.0, 200.0, 100.0)]);
+
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Left),
+        vec![(-100.0, -50.0, 50.0)]
+    );
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Right),
+        vec![(100.0, -50.0, 50.0)]
+    );
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Top),
+        vec![(-50.0, -100.0, 100.0)]
+    );
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Bottom),
+        vec![(50.0, -100.0, 100.0)]
+    );
+}
+
+#[test]
+fn side_by_side_displays_hide_shared_vertical_edges() {
+    let edges = ExposedEdges::from_displays(&[
+        rect(-100.0, 0.0, 100.0, 100.0),
+        rect(0.0, 0.0, 150.0, 100.0),
+    ]);
+
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Left),
+        vec![(-100.0, 0.0, 100.0)]
+    );
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Right),
+        vec![(150.0, 0.0, 100.0)]
+    );
+}
+
+#[test]
+fn vertically_stacked_displays_hide_shared_horizontal_edges() {
+    let edges =
+        ExposedEdges::from_displays(&[rect(0.0, -80.0, 100.0, 80.0), rect(0.0, 0.0, 100.0, 120.0)]);
+
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Top),
+        vec![(-80.0, 0.0, 100.0)]
+    );
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Bottom),
+        vec![(120.0, 0.0, 100.0)]
+    );
+}
+
+#[test]
+fn l_shape_keeps_only_uncovered_part_of_a_touching_edge() {
+    let edges = ExposedEdges::from_displays(&[
+        rect(0.0, 0.0, 100.0, 100.0),
+        rect(100.0, 50.0, 100.0, 50.0),
+    ]);
+
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Right),
+        vec![(100.0, 0.0, 50.0), (200.0, 50.0, 100.0)]
+    );
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Left),
+        vec![(0.0, 0.0, 100.0)]
+    );
+}
+
+#[test]
+fn gap_keeps_both_facing_edges_exposed() {
+    let edges = ExposedEdges::from_displays(&[
+        rect(0.0, 0.0, 100.0, 100.0),
+        rect(110.0, 0.0, 100.0, 100.0),
+    ]);
+
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Right),
+        vec![(100.0, 0.0, 100.0), (210.0, 0.0, 100.0)]
+    );
+    assert_eq!(
+        side_segments(&edges, EdgeSide::Left),
+        vec![(0.0, 0.0, 100.0), (110.0, 0.0, 100.0)]
+    );
+}
+
+#[test]
+fn overlapping_neighbors_merge_their_covered_spans() {
+    let edges = ExposedEdges::from_displays(&[
+        rect(0.0, 0.0, 100.0, 200.0),
+        rect(100.0, 25.0, 50.0, 75.0),
+        rect(100.0, 80.0, 50.0, 70.0),
+    ]);
+
+    let primary_segments: Vec<_> = edges
+        .for_side(EdgeSide::Right)
+        .filter(|segment| segment.coordinate.total_cmp(&100.0).is_eq())
+        .map(|segment| (segment.start, segment.end))
+        .collect();
+    assert_eq!(primary_segments, vec![(0.0, 25.0), (150.0, 200.0)]);
+}

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -31,6 +31,8 @@ pub use openlogi_core::app::ForegroundApp;
 pub use openlogi_core::binding::ButtonId;
 pub use openlogi_core::scroll::ScrollDelta;
 
+pub mod edge;
+
 /// Logitech's USB/Bluetooth vendor id (`0x046D`), widened from
 /// [`openlogi_core::hid::LOGITECH_VENDOR_ID`] because the hook's identity
 /// sources (IOKit, evdev) hand it back as a `u32`.


### PR DESCRIPTION
## Summary

Layer 4 of the Flow stack, on top of #1102. Add the pure geometry and state-machine engine that turns cursor movement into deliberate exposed-edge crossings.

## Changes

- Compute exposed edge segments for arbitrary multi-display layouts, including gaps, overlaps, and L-shaped arrangements.
- Detect fast arrivals and dwell crossings with velocity, hysteresis, cooldown, and one-shot latching.
- Normalize crossing position across disjoint exposed segments.
- Add exhaustive geometry and detector tests without adding platform FFI or Flow networking dependencies.

## Testing

Run on the fully integrated stack tip:

- `RUSTFLAGS='-D warnings' cargo test --workspace` — includes 61 `openlogi-hook` tests.
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- Windows GNU cross-Clippy for the affected hook/inject/agent graph.
- `cargo xtask ci` — 11 passed, 0 failed, 1 skipped (`tests (macos)`)

The engine is platform-neutral; OS display enumeration and cursor warping are added by the top integration layer.

Part of #253

Co-authored-by: Xuan Zhang <xuan@arcbox.dev>