### PR TITLE
feat(agent): integrate Flow handoff orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5565,10 +5565,14 @@ version = "0.8.1"
 dependencies = [
  "futures-lite",
  "openlogi-core",
+ "openlogi-flow",
  "openlogi-hid",
  "openlogi-hook",
  "openlogi-inject",
  "openlogi-ipc",
+ "rand 0.9.4",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5844,6 +5844,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "windows-sys 0.61.2",
+ "x11rb",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ serde_json = "1"
 toml = "0.8"
 ureq = { version = "3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
 sha2 = "0.10"
+rand = "0.9"
 atomic-write-file = "0.3.0"
 backon = { version = "1.6", default-features = false, features = ["std", "std-blocking-sleep"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/openlogi-agent-core/Cargo.toml
+++ b/crates/openlogi-agent-core/Cargo.toml
@@ -16,7 +16,10 @@ openlogi-inject = { path = "../openlogi-inject" }
 openlogi-hid = { path = "../openlogi-hid" }
 openlogi-hook = { path = "../openlogi-hook" }
 openlogi-ipc = { path = "../openlogi-ipc" }
+openlogi-flow = { path = "../openlogi-flow" }
 futures-lite = { workspace = true }
+rand = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
@@ -27,3 +30,4 @@ workspace = true
 # Only to advance virtual time in the DeviceOp/timed timeout test without a
 # real multi-second sleep.
 tokio = { workspace = true, features = ["test-util"] }
+tempfile = "3"

--- a/crates/openlogi-agent-core/src/event_monitor.rs
+++ b/crates/openlogi-agent-core/src/event_monitor.rs
@@ -189,6 +189,7 @@ mod tests {
         m.record(&MouseEvent::Moved {
             delta_x: 5,
             delta_y: 5,
+            modifiers: openlogi_hook::KeyModifiers::default(),
         });
         m.record(&MouseEvent::Button {
             id: ButtonId::Forward,

--- a/crates/openlogi-agent-core/src/flow.rs
+++ b/crates/openlogi-agent-core/src/flow.rs
@@ -1,0 +1,75 @@
+//! Agent-side bridge between Flow networking, input edges, and HID++.
+
+mod config;
+mod handoff;
+mod runtime;
+
+pub use runtime::{FlowController, FlowInputHandle};
+
+use std::collections::BTreeMap;
+
+use openlogi_core::device::DeviceKind;
+use openlogi_flow::generated as proto;
+use openlogi_flow::identity::CanonicalDeviceIdentifier;
+use openlogi_hid::DeviceRoute;
+
+/// Live local facts for one device that can participate in Flow.
+#[derive(Clone, Debug)]
+pub(crate) struct FlowDeviceSnapshot {
+    pub(crate) config_key: String,
+    pub(crate) route: Option<DeviceRoute>,
+    pub(crate) serial: Option<String>,
+    pub(crate) unit_id: [u8; 4],
+    pub(crate) kind: DeviceKind,
+    pub(crate) online: bool,
+}
+
+impl FlowDeviceSnapshot {
+    fn identity(&self) -> proto::DeviceIdentity {
+        let mut ids = Vec::with_capacity(2);
+        if let Some(serial) = self.serial.as_deref().filter(|serial| !serial.is_empty()) {
+            ids.push(CanonicalDeviceIdentifier::serial(serial).into());
+        }
+        if self.unit_id != [0; 4] {
+            ids.push(CanonicalDeviceIdentifier::unit_id(u32::from_be_bytes(self.unit_id)).into());
+        }
+        proto::DeviceIdentity {
+            ids,
+            name: self.config_key.clone(),
+            category: device_category(self.kind).into(),
+            ..Default::default()
+        }
+    }
+}
+
+fn device_category(kind: DeviceKind) -> proto::DeviceCategory {
+    match kind {
+        DeviceKind::Mouse => proto::DeviceCategory::Mouse,
+        DeviceKind::Keyboard | DeviceKind::Numpad => proto::DeviceCategory::Keyboard,
+        DeviceKind::Trackball => proto::DeviceCategory::Trackball,
+        DeviceKind::Touchpad => proto::DeviceCategory::Touchpad,
+        DeviceKind::Presenter => proto::DeviceCategory::Presenter,
+        DeviceKind::Remote
+        | DeviceKind::Tablet
+        | DeviceKind::Gamepad
+        | DeviceKind::Joystick
+        | DeviceKind::Headset
+        | DeviceKind::Camera
+        | DeviceKind::Unknown
+        | DeviceKind::Light => proto::DeviceCategory::Other,
+    }
+}
+
+fn is_pointing_device(kind: DeviceKind) -> bool {
+    matches!(
+        kind,
+        DeviceKind::Mouse | DeviceKind::Trackball | DeviceKind::Touchpad
+    )
+}
+
+#[derive(Clone, Debug)]
+struct RuntimeDevice {
+    snapshot: FlowDeviceSnapshot,
+    identity: proto::DeviceIdentity,
+    channels: BTreeMap<String, u8>,
+}

--- a/crates/openlogi-agent-core/src/flow/config.rs
+++ b/crates/openlogi-agent-core/src/flow/config.rs
@@ -1,0 +1,243 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use openlogi_core::config::{FlowConfig, FlowEdge};
+use openlogi_flow::sas::PublicKey;
+use openlogi_hook::edge::EdgeSide;
+use openlogi_ipc::{FlowLinkState, FlowPeerStatus, FlowStatus};
+use thiserror::Error;
+
+#[derive(Clone, Debug)]
+pub(super) struct CompiledFlowConfig {
+    pub(super) enabled: bool,
+    pub(super) peers: Vec<CompiledPeer>,
+    pub(super) layout: HashMap<EdgeSide, usize>,
+    pub(super) devices: BTreeMap<String, BTreeMap<String, u8>>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CompiledPeer {
+    pub(super) name: String,
+    pub(super) public_key: PublicKey,
+    pub(super) canonical_key: String,
+    pub(super) addresses: Vec<String>,
+}
+
+impl CompiledFlowConfig {
+    pub(super) fn compile(config: &FlowConfig) -> Result<Self, FlowConfigError> {
+        let mut peer_names = HashSet::new();
+        let mut peer_keys = HashSet::new();
+        let mut peers = Vec::with_capacity(config.peers.len());
+        for peer in &config.peers {
+            if peer.name.is_empty() {
+                return Err(FlowConfigError::EmptyPeerName);
+            }
+            if !peer_names.insert(peer.name.clone()) {
+                return Err(FlowConfigError::DuplicatePeerName(peer.name.clone()));
+            }
+            let public_key = parse_public_key(&peer.public_key)?;
+            if !peer_keys.insert(public_key) {
+                return Err(FlowConfigError::DuplicatePeerKey(peer.public_key.clone()));
+            }
+            peers.push(CompiledPeer {
+                name: peer.name.clone(),
+                public_key,
+                canonical_key: format_public_key(public_key),
+                addresses: peer.addresses.clone(),
+            });
+        }
+
+        let by_name: HashMap<_, _> = peers
+            .iter()
+            .enumerate()
+            .map(|(index, peer)| (peer.name.as_str(), index))
+            .collect();
+        let mut layout = HashMap::new();
+        for placement in &config.layout {
+            let side = edge_side(placement.edge);
+            let peer = by_name
+                .get(placement.peer.as_str())
+                .copied()
+                .ok_or_else(|| FlowConfigError::UnknownLayoutPeer(placement.peer.clone()))?;
+            if layout.insert(side, peer).is_some() {
+                return Err(FlowConfigError::DuplicateLayoutEdge(placement.edge));
+            }
+        }
+
+        let mut devices = BTreeMap::new();
+        for device in &config.devices {
+            if device.key.is_empty() {
+                return Err(FlowConfigError::EmptyDeviceKey);
+            }
+            if !device.peer_channels.contains_key("self") {
+                return Err(FlowConfigError::MissingSelfChannel(device.key.clone()));
+            }
+            for peer in device.peer_channels.keys().filter(|peer| *peer != "self") {
+                if !by_name.contains_key(peer.as_str()) {
+                    return Err(FlowConfigError::UnknownDevicePeer {
+                        device: device.key.clone(),
+                        peer: peer.clone(),
+                    });
+                }
+            }
+            if devices
+                .insert(device.key.clone(), device.peer_channels.clone())
+                .is_some()
+            {
+                return Err(FlowConfigError::DuplicateDevice(device.key.clone()));
+            }
+        }
+
+        Ok(Self {
+            enabled: config.enabled,
+            peers,
+            layout,
+            devices,
+        })
+    }
+
+    pub(super) fn status(&self) -> FlowStatus {
+        FlowStatus {
+            enabled: self.enabled,
+            peers: self
+                .peers
+                .iter()
+                .map(|peer| FlowPeerStatus {
+                    name: peer.name.clone(),
+                    public_key: peer.canonical_key.clone(),
+                    state: FlowLinkState::Lost,
+                })
+                .collect(),
+        }
+    }
+}
+
+pub(super) const fn edge_side(edge: FlowEdge) -> EdgeSide {
+    match edge {
+        FlowEdge::Left => EdgeSide::Left,
+        FlowEdge::Right => EdgeSide::Right,
+        FlowEdge::Top => EdgeSide::Top,
+        FlowEdge::Bottom => EdgeSide::Bottom,
+    }
+}
+
+pub(super) fn parse_public_key(value: &str) -> Result<PublicKey, FlowConfigError> {
+    let Some(hex) = value.strip_prefix("ed25519:") else {
+        return Err(FlowConfigError::InvalidPublicKey(value.to_owned()));
+    };
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(FlowConfigError::InvalidPublicKey(value.to_owned()));
+    }
+    let mut bytes = [0; 32];
+    for (index, pair) in hex.as_bytes().as_chunks::<2>().0.iter().enumerate() {
+        let pair = std::str::from_utf8(pair)
+            .map_err(|_| FlowConfigError::InvalidPublicKey(value.to_owned()))?;
+        bytes[index] = u8::from_str_radix(pair, 16)
+            .map_err(|_| FlowConfigError::InvalidPublicKey(value.to_owned()))?;
+    }
+    Ok(PublicKey::new(bytes))
+}
+
+pub(super) fn format_public_key(key: PublicKey) -> String {
+    let mut value = String::with_capacity(72);
+    value.push_str("ed25519:");
+    for byte in key.as_bytes() {
+        use std::fmt::Write as _;
+        write!(value, "{byte:02x}").unwrap_or_else(|_| unreachable!("writing to String succeeds"));
+    }
+    value
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(super) enum FlowConfigError {
+    #[error("Flow peer names must not be empty")]
+    EmptyPeerName,
+    #[error("duplicate Flow peer name {0:?}")]
+    DuplicatePeerName(String),
+    #[error("duplicate Flow peer public key {0:?}")]
+    DuplicatePeerKey(String),
+    #[error("invalid Flow public key {0:?}; expected ed25519: plus 64 lowercase hex digits")]
+    InvalidPublicKey(String),
+    #[error("Flow layout references unknown peer {0:?}")]
+    UnknownLayoutPeer(String),
+    #[error("Flow edge {0:?} is configured more than once")]
+    DuplicateLayoutEdge(FlowEdge),
+    #[error("Flow device keys must not be empty")]
+    EmptyDeviceKey,
+    #[error("duplicate Flow device {0:?}")]
+    DuplicateDevice(String),
+    #[error("Flow device {0:?} has no self channel")]
+    MissingSelfChannel(String),
+    #[error("Flow device {device:?} references unknown peer {peer:?}")]
+    UnknownDevicePeer { device: String, peer: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use openlogi_core::config::{FlowDevice, FlowLayout, FlowPeer};
+
+    use super::*;
+
+    fn key(byte: &str) -> String {
+        format!("ed25519:{}", byte.repeat(32))
+    }
+
+    #[test]
+    fn compiles_peer_layout_and_device_channels() {
+        let config = FlowConfig {
+            enabled: true,
+            require_modifier: true,
+            peers: vec![FlowPeer {
+                name: "desk".into(),
+                public_key: key("ab"),
+                addresses: vec!["desk.local".into()],
+            }],
+            layout: vec![FlowLayout {
+                edge: FlowEdge::Right,
+                peer: "desk".into(),
+            }],
+            devices: vec![FlowDevice {
+                key: "unit:01020304".into(),
+                peer_channels: BTreeMap::from([("self".into(), 0), ("desk".into(), 1)]),
+            }],
+        };
+
+        let compiled = CompiledFlowConfig::compile(&config).unwrap();
+        assert!(compiled.enabled);
+        assert!(config.require_modifier);
+        assert_eq!(compiled.layout[&EdgeSide::Right], 0);
+        assert_eq!(compiled.devices["unit:01020304"]["desk"], 1);
+        assert_eq!(compiled.status().peers[0].public_key, key("ab"));
+    }
+
+    #[test]
+    fn rejects_noncanonical_keys_and_dangling_references() {
+        let mut config = FlowConfig {
+            peers: vec![FlowPeer {
+                name: "desk".into(),
+                public_key: key("AB"),
+                addresses: Vec::new(),
+            }],
+            ..FlowConfig::default()
+        };
+        assert!(matches!(
+            CompiledFlowConfig::compile(&config),
+            Err(FlowConfigError::InvalidPublicKey(_))
+        ));
+
+        config.peers[0].public_key = key("ab");
+        config.layout.push(FlowLayout {
+            edge: FlowEdge::Left,
+            peer: "missing".into(),
+        });
+        assert_eq!(
+            CompiledFlowConfig::compile(&config).unwrap_err(),
+            FlowConfigError::UnknownLayoutPeer("missing".into())
+        );
+    }
+}

--- a/crates/openlogi-agent-core/src/flow/handoff.rs
+++ b/crates/openlogi-agent-core/src/flow/handoff.rs
@@ -1,0 +1,560 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::Duration;
+
+use openlogi_flow::frame::{FrameKind, InboundRole};
+use openlogi_flow::generated as proto;
+use openlogi_flow::identity::same_device;
+use openlogi_flow::sas::PublicKey;
+use openlogi_flow::transport::{IncomingRpc, NotificationEvent, RpcEvent, message_envelope};
+use tokio::sync::{Mutex, oneshot};
+use tokio::time::Instant;
+use tracing::debug;
+
+use super::runtime::GenerationState;
+use super::{RuntimeDevice, is_pointing_device};
+
+const ARM_TIMEOUT: Duration = Duration::from_secs(3);
+const COMPLETED_LIMIT: usize = 64;
+
+mod sender;
+
+pub(super) use sender::start_outgoing;
+
+#[derive(Default)]
+pub(super) struct HandoffBook {
+    incoming: Mutex<IncomingLedger>,
+    outgoing: Mutex<HashMap<u64, OutgoingWaiter>>,
+    sender_busy: std::sync::atomic::AtomicBool,
+}
+
+#[derive(Default)]
+struct IncomingLedger {
+    pending: Option<PendingIncoming>,
+    completed: HashMap<(PublicKey, u64), CompletedIncoming>,
+    completion_order: VecDeque<(PublicKey, u64)>,
+}
+
+struct PendingIncoming {
+    peer: PublicKey,
+    transfer_id: u64,
+    entry: proto::EntryPoint,
+    devices: Vec<PendingDevice>,
+    accepted_at: Option<Instant>,
+}
+
+struct PendingDevice {
+    key: String,
+    identity: proto::DeviceIdentity,
+    pointing: bool,
+    arrived_at: Option<Instant>,
+}
+
+#[derive(Clone)]
+struct CompletedIncoming {
+    accept: proto::HandoffAccept,
+    result: proto::HandoffResult,
+}
+
+struct OutgoingWaiter {
+    peer: PublicKey,
+    result: oneshot::Sender<OutgoingSignal>,
+}
+
+enum OutgoingSignal {
+    Result(proto::HandoffResult),
+    Cancelled,
+}
+
+enum ArmDecision {
+    New(proto::HandoffAccept),
+    Duplicate(proto::HandoffAccept),
+    Replay {
+        accept: proto::HandoffAccept,
+        result: proto::HandoffResult,
+    },
+    Reject(proto::HandoffReject),
+}
+
+impl HandoffBook {
+    async fn arm(
+        &self,
+        peer: PublicKey,
+        request: &proto::HandoffRequest,
+        local_devices: &[RuntimeDevice],
+        enabled: bool,
+    ) -> ArmDecision {
+        let reject = |reason: proto::HandoffRejectReason, detail: &str| {
+            ArmDecision::Reject(proto::HandoffReject {
+                transfer_id: request.transfer_id,
+                reason: reason.into(),
+                detail: detail.to_owned(),
+                ..Default::default()
+            })
+        };
+        if !enabled {
+            return reject(proto::HandoffRejectReason::Disabled, "Flow is disabled");
+        }
+        if request.transfer_id == 0 || request.devices.is_empty() || !valid_entry(request) {
+            return reject(
+                proto::HandoffRejectReason::NotReady,
+                "invalid handoff request",
+            );
+        }
+
+        let key = (peer, request.transfer_id);
+        let mut ledger = self.incoming.lock().await;
+        if let Some(completed) = ledger.completed.get(&key) {
+            return ArmDecision::Replay {
+                accept: completed.accept.clone(),
+                result: completed.result.clone(),
+            };
+        }
+        if let Some(pending) = &ledger.pending {
+            if pending.peer == peer && pending.transfer_id == request.transfer_id {
+                return ArmDecision::Duplicate(accept(request.transfer_id));
+            }
+            return reject(
+                proto::HandoffRejectReason::AlreadyPending,
+                "another transfer is already armed",
+            );
+        }
+
+        let mut matched = Vec::with_capacity(request.devices.len());
+        for requested in &request.devices {
+            let local = local_devices
+                .iter()
+                .find(|local| same_device(requested, &local.identity).unwrap_or(false));
+            let Some(local) = local else {
+                return reject(
+                    proto::HandoffRejectReason::UnknownDevice,
+                    "a requested device is not configured locally",
+                );
+            };
+            if local.snapshot.online {
+                return reject(
+                    proto::HandoffRejectReason::NotReady,
+                    "a requested device is already online on the receiver",
+                );
+            }
+            if matched
+                .iter()
+                .any(|device: &PendingDevice| device.key == local.snapshot.config_key)
+            {
+                return reject(
+                    proto::HandoffRejectReason::UnknownDevice,
+                    "the request repeats one physical device",
+                );
+            }
+            matched.push(PendingDevice {
+                key: local.snapshot.config_key.clone(),
+                identity: local.identity.clone(),
+                pointing: is_pointing_device(local.snapshot.kind),
+                arrived_at: None,
+            });
+        }
+
+        ledger.pending = Some(PendingIncoming {
+            peer,
+            transfer_id: request.transfer_id,
+            entry: request.entry.as_option().cloned().unwrap_or_default(),
+            devices: matched,
+            accepted_at: None,
+        });
+        ArmDecision::New(accept(request.transfer_id))
+    }
+
+    async fn mark_accepted(&self, peer: PublicKey, transfer_id: u64) -> bool {
+        let mut ledger = self.incoming.lock().await;
+        let Some(pending) = ledger.pending.as_mut() else {
+            return false;
+        };
+        if pending.peer != peer || pending.transfer_id != transfer_id {
+            return false;
+        }
+        if pending.accepted_at.is_some() {
+            return false;
+        }
+        pending.accepted_at = Some(Instant::now());
+        true
+    }
+
+    async fn observe(&self, devices: &[RuntimeDevice]) -> Option<CompletedTransfer> {
+        let mut ledger = self.incoming.lock().await;
+        let pending = ledger.pending.as_mut()?;
+        for expected in &mut pending.devices {
+            if expected.arrived_at.is_none()
+                && devices.iter().any(|device| {
+                    device.snapshot.config_key == expected.key && device.snapshot.online
+                })
+            {
+                expected.arrived_at = Some(Instant::now());
+            }
+        }
+        let accepted = pending.accepted_at?;
+        if pending
+            .devices
+            .iter()
+            .all(|device| device.arrived_at.is_some())
+        {
+            return Some(complete_pending(&mut ledger, accepted, false));
+        }
+        None
+    }
+
+    async fn expire(&self, peer: PublicKey, transfer_id: u64) -> Option<CompletedTransfer> {
+        let mut ledger = self.incoming.lock().await;
+        let pending = ledger.pending.as_ref()?;
+        if pending.peer != peer || pending.transfer_id != transfer_id {
+            return None;
+        }
+        let accepted = pending.accepted_at?;
+        Some(complete_pending(&mut ledger, accepted, true))
+    }
+
+    async fn cancel_unaccepted(&self, peer: PublicKey, transfer_id: u64) -> bool {
+        let mut ledger = self.incoming.lock().await;
+        if ledger.pending.as_ref().is_some_and(|pending| {
+            pending.peer == peer
+                && pending.transfer_id == transfer_id
+                && pending.accepted_at.is_none()
+        }) {
+            ledger.pending = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn cancel_incoming(&self, peer: PublicKey, transfer_id: u64) -> bool {
+        let mut ledger = self.incoming.lock().await;
+        if ledger
+            .pending
+            .as_ref()
+            .is_some_and(|pending| pending.peer == peer && pending.transfer_id == transfer_id)
+        {
+            ledger.pending = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn register_outgoing(
+        &self,
+        peer: PublicKey,
+        transfer_id: u64,
+    ) -> oneshot::Receiver<OutgoingSignal> {
+        let (sender, receiver) = oneshot::channel();
+        self.outgoing.lock().await.insert(
+            transfer_id,
+            OutgoingWaiter {
+                peer,
+                result: sender,
+            },
+        );
+        receiver
+    }
+
+    async fn remove_outgoing(&self, transfer_id: u64) {
+        self.outgoing.lock().await.remove(&transfer_id);
+    }
+
+    async fn deliver_result(&self, peer: PublicKey, result: proto::HandoffResult) -> bool {
+        let mut outgoing = self.outgoing.lock().await;
+        let Some(waiter) = outgoing.remove(&result.transfer_id) else {
+            return false;
+        };
+        if waiter.peer != peer {
+            outgoing.insert(result.transfer_id, waiter);
+            return false;
+        }
+        let _ = waiter.result.send(OutgoingSignal::Result(result));
+        true
+    }
+
+    async fn cancel_outgoing(&self, peer: PublicKey, transfer_id: u64) -> bool {
+        let mut outgoing = self.outgoing.lock().await;
+        let Some(waiter) = outgoing.remove(&transfer_id) else {
+            return false;
+        };
+        if waiter.peer != peer {
+            outgoing.insert(transfer_id, waiter);
+            return false;
+        }
+        let _ = waiter.result.send(OutgoingSignal::Cancelled);
+        true
+    }
+}
+
+pub(super) async fn handle_rpc(state: Arc<GenerationState>, peer: PublicKey, event: RpcEvent) {
+    let RpcEvent::Request(rpc) = event else {
+        return;
+    };
+    if rpc.request().kind != FrameKind::HandoffRequest {
+        return;
+    }
+    let Ok(request) = rpc
+        .request()
+        .decode::<proto::HandoffRequest>(InboundRole::Request)
+    else {
+        return;
+    };
+    let devices = state
+        .devices
+        .read()
+        .map_or_else(|_| Vec::new(), |guard| guard.clone());
+    let decision = state
+        .handoffs
+        .arm(
+            peer,
+            &request,
+            &devices,
+            state.config.enabled && state.is_active(),
+        )
+        .await;
+    respond_to_arm(state, peer, rpc, decision).await;
+}
+
+async fn respond_to_arm(
+    state: Arc<GenerationState>,
+    peer: PublicKey,
+    rpc: IncomingRpc,
+    decision: ArmDecision,
+) {
+    match decision {
+        ArmDecision::New(acceptance) => {
+            let transfer_id = acceptance.transfer_id;
+            let Ok(envelope) = message_envelope(FrameKind::HandoffAccept, &acceptance) else {
+                return;
+            };
+            if rpc.respond(envelope).await.is_err() {
+                state.handoffs.cancel_unaccepted(peer, transfer_id).await;
+                return;
+            }
+            accept_pending(state, peer, transfer_id).await;
+        }
+        ArmDecision::Duplicate(acceptance) => {
+            let transfer_id = acceptance.transfer_id;
+            if let Ok(envelope) = message_envelope(FrameKind::HandoffAccept, &acceptance)
+                && rpc.respond(envelope).await.is_ok()
+            {
+                accept_pending(state, peer, transfer_id).await;
+            }
+        }
+        ArmDecision::Replay { accept, result } => {
+            let Ok(envelope) = message_envelope(FrameKind::HandoffAccept, &accept) else {
+                return;
+            };
+            if rpc.respond(envelope).await.is_ok() {
+                let _lifecycle = state.lifecycle.lock().await;
+                if state.is_active() {
+                    state.send_result(peer, result).await;
+                }
+            }
+        }
+        ArmDecision::Reject(rejection) => {
+            if let Ok(envelope) = message_envelope(FrameKind::HandoffReject, &rejection) {
+                let _ = rpc.respond(envelope).await;
+            }
+        }
+    }
+}
+
+async fn accept_pending(state: Arc<GenerationState>, peer: PublicKey, transfer_id: u64) {
+    let completed = {
+        let _lifecycle = state.lifecycle.lock().await;
+        if !state.is_active() {
+            state.handoffs.cancel_incoming(peer, transfer_id).await;
+            state
+                .send_cancel(peer, transfer_id, proto::HandoffCancelReason::Shutdown)
+                .await;
+            return;
+        }
+        if state.handoffs.mark_accepted(peer, transfer_id).await {
+            spawn_arm_timeout(Arc::clone(&state), peer, transfer_id);
+            state.handoffs.observe(&state.devices_snapshot()).await
+        } else {
+            None
+        }
+    };
+    if let Some(completed) = completed {
+        finish_incoming(state, completed).await;
+    }
+}
+
+fn spawn_arm_timeout(state: Arc<GenerationState>, peer: PublicKey, transfer_id: u64) {
+    tokio::spawn(async move {
+        tokio::time::sleep(ARM_TIMEOUT).await;
+        if let Some(completed) = state.handoffs.expire(peer, transfer_id).await {
+            finish_incoming(state, completed).await;
+        }
+    });
+}
+
+pub(super) async fn inventory_changed(state: Arc<GenerationState>) {
+    if let Some(completed) = state.handoffs.observe(&state.devices_snapshot()).await {
+        finish_incoming(state, completed).await;
+    }
+}
+
+async fn finish_incoming(state: Arc<GenerationState>, completed: CompletedTransfer) {
+    let _lifecycle = state.lifecycle.lock().await;
+    if !state.is_active() {
+        state
+            .send_cancel(
+                completed.peer,
+                completed.result.transfer_id,
+                proto::HandoffCancelReason::Shutdown,
+            )
+            .await;
+        return;
+    }
+    if completed.warp_pointer {
+        super::runtime::warp_entry(&completed.entry);
+    }
+    state.send_result(completed.peer, completed.result).await;
+}
+
+pub(super) async fn handle_notification(
+    state: Arc<GenerationState>,
+    peer: PublicKey,
+    event: NotificationEvent,
+) {
+    let NotificationEvent::Notification(notification) = event else {
+        return;
+    };
+    match notification.kind {
+        FrameKind::HandoffResult => {
+            let Ok(result) = notification.decode::<proto::HandoffResult>(InboundRole::Notification)
+            else {
+                return;
+            };
+            if !state.handoffs.deliver_result(peer, result.clone()).await {
+                debug!(
+                    transfer_id = result.transfer_id,
+                    "stale Flow handoff result ignored"
+                );
+            }
+        }
+        FrameKind::HandoffCancel => {
+            let Ok(cancel) = notification.decode::<proto::HandoffCancel>(InboundRole::Notification)
+            else {
+                return;
+            };
+            let incoming = state
+                .handoffs
+                .cancel_incoming(peer, cancel.transfer_id)
+                .await;
+            let outgoing = state
+                .handoffs
+                .cancel_outgoing(peer, cancel.transfer_id)
+                .await;
+            if !(incoming || outgoing) {
+                debug!(
+                    transfer_id = cancel.transfer_id,
+                    "stale Flow handoff cancel ignored"
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+struct CompletedTransfer {
+    peer: PublicKey,
+    entry: proto::EntryPoint,
+    result: proto::HandoffResult,
+    warp_pointer: bool,
+}
+
+fn complete_pending(
+    ledger: &mut IncomingLedger,
+    accepted_at: Instant,
+    timed_out: bool,
+) -> CompletedTransfer {
+    let pending = ledger
+        .pending
+        .take()
+        .unwrap_or_else(|| unreachable!("completion requires a pending transfer"));
+    let arrived_count = pending
+        .devices
+        .iter()
+        .filter(|device| device.arrived_at.is_some())
+        .count();
+    let outcome = if arrived_count == pending.devices.len() {
+        proto::HandoffOutcome::Arrived
+    } else if arrived_count > 0 {
+        proto::HandoffOutcome::Partial
+    } else if timed_out {
+        proto::HandoffOutcome::Timeout
+    } else {
+        unreachable!("non-timeout completion has at least one arrival")
+    };
+    let arrivals = pending
+        .devices
+        .iter()
+        .map(|device| {
+            let mut arrival = proto::DeviceArrival {
+                arrived: device.arrived_at.is_some(),
+                elapsed_ms: device.arrived_at.map_or(0, |arrived| {
+                    u32::try_from(arrived.duration_since(accepted_at).as_millis())
+                        .unwrap_or(u32::MAX)
+                }),
+                ..Default::default()
+            };
+            *arrival.device.get_or_insert_default() = device.identity.clone();
+            arrival
+        })
+        .collect();
+    let result = proto::HandoffResult {
+        transfer_id: pending.transfer_id,
+        outcome: outcome.into(),
+        arrivals,
+        ..Default::default()
+    };
+    let completed = CompletedIncoming {
+        accept: accept(pending.transfer_id),
+        result: result.clone(),
+    };
+    let key = (pending.peer, pending.transfer_id);
+    ledger.completed.insert(key, completed);
+    ledger.completion_order.push_back(key);
+    while ledger.completion_order.len() > COMPLETED_LIMIT {
+        if let Some(expired) = ledger.completion_order.pop_front() {
+            ledger.completed.remove(&expired);
+        }
+    }
+    CompletedTransfer {
+        peer: pending.peer,
+        entry: pending.entry,
+        result,
+        warp_pointer: pending
+            .devices
+            .iter()
+            .any(|device| device.pointing && device.arrived_at.is_some()),
+    }
+}
+
+fn accept(transfer_id: u64) -> proto::HandoffAccept {
+    proto::HandoffAccept {
+        transfer_id,
+        arm_timeout_ms: u32::try_from(ARM_TIMEOUT.as_millis())
+            .unwrap_or_else(|_| unreachable!("three seconds fits in u32 milliseconds")),
+        ..Default::default()
+    }
+}
+
+fn valid_entry(request: &proto::HandoffRequest) -> bool {
+    request.entry.as_option().is_some_and(|entry| {
+        entry
+            .side
+            .as_known()
+            .is_some_and(|side| side != proto::Side::Unspecified)
+            && entry.t.is_finite()
+            && (0.0..=1.0).contains(&entry.t)
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-agent-core/src/flow/handoff/sender.rs
+++ b/crates/openlogi-agent-core/src/flow/handoff/sender.rs
@@ -1,0 +1,211 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use openlogi_flow::frame::{Envelope, FrameKind, InboundRole};
+use openlogi_flow::generated as proto;
+use openlogi_flow::transport::{FlowConnection, message_envelope};
+use openlogi_hook::edge::{EdgeCrossing, EdgeSide};
+use tracing::{debug, info, warn};
+
+use super::OutgoingSignal;
+use crate::flow::runtime::GenerationState;
+
+const NETWORK_SLACK: Duration = Duration::from_secs(2);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(in crate::flow) fn start_outgoing(state: Arc<GenerationState>, crossing: EdgeCrossing) {
+    if !state.is_active()
+        || state
+            .handoffs
+            .sender_busy
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+    {
+        return;
+    }
+    tokio::spawn(async move {
+        run_outgoing(&state, crossing).await;
+        state
+            .handoffs
+            .sender_busy
+            .store(false, std::sync::atomic::Ordering::Release);
+    });
+}
+
+async fn run_outgoing(state: &Arc<GenerationState>, crossing: EdgeCrossing) {
+    // A config reload deactivates a generation at this lock boundary. Once a
+    // peer accepts, keep the bounded handoff transaction on one generation
+    // through its arrival acknowledgment so stale config cannot switch hosts.
+    let _lifecycle = state.lifecycle.lock().await;
+    if !state.is_active() {
+        return;
+    }
+    let Some(&peer_index) = state.config.layout.get(&crossing.side) else {
+        return;
+    };
+    let Some(peer) = state.config.peers.get(peer_index) else {
+        return;
+    };
+    let Some(connection) = state.connection(peer.public_key) else {
+        debug!(peer = %peer.name, "Flow edge ignored while peer is disconnected");
+        return;
+    };
+    let targets = state.outgoing_devices(&peer.name);
+    if targets.is_empty() {
+        warn!(peer = %peer.name, "Flow edge has no online configured devices to hand off");
+        return;
+    }
+
+    let transfer_id = random_transfer_id();
+    let mut request = proto::HandoffRequest {
+        transfer_id,
+        devices: targets
+            .iter()
+            .map(|target| target.identity.clone())
+            .collect(),
+        sent_at_ms: unix_millis(),
+        ..Default::default()
+    };
+    *request.entry.get_or_insert_default() = entry_from_crossing(crossing);
+    let Ok(envelope) = message_envelope(FrameKind::HandoffRequest, &request) else {
+        return;
+    };
+    // Register before opening the RPC stream: QUIC does not order the response
+    // stream against the receiver's HandoffResult notification stream.
+    let result = state
+        .handoffs
+        .register_outgoing(peer.public_key, transfer_id)
+        .await;
+    let Some(acceptance) = request_acceptance(&connection, &peer.name, transfer_id, envelope).await
+    else {
+        state.handoffs.remove_outgoing(transfer_id).await;
+        return;
+    };
+    match state.switch_devices(&targets).await {
+        Ok(true) => {}
+        Ok(false) => {
+            state.handoffs.remove_outgoing(transfer_id).await;
+            state
+                .send_cancel(
+                    peer.public_key,
+                    transfer_id,
+                    proto::HandoffCancelReason::Shutdown,
+                )
+                .await;
+            return;
+        }
+        Err(error) => {
+            state.handoffs.remove_outgoing(transfer_id).await;
+            warn!(%error, peer = %peer.name, "Flow host switch failed after receiver acceptance");
+            state
+                .send_cancel(
+                    peer.public_key,
+                    transfer_id,
+                    proto::HandoffCancelReason::SwitchFailed,
+                )
+                .await;
+            return;
+        }
+    }
+
+    let deadline = Duration::from_millis(u64::from(acceptance.arm_timeout_ms)) + NETWORK_SLACK;
+    match tokio::time::timeout(deadline, result).await {
+        Ok(Ok(OutgoingSignal::Result(result))) => {
+            info!(
+                peer = %peer.name,
+                transfer_id,
+                outcome = result.outcome.to_i32(),
+                "Flow handoff completed"
+            );
+        }
+        Ok(Ok(OutgoingSignal::Cancelled)) => {
+            debug!(peer = %peer.name, transfer_id, "Flow handoff cancelled by peer");
+        }
+        Ok(Err(_)) | Err(_) => {
+            state.handoffs.remove_outgoing(transfer_id).await;
+            warn!(peer = %peer.name, transfer_id, "Flow arrival acknowledgment timed out");
+        }
+    }
+}
+
+async fn request_acceptance(
+    connection: &FlowConnection,
+    peer_name: &str,
+    transfer_id: u64,
+    request: Envelope,
+) -> Option<proto::HandoffAccept> {
+    let response = match tokio::time::timeout(REQUEST_TIMEOUT, connection.call(request)).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            debug!(%error, peer = peer_name, "Flow handoff request failed");
+            return None;
+        }
+        Err(_) => {
+            debug!(peer = peer_name, "Flow handoff request timed out");
+            return None;
+        }
+    };
+    if response.kind == FrameKind::HandoffReject {
+        if let Ok(rejection) = response.decode::<proto::HandoffReject>(InboundRole::Request) {
+            debug!(
+                peer = peer_name,
+                reason = rejection.reason.to_i32(),
+                "Flow handoff rejected"
+            );
+        }
+        return None;
+    }
+    if response.kind != FrameKind::HandoffAccept {
+        return None;
+    }
+    let Ok(acceptance) = response.decode::<proto::HandoffAccept>(InboundRole::Request) else {
+        return None;
+    };
+    if acceptance.transfer_id != transfer_id || acceptance.arm_timeout_ms == 0 {
+        warn!(
+            peer = peer_name,
+            "Flow peer returned an invalid handoff acceptance"
+        );
+        return None;
+    }
+    Some(acceptance)
+}
+
+fn entry_from_crossing(crossing: EdgeCrossing) -> proto::EntryPoint {
+    let mut entry = proto::EntryPoint {
+        side: receiver_side(crossing.side).into(),
+        t: crossing.t.clamp(0.0, 1.0),
+        ..Default::default()
+    };
+    *entry.velocity.get_or_insert_default() = proto::Vec2 {
+        x: crossing.velocity.x,
+        y: crossing.velocity.y,
+        ..Default::default()
+    };
+    entry
+}
+
+const fn receiver_side(side: EdgeSide) -> proto::Side {
+    match side {
+        EdgeSide::Left => proto::Side::Right,
+        EdgeSide::Right => proto::Side::Left,
+        EdgeSide::Top => proto::Side::Bottom,
+        EdgeSide::Bottom => proto::Side::Top,
+    }
+}
+
+fn random_transfer_id() -> u64 {
+    loop {
+        let id = rand::random();
+        if id != 0 {
+            return id;
+        }
+    }
+}
+
+fn unix_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+        })
+}

--- a/crates/openlogi-agent-core/src/flow/handoff/sender.rs
+++ b/crates/openlogi-agent-core/src/flow/handoff/sender.rs
@@ -12,6 +12,7 @@ use crate::flow::runtime::GenerationState;
 
 const NETWORK_SLACK: Duration = Duration::from_secs(2);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+const MAX_PEER_ARM_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(in crate::flow) fn start_outgoing(state: Arc<GenerationState>, crossing: EdgeCrossing) {
     if !state.is_active()
@@ -75,7 +76,7 @@ async fn run_outgoing(state: &Arc<GenerationState>, crossing: EdgeCrossing) {
         .handoffs
         .register_outgoing(peer.public_key, transfer_id)
         .await;
-    let Some(acceptance) = request_acceptance(&connection, &peer.name, transfer_id, envelope).await
+    let Some(deadline) = request_acceptance(&connection, &peer.name, transfer_id, envelope).await
     else {
         state.handoffs.remove_outgoing(transfer_id).await;
         return;
@@ -107,7 +108,6 @@ async fn run_outgoing(state: &Arc<GenerationState>, crossing: EdgeCrossing) {
         }
     }
 
-    let deadline = Duration::from_millis(u64::from(acceptance.arm_timeout_ms)) + NETWORK_SLACK;
     match tokio::time::timeout(deadline, result).await {
         Ok(Ok(OutgoingSignal::Result(result))) => {
             info!(
@@ -132,7 +132,7 @@ async fn request_acceptance(
     peer_name: &str,
     transfer_id: u64,
     request: Envelope,
-) -> Option<proto::HandoffAccept> {
+) -> Option<Duration> {
     let response = match tokio::time::timeout(REQUEST_TIMEOUT, connection.call(request)).await {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => {
@@ -160,14 +160,22 @@ async fn request_acceptance(
     let Ok(acceptance) = response.decode::<proto::HandoffAccept>(InboundRole::Request) else {
         return None;
     };
-    if acceptance.transfer_id != transfer_id || acceptance.arm_timeout_ms == 0 {
+    let Some(deadline) = handoff_deadline(&acceptance, transfer_id) else {
         warn!(
             peer = peer_name,
             "Flow peer returned an invalid handoff acceptance"
         );
         return None;
-    }
-    Some(acceptance)
+    };
+    Some(deadline)
+}
+
+fn handoff_deadline(acceptance: &proto::HandoffAccept, transfer_id: u64) -> Option<Duration> {
+    let arm_timeout = Duration::from_millis(u64::from(acceptance.arm_timeout_ms));
+    (acceptance.transfer_id == transfer_id
+        && !arm_timeout.is_zero()
+        && arm_timeout <= MAX_PEER_ARM_TIMEOUT)
+        .then(|| arm_timeout + NETWORK_SLACK)
 }
 
 fn entry_from_crossing(crossing: EdgeCrossing) -> proto::EntryPoint {
@@ -208,4 +216,44 @@ fn unix_millis() -> u64 {
         .map_or(0, |duration| {
             u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acceptance(transfer_id: u64, arm_timeout_ms: u32) -> proto::HandoffAccept {
+        proto::HandoffAccept {
+            transfer_id,
+            arm_timeout_ms,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn peer_arm_timeout_is_bounded_before_handoff() {
+        let transfer_id = 42;
+        let max_ms = u32::try_from(MAX_PEER_ARM_TIMEOUT.as_millis()).unwrap();
+
+        assert_eq!(
+            handoff_deadline(&acceptance(transfer_id, max_ms), transfer_id),
+            Some(MAX_PEER_ARM_TIMEOUT + NETWORK_SLACK)
+        );
+        assert_eq!(
+            handoff_deadline(&acceptance(transfer_id, 0), transfer_id),
+            None
+        );
+        assert_eq!(
+            handoff_deadline(&acceptance(transfer_id, max_ms + 1), transfer_id),
+            None
+        );
+        assert_eq!(
+            handoff_deadline(&acceptance(transfer_id, u32::MAX), transfer_id),
+            None
+        );
+        assert_eq!(
+            handoff_deadline(&acceptance(transfer_id + 1, max_ms), transfer_id),
+            None
+        );
+    }
 }

--- a/crates/openlogi-agent-core/src/flow/handoff/tests.rs
+++ b/crates/openlogi-agent-core/src/flow/handoff/tests.rs
@@ -1,0 +1,204 @@
+use std::collections::BTreeMap;
+
+use openlogi_core::device::DeviceKind;
+use openlogi_flow::identity::CanonicalDeviceIdentifier;
+
+use super::*;
+use crate::flow::{FlowDeviceSnapshot, RuntimeDevice};
+
+fn device(key: &str, unit: u32, online: bool) -> RuntimeDevice {
+    let identity = proto::DeviceIdentity {
+        ids: vec![CanonicalDeviceIdentifier::unit_id(unit).into()],
+        ..Default::default()
+    };
+    RuntimeDevice {
+        snapshot: FlowDeviceSnapshot {
+            config_key: key.into(),
+            route: None,
+            serial: None,
+            unit_id: unit.to_be_bytes(),
+            kind: DeviceKind::Mouse,
+            online,
+        },
+        identity,
+        channels: BTreeMap::new(),
+    }
+}
+
+fn request(id: u64, devices: &[RuntimeDevice]) -> proto::HandoffRequest {
+    let mut request = proto::HandoffRequest {
+        transfer_id: id,
+        devices: devices
+            .iter()
+            .map(|device| device.identity.clone())
+            .collect(),
+        ..Default::default()
+    };
+    *request.entry.get_or_insert_default() = proto::EntryPoint {
+        side: proto::Side::Left.into(),
+        t: 0.5,
+        ..Default::default()
+    };
+    request
+}
+
+#[tokio::test]
+async fn receiver_arms_before_accept_and_dedupes_same_transfer() {
+    let book = HandoffBook::default();
+    let peer = PublicKey::new([7; 32]);
+    let devices = vec![device("mouse", 1, false)];
+    let request = request(42, &devices);
+
+    assert!(matches!(
+        book.arm(peer, &request, &devices, true).await,
+        ArmDecision::New(_)
+    ));
+    assert!(matches!(
+        book.arm(peer, &request, &devices, true).await,
+        ArmDecision::Duplicate(_)
+    ));
+    assert!(book.mark_accepted(peer, 42).await);
+}
+
+#[tokio::test]
+async fn receiver_rejects_conflict_unknown_and_already_online() {
+    let book = HandoffBook::default();
+    let peer = PublicKey::new([7; 32]);
+    let offline = vec![device("mouse", 1, false)];
+    assert!(matches!(
+        book.arm(peer, &request(1, &offline), &offline, true).await,
+        ArmDecision::New(_)
+    ));
+    assert!(matches!(
+        book.arm(peer, &request(2, &offline), &offline, true).await,
+        ArmDecision::Reject(proto::HandoffReject { reason, .. })
+            if reason.as_known() == Some(proto::HandoffRejectReason::AlreadyPending)
+    ));
+
+    let other = HandoffBook::default();
+    let online = vec![device("mouse", 1, true)];
+    assert!(matches!(
+        other.arm(peer, &request(3, &online), &online, true).await,
+        ArmDecision::Reject(proto::HandoffReject { reason, .. })
+            if reason.as_known() == Some(proto::HandoffRejectReason::NotReady)
+    ));
+    assert!(matches!(
+        other
+            .arm(peer, &request(4, &[device("unknown", 2, false)]), &online, true)
+            .await,
+        ArmDecision::Reject(proto::HandoffReject { reason, .. })
+            if reason.as_known() == Some(proto::HandoffRejectReason::UnknownDevice)
+    ));
+}
+
+#[tokio::test]
+async fn receiver_reports_arrived_partial_and_timeout_from_fresh_inventory() {
+    let peer = PublicKey::new([7; 32]);
+    let configured = vec![device("mouse", 1, false), device("keyboard", 2, false)];
+
+    let book = HandoffBook::default();
+    assert!(matches!(
+        book.arm(peer, &request(5, &configured), &configured, true)
+            .await,
+        ArmDecision::New(_)
+    ));
+    assert!(book.mark_accepted(peer, 5).await);
+    let arrived = vec![device("mouse", 1, true), device("keyboard", 2, true)];
+    let completed = book.observe(&arrived).await.unwrap();
+    assert_eq!(
+        completed.result.outcome.as_known(),
+        Some(proto::HandoffOutcome::Arrived)
+    );
+
+    let book = HandoffBook::default();
+    assert!(matches!(
+        book.arm(peer, &request(6, &configured), &configured, true)
+            .await,
+        ArmDecision::New(_)
+    ));
+    assert!(book.mark_accepted(peer, 6).await);
+    let partial = vec![device("mouse", 1, true), device("keyboard", 2, false)];
+    assert!(book.observe(&partial).await.is_none());
+    let completed = book.expire(peer, 6).await.unwrap();
+    assert_eq!(
+        completed.result.outcome.as_known(),
+        Some(proto::HandoffOutcome::Partial)
+    );
+
+    let book = HandoffBook::default();
+    assert!(matches!(
+        book.arm(peer, &request(7, &configured), &configured, true)
+            .await,
+        ArmDecision::New(_)
+    ));
+    assert!(book.mark_accepted(peer, 7).await);
+    let completed = book.expire(peer, 7).await.unwrap();
+    assert_eq!(
+        completed.result.outcome.as_known(),
+        Some(proto::HandoffOutcome::Timeout)
+    );
+}
+
+#[tokio::test]
+async fn stale_result_does_not_consume_another_peer_waiter() {
+    let book = HandoffBook::default();
+    let expected = PublicKey::new([1; 32]);
+    let stale = PublicKey::new([2; 32]);
+    let mut receiver = book.register_outgoing(expected, 9).await;
+    let result = proto::HandoffResult {
+        transfer_id: 9,
+        outcome: proto::HandoffOutcome::Arrived.into(),
+        ..Default::default()
+    };
+    assert!(!book.deliver_result(stale, result.clone()).await);
+    assert!(receiver.try_recv().is_err());
+    assert!(book.deliver_result(expected, result).await);
+    assert!(matches!(receiver.await, Ok(OutgoingSignal::Result(_))));
+}
+
+#[tokio::test]
+async fn completed_transfer_is_replayed_without_rearming() {
+    let book = HandoffBook::default();
+    let peer = PublicKey::new([7; 32]);
+    let offline = vec![device("mouse", 1, false)];
+    let request = request(10, &offline);
+    assert!(matches!(
+        book.arm(peer, &request, &offline, true).await,
+        ArmDecision::New(_)
+    ));
+    assert!(book.mark_accepted(peer, 10).await);
+    let completed = book
+        .observe(&[device("mouse", 1, true)])
+        .await
+        .expect("online inventory completes the accepted transfer");
+
+    assert!(matches!(
+        book.arm(peer, &request, &offline, true).await,
+        ArmDecision::Replay { accept, result }
+            if accept.transfer_id == 10 && result == completed.result
+    ));
+}
+
+#[tokio::test]
+async fn response_failure_cannot_disarm_accepted_transfer_but_cancel_can() {
+    let book = HandoffBook::default();
+    let peer = PublicKey::new([7; 32]);
+    let offline = vec![device("mouse", 1, false)];
+    let request = request(11, &offline);
+    assert!(matches!(
+        book.arm(peer, &request, &offline, true).await,
+        ArmDecision::New(_)
+    ));
+    assert!(book.mark_accepted(peer, 11).await);
+
+    assert!(!book.cancel_unaccepted(peer, 11).await);
+    assert!(matches!(
+        book.arm(peer, &request, &offline, true).await,
+        ArmDecision::Duplicate(_)
+    ));
+    assert!(book.cancel_incoming(peer, 11).await);
+    assert!(matches!(
+        book.arm(peer, &request, &offline, true).await,
+        ArmDecision::New(_)
+    ));
+}

--- a/crates/openlogi-agent-core/src/flow/runtime.rs
+++ b/crates/openlogi-agent-core/src/flow/runtime.rs
@@ -1,0 +1,708 @@
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write as _};
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use openlogi_flow::discovery::{
+    CandidateSource, DEFAULT_PORT, ManualCandidateSource, MdnsAdvertiser, MdnsCandidateSource,
+    MdnsRecord,
+};
+use openlogi_flow::frame::FrameKind;
+use openlogi_flow::generated as proto;
+use openlogi_flow::sas::PublicKey;
+use openlogi_flow::session::{
+    LinkState, PeerConfig, PeerSessionHandle, SessionManager, SessionPolicy, TrustedInitialState,
+    TrustedStateProvider,
+};
+use openlogi_flow::transport::{
+    FlowConnection, FlowEndpoint, MachineIdentity, NotificationEvent, PeerTrust, RpcEvent,
+    message_envelope,
+};
+use openlogi_hid::{ChannelPool, DeviceRoute};
+use openlogi_hook::edge::{EdgeSide, ExposedEdges};
+use openlogi_ipc::{FlowLinkState, FlowPeerStatus, FlowStatus};
+use thiserror::Error;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use super::config::CompiledFlowConfig;
+use super::handoff::{HandoffBook, handle_notification, handle_rpc, inventory_changed};
+use super::{FlowDeviceSnapshot, RuntimeDevice, is_pointing_device};
+use crate::observable::ObservableState;
+use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess};
+
+const FLOW_IDENTITY_FILE: &str = "flow-identity.pk8";
+const PROTOCOL_MIN: u32 = 1;
+const PROTOCOL_MAX: u32 = 1;
+
+mod controller;
+
+pub use controller::{FlowController, FlowInputHandle};
+
+struct FlowGeneration {
+    state: Arc<GenerationState>,
+    sessions: SessionManager,
+    tasks: Vec<JoinHandle<()>>,
+    _advertiser: Option<MdnsAdvertiser>,
+    _endpoint: Arc<FlowEndpoint>,
+}
+
+impl FlowGeneration {
+    async fn start(
+        config: Arc<CompiledFlowConfig>,
+        snapshots: &[FlowDeviceSnapshot],
+        observable: Arc<ObservableState>,
+        channel_pool: ChannelPool,
+        receiver_access: ReceiverAccess,
+    ) -> Result<Self, FlowRuntimeError> {
+        let identity = tokio::task::spawn_blocking(load_machine_identity)
+            .await
+            .map_err(|error| FlowRuntimeError::IdentityTask(error.to_string()))??;
+        let hello = proto::Hello {
+            proto_min: PROTOCOL_MIN,
+            proto_max: PROTOCOL_MAX,
+            public_key: identity.public_key().as_bytes().to_vec(),
+            session_nonce: rand::random::<[u8; 16]>().to_vec(),
+            machine_name: machine_name(),
+            platform: platform().into(),
+            app_version: env!("CARGO_PKG_VERSION").to_owned(),
+            ..Default::default()
+        };
+        let endpoint = Arc::new(FlowEndpoint::bind(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, DEFAULT_PORT)),
+            identity,
+            PeerTrust::pinned(config.peers.iter().map(|peer| peer.public_key)),
+            hello,
+        )?);
+        let record = MdnsRecord::new(endpoint.public_key(), PROTOCOL_MIN, PROTOCOL_MAX)?;
+        let advertiser = match MdnsAdvertiser::start(record, endpoint.local_addr()?.port()) {
+            Ok(advertiser) => Some(advertiser),
+            Err(error) => {
+                warn!(%error, "Flow mDNS advertisement unavailable — manual addresses remain active");
+                None
+            }
+        };
+        let browser: Option<Arc<dyn CandidateSource>> =
+            match MdnsCandidateSource::browse(PROTOCOL_MIN, PROTOCOL_MAX) {
+                Ok(browser) => Some(Arc::new(browser)),
+                Err(error) => {
+                    warn!(%error, "Flow mDNS browsing unavailable — manual addresses only");
+                    None
+                }
+            };
+        let peers = config.peers.iter().map(|peer| {
+            let mut sources = Vec::<Arc<dyn CandidateSource>>::new();
+            if let Some(browser) = &browser {
+                sources.push(Arc::clone(browser));
+            }
+            if !peer.addresses.is_empty() {
+                sources.push(Arc::new(ManualCandidateSource::new(peer.addresses.clone())));
+            }
+            PeerConfig {
+                public_key: peer.public_key,
+                sources,
+            }
+        });
+        let state = Arc::new(GenerationState::new(
+            Arc::clone(&config),
+            snapshots,
+            observable,
+            channel_pool,
+            receiver_access,
+        ));
+        let provider: Arc<dyn TrustedStateProvider> = state.clone();
+        let sessions = SessionManager::start(
+            Arc::clone(&endpoint),
+            peers,
+            provider,
+            SessionPolicy::default(),
+        )?;
+        let handles: Vec<_> = sessions.peers().cloned().collect();
+        let mut tasks = Vec::with_capacity(handles.len() * 2);
+        for handle in handles {
+            tasks.push(tokio::spawn(watch_link_state(
+                Arc::clone(&state),
+                handle.clone(),
+            )));
+            tasks.push(tokio::spawn(watch_connection(Arc::clone(&state), handle)));
+        }
+        info!(peers = config.peers.len(), "Flow runtime armed");
+        Ok(Self {
+            state,
+            sessions,
+            tasks,
+            _advertiser: advertiser,
+            _endpoint: endpoint,
+        })
+    }
+
+    async fn update_devices(&self, snapshots: &[FlowDeviceSnapshot]) {
+        self.state.update_devices(snapshots);
+        self.state.publish_device_state().await;
+        inventory_changed(Arc::clone(&self.state)).await;
+    }
+
+    async fn shutdown(mut self) {
+        {
+            let _lifecycle = self.state.lifecycle.lock().await;
+            self.state.active.store(false, Ordering::Release);
+        }
+        self.sessions.shutdown().await;
+        for task in self.tasks.drain(..) {
+            let _ = task.await;
+        }
+    }
+}
+
+pub(super) struct GenerationState {
+    pub(super) config: Arc<CompiledFlowConfig>,
+    pub(super) devices: RwLock<Vec<RuntimeDevice>>,
+    connections: RwLock<HashMap<PublicKey, Arc<FlowConnection>>>,
+    link_states: RwLock<HashMap<PublicKey, LinkState>>,
+    observable: Arc<ObservableState>,
+    channel_pool: ChannelPool,
+    receiver_access: ReceiverAccess,
+    device_revision: AtomicU64,
+    peer_revision: AtomicU64,
+    active: AtomicBool,
+    pub(super) lifecycle: Mutex<()>,
+    pub(super) handoffs: HandoffBook,
+}
+
+#[derive(Clone)]
+pub(super) struct OutgoingDevice {
+    route: DeviceRoute,
+    host: u8,
+    pub(super) identity: proto::DeviceIdentity,
+}
+
+impl GenerationState {
+    fn new(
+        config: Arc<CompiledFlowConfig>,
+        snapshots: &[FlowDeviceSnapshot],
+        observable: Arc<ObservableState>,
+        channel_pool: ChannelPool,
+        receiver_access: ReceiverAccess,
+    ) -> Self {
+        let devices = runtime_devices(&config, snapshots);
+        Self {
+            config,
+            devices: RwLock::new(devices),
+            connections: RwLock::new(HashMap::new()),
+            link_states: RwLock::new(HashMap::new()),
+            observable,
+            channel_pool,
+            receiver_access,
+            device_revision: AtomicU64::new(1),
+            peer_revision: AtomicU64::new(1),
+            active: AtomicBool::new(true),
+            lifecycle: Mutex::new(()),
+            handoffs: HandoffBook::default(),
+        }
+    }
+
+    pub(super) fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+
+    fn update_devices(&self, snapshots: &[FlowDeviceSnapshot]) {
+        if let Ok(mut devices) = self.devices.write() {
+            *devices = runtime_devices(&self.config, snapshots);
+            self.device_revision.fetch_add(1, Ordering::Relaxed);
+            self.peer_revision.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(super) fn devices_snapshot(&self) -> Vec<RuntimeDevice> {
+        self.devices
+            .read()
+            .map_or_else(|_| Vec::new(), |devices| devices.clone())
+    }
+
+    pub(super) fn connection(&self, peer: PublicKey) -> Option<Arc<FlowConnection>> {
+        self.connections
+            .read()
+            .ok()
+            .and_then(|connections| connections.get(&peer).cloned())
+    }
+
+    fn set_connection(&self, peer: PublicKey, connection: Option<Arc<FlowConnection>>) {
+        if let Ok(mut connections) = self.connections.write() {
+            match connection {
+                Some(connection) => {
+                    connections.insert(peer, connection);
+                }
+                None => {
+                    connections.remove(&peer);
+                }
+            }
+        }
+    }
+
+    async fn set_link_state(&self, peer: PublicKey, state: LinkState) {
+        let _lifecycle = self.lifecycle.lock().await;
+        if !self.is_active() {
+            return;
+        }
+        if let Ok(mut states) = self.link_states.write() {
+            states.insert(peer, state);
+        }
+        self.publish_status();
+    }
+
+    fn publish_status(&self) {
+        let states = self.link_states.read().ok();
+        self.observable.set_flow(FlowStatus {
+            enabled: self.config.enabled,
+            peers: self
+                .config
+                .peers
+                .iter()
+                .map(|peer| FlowPeerStatus {
+                    name: peer.name.clone(),
+                    public_key: peer.canonical_key.clone(),
+                    state: states
+                        .as_ref()
+                        .and_then(|states| states.get(&peer.public_key))
+                        .copied()
+                        .map_or(FlowLinkState::Lost, ipc_link_state),
+                })
+                .collect(),
+        });
+    }
+
+    pub(super) fn outgoing_devices(&self, peer: &str) -> Vec<OutgoingDevice> {
+        let mut devices: Vec<_> = self
+            .devices_snapshot()
+            .into_iter()
+            .filter(|device| device.snapshot.online)
+            .filter_map(|device| {
+                let route = device.snapshot.route.clone()?;
+                let host = device.channels.get(peer).copied()?;
+                Some((
+                    device.snapshot.kind,
+                    OutgoingDevice {
+                        route,
+                        host,
+                        identity: device.identity,
+                    },
+                ))
+            })
+            .collect();
+        devices.sort_by_key(|(kind, _)| {
+            if is_pointing_device(*kind) {
+                0
+            } else if *kind == openlogi_core::device::DeviceKind::Keyboard {
+                2
+            } else {
+                1
+            }
+        });
+        devices.into_iter().map(|(_, device)| device).collect()
+    }
+
+    pub(super) async fn switch_devices(
+        &self,
+        devices: &[OutgoingDevice],
+    ) -> Result<bool, openlogi_hid::HostSwitchError> {
+        let _lease = self
+            .receiver_access
+            .acquire_exclusive(ExclusiveAccessReason::HostTransition)
+            .await;
+        if !self.is_active() {
+            return Ok(false);
+        }
+        let targets: Vec<_> = devices
+            .iter()
+            .map(|device| (device.route.clone(), device.host))
+            .collect();
+        openlogi_hid::switch_hosts(&targets, &self.channel_pool).await?;
+        Ok(true)
+    }
+
+    pub(super) async fn send_result(&self, peer: PublicKey, result: proto::HandoffResult) {
+        let Some(connection) = self.connection(peer) else {
+            return;
+        };
+        if let Ok(envelope) = message_envelope(FrameKind::HandoffResult, &result) {
+            let _ = connection.notify(envelope).await;
+        }
+    }
+
+    pub(super) async fn send_cancel(
+        &self,
+        peer: PublicKey,
+        transfer_id: u64,
+        reason: proto::HandoffCancelReason,
+    ) {
+        let Some(connection) = self.connection(peer) else {
+            return;
+        };
+        let cancel = proto::HandoffCancel {
+            transfer_id,
+            reason: reason.into(),
+            ..Default::default()
+        };
+        if let Ok(envelope) = message_envelope(FrameKind::HandoffCancel, &cancel) {
+            let _ = connection.notify(envelope).await;
+        }
+    }
+
+    async fn publish_device_state(&self) {
+        let initial = self.initial_state(PublicKey::new([0; 32]));
+        let connections: Vec<_> = self.connections.read().map_or_else(
+            |_| Vec::new(),
+            |connections| connections.values().cloned().collect(),
+        );
+        for connection in connections {
+            if let Ok(envelope) =
+                message_envelope(FrameKind::AnnounceDevices, &initial.announce_devices)
+            {
+                let _ = connection.notify(envelope).await;
+            }
+            if let Ok(envelope) = message_envelope(FrameKind::PeerState, &initial.peer_state) {
+                let _ = connection.notify(envelope).await;
+            }
+        }
+    }
+}
+
+impl TrustedStateProvider for GenerationState {
+    fn initial_state(&self, _peer_key: PublicKey) -> TrustedInitialState {
+        let devices = self.devices_snapshot();
+        TrustedInitialState {
+            announce_devices: proto::AnnounceDevices {
+                devices: devices
+                    .iter()
+                    .map(|device| {
+                        let mut view = proto::DeviceView {
+                            channel_to_me: u32::from(
+                                device.channels.get("self").copied().unwrap_or_default(),
+                            ),
+                            connected: device.snapshot.online,
+                            host_count: device
+                                .channels
+                                .values()
+                                .copied()
+                                .max()
+                                .map_or(0, |host| u32::from(host) + 1),
+                            ..Default::default()
+                        };
+                        *view.identity.get_or_insert_default() = device.identity.clone();
+                        view
+                    })
+                    .collect(),
+                revision: self.device_revision.load(Ordering::Relaxed),
+                ..Default::default()
+            },
+            peer_state: proto::PeerState {
+                flow_enabled: self.config.enabled,
+                held: devices
+                    .iter()
+                    .filter(|device| device.snapshot.online)
+                    .map(|device| device.identity.clone())
+                    .collect(),
+                revision: self.peer_revision.load(Ordering::Relaxed),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+fn runtime_devices(
+    config: &CompiledFlowConfig,
+    snapshots: &[FlowDeviceSnapshot],
+) -> Vec<RuntimeDevice> {
+    snapshots
+        .iter()
+        .filter_map(|snapshot| {
+            let channels = config.devices.get(&snapshot.config_key)?.clone();
+            let identity = snapshot.identity();
+            (!identity.ids.is_empty()).then(|| RuntimeDevice {
+                snapshot: snapshot.clone(),
+                identity,
+                channels,
+            })
+        })
+        .collect()
+}
+
+async fn watch_link_state(state: Arc<GenerationState>, handle: PeerSessionHandle) {
+    let peer = handle.public_key();
+    let mut changes = handle.subscribe_state();
+    let current = *changes.borrow_and_update();
+    state.set_link_state(peer, current).await;
+    while changes.changed().await.is_ok() {
+        let current = *changes.borrow_and_update();
+        state.set_link_state(peer, current).await;
+    }
+    state.set_link_state(peer, LinkState::Lost).await;
+}
+
+async fn watch_connection(state: Arc<GenerationState>, handle: PeerSessionHandle) {
+    let peer = handle.public_key();
+    let mut changes = handle.subscribe_connection();
+    let mut application: Option<JoinHandle<()>> = None;
+    loop {
+        if let Some(task) = application.take() {
+            task.abort();
+            let _ = task.await;
+        }
+        let connection = changes.borrow_and_update().clone();
+        state.set_connection(peer, connection.clone());
+        if let Some(connection) = connection {
+            application = Some(tokio::spawn(run_application_connection(
+                Arc::clone(&state),
+                peer,
+                connection,
+            )));
+        }
+        if changes.changed().await.is_err() {
+            break;
+        }
+    }
+    if let Some(task) = application {
+        task.abort();
+        let _ = task.await;
+    }
+    state.set_connection(peer, None);
+}
+
+async fn run_application_connection(
+    state: Arc<GenerationState>,
+    peer: PublicKey,
+    connection: Arc<FlowConnection>,
+) {
+    loop {
+        tokio::select! {
+            rpc = connection.accept_rpc() => match rpc {
+                Ok(event @ (RpcEvent::Request(_) | RpcEvent::Rejected(_))) => {
+                    handle_rpc(Arc::clone(&state), peer, event).await;
+                }
+                Err(_) => return,
+            },
+            notification = connection.accept_notification() => match notification {
+                Ok(event @ (NotificationEvent::Notification(_) | NotificationEvent::Dropped(_))) => {
+                    handle_notification(Arc::clone(&state), peer, event).await;
+                }
+                Err(_) => return,
+            },
+        }
+    }
+}
+
+pub(super) fn warp_entry(entry: &proto::EntryPoint) {
+    let Some(side) = entry.side.as_known() else {
+        return;
+    };
+    let displays = openlogi_hook::display_rects();
+    let edges = ExposedEdges::from_displays(&displays);
+    let Some((x, y)) = point_on_edge(&edges, side, entry.t) else {
+        return;
+    };
+    if !openlogi_inject::warp_cursor(x, y) {
+        warn!("Flow device arrived, but cursor warp is unsupported on this display server");
+    }
+}
+
+fn point_on_edge(edges: &ExposedEdges, side: proto::Side, t: f64) -> Option<(f64, f64)> {
+    const INSET: f64 = 1.0;
+    let side = match side {
+        proto::Side::Left => EdgeSide::Left,
+        proto::Side::Right => EdgeSide::Right,
+        proto::Side::Top => EdgeSide::Top,
+        proto::Side::Bottom => EdgeSide::Bottom,
+        proto::Side::Unspecified => return None,
+    };
+    let segments: Vec<_> = edges.for_side(side).collect();
+    let total: f64 = segments
+        .iter()
+        .map(|segment| segment.end() - segment.start())
+        .sum();
+    if total <= 0.0 {
+        return None;
+    }
+    let mut offset = t.clamp(0.0, 1.0) * total;
+    let segment = segments.iter().find(|segment| {
+        let length = segment.end() - segment.start();
+        if offset <= length {
+            true
+        } else {
+            offset -= length;
+            false
+        }
+    })?;
+    let along = (segment.start() + offset).min(segment.end());
+    Some(match side {
+        EdgeSide::Left => (segment.coordinate() + INSET, along),
+        EdgeSide::Right => (segment.coordinate() - INSET, along),
+        EdgeSide::Top => (along, segment.coordinate() + INSET),
+        EdgeSide::Bottom => (along, segment.coordinate() - INSET),
+    })
+}
+
+const fn ipc_link_state(state: LinkState) -> FlowLinkState {
+    match state {
+        LinkState::Connected => FlowLinkState::Connected,
+        LinkState::Degraded => FlowLinkState::Degraded,
+        LinkState::Lost => FlowLinkState::Lost,
+    }
+}
+
+fn machine_name() -> String {
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .ok()
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "OpenLogi".to_owned())
+}
+
+fn platform() -> proto::Platform {
+    if cfg!(target_os = "macos") {
+        proto::Platform::Macos
+    } else if cfg!(target_os = "linux") {
+        if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+            proto::Platform::LinuxWayland
+        } else {
+            proto::Platform::LinuxX11
+        }
+    } else if cfg!(target_os = "windows") {
+        proto::Platform::Windows
+    } else {
+        proto::Platform::Other
+    }
+}
+
+fn load_machine_identity() -> Result<MachineIdentity, FlowRuntimeError> {
+    let path = openlogi_core::paths::data_dir()?.join(FLOW_IDENTITY_FILE);
+    load_machine_identity_at(&path)
+}
+
+fn load_machine_identity_at(path: &Path) -> Result<MachineIdentity, FlowRuntimeError> {
+    match fs::read(path) {
+        Ok(bytes) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+            }
+            return MachineIdentity::from_pkcs8(bytes).map_err(FlowRuntimeError::from);
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let identity = MachineIdentity::generate()?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    match options.open(path) {
+        Ok(mut file) => {
+            file.write_all(identity.private_key_pkcs8())?;
+            file.sync_all()?;
+            Ok(identity)
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            MachineIdentity::from_pkcs8(fs::read(path)?).map_err(FlowRuntimeError::from)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[derive(Debug, Error)]
+enum FlowRuntimeError {
+    #[error(transparent)]
+    Paths(#[from] openlogi_core::paths::PathsError),
+    #[error("Flow identity I/O failed: {0}")]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Identity(#[from] openlogi_flow::transport::IdentityError),
+    #[error(transparent)]
+    Transport(#[from] openlogi_flow::transport::TransportError),
+    #[error(transparent)]
+    Discovery(#[from] openlogi_flow::discovery::DiscoveryError),
+    #[error(transparent)]
+    Session(#[from] openlogi_flow::session::SessionManagerError),
+    #[error("Flow identity task failed: {0}")]
+    IdentityTask(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openlogi_hook::edge::DisplayRect;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+    use tempfile::tempdir;
+
+    #[test]
+    fn maps_entry_across_disconnected_exposed_segments() {
+        let displays = [
+            DisplayRect::new(0.0, 0.0, 100.0, 100.0).unwrap(),
+            DisplayRect::new(0.0, 200.0, 100.0, 100.0).unwrap(),
+        ];
+        let edges = ExposedEdges::from_displays(&displays);
+        assert_eq!(
+            point_on_edge(&edges, proto::Side::Left, 0.25),
+            Some((1.0, 50.0))
+        );
+        assert_eq!(
+            point_on_edge(&edges, proto::Side::Left, 0.75),
+            Some((1.0, 250.0))
+        );
+    }
+
+    #[test]
+    fn machine_identity_is_persistent_and_private() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join(FLOW_IDENTITY_FILE);
+        let first = load_machine_identity_at(&path).expect("generate identity");
+
+        #[cfg(unix)]
+        {
+            let mode = fs::metadata(&path)
+                .expect("identity metadata")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+                .expect("loosen permissions for reload test");
+        }
+
+        let second = load_machine_identity_at(&path).expect("reload identity");
+        assert_eq!(first.public_key(), second.public_key());
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("identity metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn invalid_machine_identity_is_not_silently_replaced() {
+        let directory = tempdir().expect("temporary directory");
+        let path = directory.path().join(FLOW_IDENTITY_FILE);
+        let invalid = b"not a PKCS#8 Ed25519 private key";
+        fs::write(&path, invalid).expect("write invalid identity");
+
+        assert!(matches!(
+            load_machine_identity_at(&path),
+            Err(FlowRuntimeError::Identity(_))
+        ));
+        assert_eq!(fs::read(path).expect("read invalid identity"), invalid);
+    }
+}

--- a/crates/openlogi-agent-core/src/flow/runtime/controller.rs
+++ b/crates/openlogi-agent-core/src/flow/runtime/controller.rs
@@ -1,0 +1,334 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+use openlogi_core::config::FlowConfig;
+use openlogi_hid::ChannelPool;
+use openlogi_hook::edge::{
+    ArmedSides, EdgeCrossing, EdgeDetector, EdgeDetectorParams, ExposedEdges,
+};
+use openlogi_ipc::{FlowLinkState, FlowPeerStatus, FlowStatus};
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use super::FlowGeneration;
+use crate::flow::FlowDeviceSnapshot;
+use crate::flow::config::CompiledFlowConfig;
+use crate::flow::handoff::start_outgoing;
+use crate::observable::ObservableState;
+use crate::receiver_access::ReceiverAccess;
+
+const CONTROL_QUEUE: usize = 4;
+const GEOMETRY_REFRESH: Duration = Duration::from_secs(2);
+
+/// Cloneable owner of Flow's dormant configuration and armed network runtime.
+#[derive(Clone)]
+pub struct FlowController {
+    inner: Arc<ControllerInner>,
+}
+
+struct ControllerInner {
+    config: RwLock<FlowConfig>,
+    devices: RwLock<Vec<FlowDeviceSnapshot>>,
+    observable: Arc<ObservableState>,
+    control_tx: mpsc::UnboundedSender<Control>,
+    control_rx: Mutex<Option<mpsc::UnboundedReceiver<Control>>>,
+    movement_tx: mpsc::Sender<Movement>,
+    movement_rx: Mutex<Option<mpsc::Receiver<Movement>>>,
+    edge_settings: Arc<RwLock<EdgeSettings>>,
+    channel_pool: ChannelPool,
+    receiver_access: ReceiverAccess,
+    armed: AtomicBool,
+}
+
+/// Bounded, callback-safe input seam for pointer movement.
+#[derive(Clone)]
+pub struct FlowInputHandle {
+    movement: mpsc::Sender<Movement>,
+}
+
+#[derive(Clone, Copy)]
+struct Movement {
+    control_held: bool,
+}
+
+enum Control {
+    Reconfigure(FlowConfig),
+    Devices(Vec<FlowDeviceSnapshot>),
+    Crossing(EdgeCrossing),
+}
+
+#[derive(Clone)]
+struct EdgeSettings {
+    enabled: bool,
+    require_modifier: bool,
+    sides: ArmedSides,
+    revision: u64,
+}
+
+impl FlowController {
+    #[must_use]
+    pub fn new(
+        config: FlowConfig,
+        observable: Arc<ObservableState>,
+        channel_pool: ChannelPool,
+        receiver_access: ReceiverAccess,
+    ) -> Self {
+        let (control_tx, control_rx) = mpsc::unbounded_channel();
+        let (movement_tx, movement_rx) = mpsc::channel(CONTROL_QUEUE);
+        let edge_settings = edge_settings(&config, 0);
+        observable.set_flow(status_from_config(&config));
+        Self {
+            inner: Arc::new(ControllerInner {
+                config: RwLock::new(config),
+                devices: RwLock::new(Vec::new()),
+                observable,
+                control_tx,
+                control_rx: Mutex::new(Some(control_rx)),
+                movement_tx,
+                movement_rx: Mutex::new(Some(movement_rx)),
+                edge_settings: Arc::new(RwLock::new(edge_settings)),
+                channel_pool,
+                receiver_access,
+                armed: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Start Flow networking and edge processing after the agent's dormancy gate.
+    pub fn arm(&self) {
+        if self.inner.armed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let control = self
+            .inner
+            .control_rx
+            .lock()
+            .ok()
+            .and_then(|mut receiver| receiver.take());
+        let movement = self
+            .inner
+            .movement_rx
+            .lock()
+            .ok()
+            .and_then(|mut receiver| receiver.take());
+        let (Some(control), Some(movement)) = (control, movement) else {
+            warn!("Flow controller channels unavailable — Flow remains disabled");
+            return;
+        };
+        let config = self
+            .inner
+            .config
+            .read()
+            .map_or_else(|_| FlowConfig::default(), |config| config.clone());
+        let devices = self
+            .inner
+            .devices
+            .read()
+            .map_or_else(|_| Vec::new(), |devices| devices.clone());
+        tokio::spawn(run_controller(
+            Arc::clone(&self.inner),
+            control,
+            config,
+            devices,
+        ));
+        tokio::spawn(run_edge_input(
+            movement,
+            Arc::clone(&self.inner.edge_settings),
+            self.inner.control_tx.clone(),
+        ));
+    }
+
+    /// Apply a live `[flow]` config reload.
+    pub fn update_config(&self, config: &FlowConfig) {
+        if let Ok(mut current) = self.inner.config.write() {
+            *current = config.clone();
+        }
+        let revision = self
+            .inner
+            .edge_settings
+            .read()
+            .map_or(1, |settings| settings.revision.wrapping_add(1));
+        if let Ok(mut settings) = self.inner.edge_settings.write() {
+            *settings = edge_settings(config, revision);
+        }
+        if self.inner.armed.load(Ordering::Acquire)
+            && self
+                .inner
+                .control_tx
+                .send(Control::Reconfigure(config.clone()))
+                .is_ok()
+        {
+            return;
+        }
+        self.inner.observable.set_flow(status_from_config(config));
+    }
+
+    /// Publish a fresh inventory-derived Flow device snapshot.
+    pub(crate) fn update_devices(&self, devices: Vec<FlowDeviceSnapshot>) {
+        if let Ok(mut current) = self.inner.devices.write() {
+            current.clone_from(&devices);
+        }
+        if self.inner.armed.load(Ordering::Acquire) {
+            let _ = self.inner.control_tx.send(Control::Devices(devices));
+        }
+    }
+
+    /// Clone the bounded input seam installed in the OS hook.
+    #[must_use]
+    pub fn input(&self) -> FlowInputHandle {
+        FlowInputHandle {
+            movement: self.inner.movement_tx.clone(),
+        }
+    }
+}
+
+impl FlowInputHandle {
+    /// Queue one pointer movement without blocking the OS hook callback.
+    pub fn try_moved(&self, control_held: bool) {
+        let _ = self.movement.try_send(Movement { control_held });
+    }
+}
+
+fn status_from_config(config: &FlowConfig) -> FlowStatus {
+    CompiledFlowConfig::compile(config).map_or_else(
+        |_| FlowStatus {
+            enabled: config.enabled,
+            peers: config
+                .peers
+                .iter()
+                .map(|peer| FlowPeerStatus {
+                    name: peer.name.clone(),
+                    public_key: peer.public_key.clone(),
+                    state: FlowLinkState::Lost,
+                })
+                .collect(),
+        },
+        |compiled| compiled.status(),
+    )
+}
+
+fn edge_settings(config: &FlowConfig, revision: u64) -> EdgeSettings {
+    let compiled = CompiledFlowConfig::compile(config).ok();
+    let sides = compiled.as_ref().map_or(ArmedSides::NONE, |compiled| {
+        ArmedSides::from_sides(compiled.layout.keys().copied())
+    });
+    EdgeSettings {
+        enabled: compiled.as_ref().is_some_and(|compiled| compiled.enabled),
+        require_modifier: config.require_modifier,
+        sides,
+        revision,
+    }
+}
+
+async fn run_controller(
+    inner: Arc<ControllerInner>,
+    mut control: mpsc::UnboundedReceiver<Control>,
+    initial_config: FlowConfig,
+    mut devices: Vec<FlowDeviceSnapshot>,
+) {
+    let mut generation = start_generation(&inner, &initial_config, &devices).await;
+    while let Some(command) = control.recv().await {
+        match command {
+            Control::Reconfigure(config) => {
+                if let Some(active) = generation.take() {
+                    active.shutdown().await;
+                }
+                generation = start_generation(&inner, &config, &devices).await;
+            }
+            Control::Devices(next) => {
+                devices = next;
+                if let Some(active) = &generation {
+                    active.update_devices(&devices).await;
+                }
+            }
+            Control::Crossing(crossing) => {
+                if let Some(active) = &generation {
+                    start_outgoing(Arc::clone(&active.state), crossing);
+                }
+            }
+        }
+    }
+    if let Some(active) = generation {
+        active.shutdown().await;
+    }
+}
+
+async fn start_generation(
+    inner: &Arc<ControllerInner>,
+    config: &FlowConfig,
+    devices: &[FlowDeviceSnapshot],
+) -> Option<FlowGeneration> {
+    inner.observable.set_flow(status_from_config(config));
+    let compiled = match CompiledFlowConfig::compile(config) {
+        Ok(compiled) => Arc::new(compiled),
+        Err(error) => {
+            warn!(%error, "invalid Flow configuration — networking not started");
+            return None;
+        }
+    };
+    inner.observable.set_flow(compiled.status());
+    if !compiled.enabled {
+        return None;
+    }
+    match FlowGeneration::start(
+        compiled,
+        devices,
+        Arc::clone(&inner.observable),
+        inner.channel_pool.clone(),
+        inner.receiver_access.clone(),
+    )
+    .await
+    {
+        Ok(generation) => Some(generation),
+        Err(error) => {
+            warn!(%error, "Flow runtime failed to start");
+            None
+        }
+    }
+}
+
+async fn run_edge_input(
+    mut movement: mpsc::Receiver<Movement>,
+    settings: Arc<RwLock<EdgeSettings>>,
+    control: mpsc::UnboundedSender<Control>,
+) {
+    let epoch = Instant::now();
+    let mut detector = None;
+    let mut active_revision = u64::MAX;
+    let mut refreshed_at = Instant::now()
+        .checked_sub(GEOMETRY_REFRESH)
+        .unwrap_or_else(Instant::now);
+    while let Some(movement) = movement.recv().await {
+        let current = settings.read().map_or_else(
+            |_| edge_settings(&FlowConfig::default(), 0),
+            |value| value.clone(),
+        );
+        if !current.enabled || (current.require_modifier && !movement.control_held) {
+            detector = None;
+            continue;
+        }
+        let refresh = current.revision != active_revision
+            || Instant::now().duration_since(refreshed_at) >= GEOMETRY_REFRESH;
+        if refresh {
+            let displays = openlogi_hook::display_rects();
+            detector = (!displays.is_empty()).then(|| {
+                EdgeDetector::new(
+                    ExposedEdges::from_displays(&displays),
+                    current.sides,
+                    EdgeDetectorParams::default(),
+                )
+            });
+            active_revision = current.revision;
+            refreshed_at = Instant::now();
+        }
+        let (Some(detector), Some(position)) =
+            (detector.as_mut(), openlogi_hook::cursor_position())
+        else {
+            continue;
+        };
+        if let Some(crossing) = detector.update(position, epoch.elapsed()) {
+            let _ = control.send(Control::Crossing(crossing));
+        }
+    }
+}

--- a/crates/openlogi-agent-core/src/lib.rs
+++ b/crates/openlogi-agent-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod action_ring;
 pub mod capture_plan;
 mod dpi;
 pub mod event_monitor;
+pub mod flow;
 pub mod hardware;
 pub mod observable;
 pub mod orchestrator;

--- a/crates/openlogi-agent-core/src/observable.rs
+++ b/crates/openlogi-agent-core/src/observable.rs
@@ -19,8 +19,8 @@ use openlogi_core::brand::is_openlogi_foreground_id;
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
 use openlogi_hook::Hook;
 use openlogi_ipc::{
-    AgentSnapshot, AgentStatus, ForegroundApps, FoundDevice, Generation, InventoryHealth,
-    OBSERVE_HOLD, Observation, PROTOCOL_VERSION, PairingPhase, RECENT_APPS,
+    AgentSnapshot, AgentStatus, FlowStatus, ForegroundApps, FoundDevice, Generation,
+    InventoryHealth, OBSERVE_HOLD, Observation, PROTOCOL_VERSION, PairingPhase, RECENT_APPS,
 };
 use tokio::sync::watch;
 
@@ -60,6 +60,7 @@ impl ObservableState {
                 camera_active: false,
                 pairing: None,
                 foreground: ForegroundApps::default(),
+                flow: FlowStatus::default(),
             },
         });
         Self { tx }
@@ -206,6 +207,17 @@ impl ObservableState {
                 return false;
             }
             snapshot.pairing = phase;
+            true
+        });
+    }
+
+    /// Publish configured Flow peers and their coarse connection states.
+    pub fn set_flow(&self, flow: FlowStatus) {
+        self.update(|snapshot| {
+            if snapshot.flow == flow {
+                return false;
+            }
+            snapshot.flow = flow;
             true
         });
     }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -31,6 +31,7 @@ use tracing::{debug, info, warn};
 
 use crate::action_ring::ActionRingSessionSpec;
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans, plan_for_device};
+use crate::flow::{FlowController, FlowDeviceSnapshot};
 use crate::hardware::DeviceOp;
 use crate::observable::ObservableState;
 use crate::receiver_access::ReceiverAccess;
@@ -103,6 +104,8 @@ pub struct SharedRuntime {
     pub receiver_access: ReceiverAccess,
     /// Keyboard → pointing-device routes resolved from `config.toml`.
     pub host_switch_links: HostSwitchLinks,
+    /// Flow network, handoff, and edge runtime. Dormant until the agent arms.
+    pub flow: FlowController,
 }
 
 impl SharedRuntime {
@@ -194,6 +197,14 @@ impl Orchestrator {
     /// it carries are seeded here.
     #[must_use]
     pub fn new(config: Config, observable: Arc<ObservableState>) -> Self {
+        let channel_pool = openlogi_hid::host::channel_pool();
+        let receiver_access = ReceiverAccess::default();
+        let flow = FlowController::new(
+            config.flow.clone(),
+            Arc::clone(&observable),
+            channel_pool.clone(),
+            receiver_access.clone(),
+        );
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(config.keyboard.bindings.clone())),
@@ -205,12 +216,13 @@ impl Orchestrator {
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: ChannelRegistry::default(),
-            channel_pool: openlogi_hid::host::channel_pool(),
+            channel_pool,
             keyboard_spec: Arc::new(RwLock::new(None)),
             keyboard_channel: Arc::new(RwLock::new(None)),
             capture_rearm_generation: Arc::new(AtomicU64::new(0)),
-            receiver_access: ReceiverAccess::default(),
+            receiver_access,
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
+            flow,
         };
         let orch = Self {
             config,
@@ -347,6 +359,19 @@ impl Orchestrator {
             &self.shared.keyboard_spec,
             self.keyboard_spec_for(),
             "keyboard_spec",
+        );
+        self.shared.flow.update_devices(
+            self.devices
+                .iter()
+                .map(|device| FlowDeviceSnapshot {
+                    config_key: device.config_key.clone(),
+                    route: device.route.clone(),
+                    serial: device.serial.clone(),
+                    unit_id: device.unit_id,
+                    kind: device.kind,
+                    online: device.online,
+                })
+                .collect(),
         );
     }
 
@@ -763,6 +788,7 @@ impl Orchestrator {
         // Parameter-only edits must not erase a transient manual choice while
         // the light remains camera-linked. Changing the policy invalidates it.
         self.config = config;
+        self.shared.flow.update_config(&self.config.flow);
         self.shared.scroll_preferences.publish(
             self.config.app_settings.smooth_scroll,
             self.config.app_settings.vertical_scroll_sensitivity,

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -8,7 +8,8 @@ use super::{
 use openlogi_core::app::ForegroundApp;
 use openlogi_core::binding::{Action, Binding, ButtonId};
 use openlogi_core::config::{
-    Config, DeviceConfig, LightSettings, LinkConfig, ScrollResolution, VerticalScrollSensitivity,
+    Config, DeviceConfig, FlowPeer, LightSettings, LinkConfig, ScrollResolution,
+    VerticalScrollSensitivity,
 };
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
@@ -677,6 +678,34 @@ fn every_inventory_mutator_republishes_what_the_ipc_server_answers() {
     config.app_settings.launch_at_login = true;
     orch.reload_config(config);
     assert!(observable.snapshot().status.launch_at_login);
+}
+
+#[test]
+fn flow_config_is_published_on_startup_and_reload() {
+    let peer = FlowPeer {
+        name: "desk".to_string(),
+        public_key: format!("ed25519:{}", "01".repeat(32)),
+        addresses: vec!["desk.local:42424".to_string()],
+    };
+    let mut config = Config::default();
+    config.flow.enabled = true;
+    config.flow.peers.push(peer.clone());
+    let observable = Arc::new(ObservableState::new("test".to_string()));
+    let mut orch = Orchestrator::new(config, Arc::clone(&observable));
+
+    let published = observable.snapshot().flow;
+    assert!(published.enabled);
+    assert_eq!(published.peers.len(), 1);
+    assert_eq!(published.peers[0].name, peer.name);
+    assert_eq!(published.peers[0].public_key, peer.public_key);
+
+    let mut updated = Config::default();
+    updated.flow.peers.push(peer);
+    orch.reload_config(updated);
+
+    let published = observable.snapshot().flow;
+    assert!(!published.enabled);
+    assert_eq!(published.peers.len(), 1);
 }
 
 #[test]

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -430,6 +430,7 @@ pub fn start(
     dispatcher: ActionDispatcher,
     scroll: ScrollInputHandle,
     monitor: SharedEventMonitor,
+    flow: crate::flow::FlowInputHandle,
 ) -> Option<Hook> {
     if !Hook::has_accessibility() {
         warn!(
@@ -454,8 +455,11 @@ pub fn start(
                     device,
                 } => handle_button(id, pressed, device.as_ref(), &hooks, &dispatcher),
                 MouseEvent::Moved {
-                    delta_x, delta_y, ..
+                    delta_x,
+                    delta_y,
+                    modifiers,
                 } => {
+                    flow.try_moved(modifiers.control);
                     handle_moved(delta_x, delta_y, &hooks, &dispatcher)
                 }
                 MouseEvent::CaptureInterrupted => {

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -453,7 +453,9 @@ pub fn start(
                     pressed,
                     device,
                 } => handle_button(id, pressed, device.as_ref(), &hooks, &dispatcher),
-                MouseEvent::Moved { delta_x, delta_y } => {
+                MouseEvent::Moved {
+                    delta_x, delta_y, ..
+                } => {
                     handle_moved(delta_x, delta_y, &hooks, &dispatcher)
                 }
                 MouseEvent::CaptureInterrupted => {

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -56,9 +56,10 @@ use openlogi_hid::{
 use openlogi_ipc::transport;
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus, ClientKind,
-    ConfigReloadError, ForegroundApps, FoundDevice, Generation, Identity, InventoryHealth,
-    MonitorEvent, OBSERVE_HOLD, Observation, PROTOCOL_VERSION, PairingCommandError, PairingFailure,
-    PairingPhase, PairingUpdate, RingObservation, SwitchHostError,
+    ConfigReloadError, FlowStatus, ForegroundApps, FoundDevice, Generation, Identity,
+    InventoryHealth, MonitorEvent, OBSERVE_HOLD, Observation, PROTOCOL_VERSION,
+    PairingCommandError, PairingFailure, PairingPhase, PairingUpdate, RingObservation,
+    SwitchHostError,
 };
 use succession::Compat;
 use tarpc::context::Context;
@@ -760,6 +761,7 @@ fn snapshot_of(state: &State) -> AgentSnapshot {
         camera_active: state.camera_active(),
         pairing: state.phase.clone(),
         foreground: state.foreground(),
+        flow: FlowStatus::default(),
     }
 }
 

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -216,6 +216,7 @@ impl Wanted {
         // Closing the channel turns post-arming declarations into no-ops in
         // the server's `declare_client` handler.
         drop(demand);
+        shared.flow.arm();
         Armed {
             orchestrator,
             shared,
@@ -419,6 +420,7 @@ impl Armed {
             self.inputs.dispatcher.clone(),
             self.inputs.scroll_input.clone(),
             Arc::clone(&self.event_monitor),
+            self.shared.flow.input(),
         )
     }
 

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -390,6 +390,8 @@ mod tests {
     use std::sync::RwLock;
 
     use openlogi_agent_core::DpiCycles;
+    use openlogi_agent_core::flow::FlowController;
+    use openlogi_agent_core::observable::ObservableState;
     use openlogi_agent_core::receiver_access::ReceiverAccess;
     use openlogi_agent_core::runtime::hook::HookMaps;
     use openlogi_agent_core::runtime::scroll::ScrollPreferences;
@@ -397,6 +399,14 @@ mod tests {
     use openlogi_hid::PairingError;
 
     fn shared_runtime() -> SharedRuntime {
+        let channel_pool = openlogi_hid::host::channel_pool();
+        let receiver_access = ReceiverAccess::default();
+        let flow = FlowController::new(
+            openlogi_core::config::FlowConfig::default(),
+            Arc::new(ObservableState::new("test".to_owned())),
+            channel_pool.clone(),
+            receiver_access.clone(),
+        );
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
@@ -408,12 +418,13 @@ mod tests {
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: openlogi_hid::ChannelRegistry::default(),
-            channel_pool: openlogi_hid::host::channel_pool(),
+            channel_pool,
             keyboard_spec: Arc::new(RwLock::new(None)),
             keyboard_channel: Arc::new(RwLock::new(None)),
             capture_rearm_generation: Arc::new(0.into()),
-            receiver_access: ReceiverAccess::default(),
+            receiver_access,
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
+            flow,
         }
     }
 

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -50,7 +50,7 @@ pub use pairing::{
 };
 pub use session::gesture::{CaptureChannel, CapturedInput, GestureError, run_capture_session};
 pub use session::host_switch::{
-    HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_host_on,
+    HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_host_on, switch_hosts,
     switch_linked_hosts,
 };
 pub use session::keyboard::{

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -215,6 +215,31 @@ pub async fn switch_linked_hosts(
     Ok(changed)
 }
 
+/// Validate and switch several devices to independently configured host slots.
+///
+/// Every target is prepared before the first write, so an invalid or explicitly
+/// empty destination cannot strand an earlier device. Callers choose the apply
+/// order; Flow places pointing devices first and keyboards last because a
+/// keyboard leaving a shared receiver can remove the command path used by the
+/// other devices. A successful write remains fire-and-forget — destination
+/// arrival requires receiver-side connection evidence.
+pub async fn switch_hosts(
+    targets: &[(DeviceRoute, u8)],
+    channel_pool: &ChannelPool,
+) -> Result<(), HostSwitchError> {
+    let mut prepared = Vec::with_capacity(targets.len());
+    for (route, host) in targets {
+        let channel = open_channel(channel_pool, route, "opening Flow device channel")
+            .await?
+            .ok_or(HostSwitchError::TargetNotFound)?;
+        prepared.push(prepare_host_change_on(&channel, route.device_index(), *host).await?);
+    }
+    for change in prepared {
+        apply_host_change(change).await?;
+    }
+    Ok(())
+}
+
 /// Switch one device on an already-open shared channel to the zero-based `host`.
 ///
 /// The device's reported host count is validated before writing, and an

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -19,7 +19,7 @@ evdev = { workspace = true }
 libc = "0.2"
 wayland-client = "0.31"
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
-x11rb = "0.13"
+x11rb = { version = "0.13", features = ["randr"] }
 zbus = "5"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
@@ -41,6 +41,7 @@ objc2-core-foundation = { workspace = true, features = ["std", "CFDictionary", "
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_System_Threading",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -178,6 +178,8 @@ pub enum MouseEvent {
         delta_x: i32,
         /// Positive = down, negative = up.
         delta_y: i32,
+        /// Which modifiers were held during this movement sample.
+        modifiers: KeyModifiers,
     },
     /// The OS interrupted event capture (on macOS, the tap was disabled by a
     /// timeout or by competing user input). Any in-progress gesture hold must be
@@ -370,6 +372,11 @@ trait HookBackend {
     fn cursor_position() -> Option<CursorPosition> {
         None
     }
+
+    /// See [`crate::display_rects`].
+    fn display_rects() -> Vec<edge::DisplayRect> {
+        Vec::new()
+    }
 }
 
 /// The backend for a platform with no hook: every default, and a
@@ -539,6 +546,17 @@ pub fn frontmost_application() -> Option<ForegroundApp> {
 #[must_use]
 pub fn cursor_position() -> Option<CursorPosition> {
     Backend::cursor_position()
+}
+
+/// Return active display bounds in the same global coordinate space as
+/// [`cursor_position`].
+///
+/// Returns an empty vector when enumeration is unavailable. Native Wayland
+/// deliberately has no global display coordinate space, so it is unsupported
+/// unless an X11/XWayland display is reachable.
+#[must_use]
+pub fn display_rects() -> Vec<edge::DisplayRect> {
+    Backend::display_rects()
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -39,7 +39,7 @@ use tracing::{debug, error, warn};
 use x11rb::connection::Connection as _;
 use x11rb::properties::WmClass;
 use x11rb::protocol::randr::ConnectionExt as _;
-use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Window};
+use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, KeyButMask, Window};
 use x11rb::rust_connection::RustConnection;
 
 use crate::edge::DisplayRect;
@@ -403,7 +403,11 @@ fn scroll(delta_x: f64, delta_y: f64) -> MouseEvent {
     }
 }
 
-fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent> {
+fn translate_with_modifiers(
+    event: &evdev::InputEvent,
+    hires_scroll: bool,
+    modifiers: KeyModifiers,
+) -> Option<MouseEvent> {
     match event.destructure() {
         EventSummary::Key(_, key, value) => {
             let id = key_to_button(key)?;
@@ -423,12 +427,12 @@ fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent
             RelativeAxisCode::REL_X => Some(MouseEvent::Moved {
                 delta_x: value,
                 delta_y: 0,
-                modifiers: KeyModifiers::default(),
+                modifiers,
             }),
             RelativeAxisCode::REL_Y => Some(MouseEvent::Moved {
                 delta_x: 0,
                 delta_y: value,
-                modifiers: KeyModifiers::default(),
+                modifiers,
             }),
             _ => {
                 let v = f64::from(value);
@@ -453,6 +457,20 @@ fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent
             }
         },
         _ => None,
+    }
+}
+
+#[cfg(test)]
+fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent> {
+    translate_with_modifiers(event, hires_scroll, KeyModifiers::default())
+}
+
+fn modifiers_from_mask(mask: KeyButMask) -> KeyModifiers {
+    KeyModifiers {
+        shift: mask & KeyButMask::SHIFT != KeyButMask::default(),
+        control: mask & KeyButMask::CONTROL != KeyButMask::default(),
+        option: mask & KeyButMask::MOD1 != KeyButMask::default(),
+        command: mask & KeyButMask::MOD4 != KeyButMask::default(),
     }
 }
 
@@ -500,8 +518,10 @@ fn device_thread(
 
     let device_fd = device.as_raw_fd();
     let stop_fd = stop_rx.as_raw_fd();
+    let modifier_source = X11ModifierSource::connect();
     // Events that will be re-injected at the next SYN_REPORT.
     let mut pending: Vec<evdev::InputEvent> = Vec::new();
+    let mut report_modifiers = None;
 
     debug!("hook started on {}", path.display());
 
@@ -523,6 +543,7 @@ fn device_thread(
 
         for event in events {
             if let EventSummary::Synchronization(..) = event.destructure() {
+                report_modifiers = None;
                 // Flush the report. `emit()` appends its own SYN_REPORT, so the
                 // incoming sync event is dropped rather than re-emitted — pushing
                 // it would send a redundant second SYN_REPORT.
@@ -542,7 +563,23 @@ fn device_thread(
                     pending.clear();
                 }
             } else {
-                let disposition = match translate(&event, hires_scroll) {
+                let modifiers = if matches!(
+                    event.destructure(),
+                    EventSummary::RelativeAxis(
+                        _,
+                        RelativeAxisCode::REL_X | RelativeAxisCode::REL_Y,
+                        _
+                    )
+                ) {
+                    *report_modifiers.get_or_insert_with(|| {
+                        modifier_source
+                            .as_ref()
+                            .map_or_else(KeyModifiers::default, X11ModifierSource::current)
+                    })
+                } else {
+                    KeyModifiers::default()
+                };
+                let disposition = match translate_with_modifiers(&event, hires_scroll, modifiers) {
                     Some(me) => cb(HookEvent::Mouse(me)),
                     // Low-res companions (REL_WHEEL/REL_HWHEEL) must be suppressed when hi-res
                     // is active — passing them through would double the scroll distance.
@@ -573,6 +610,34 @@ fn device_thread(
 }
 
 // ── frontmost_app_id ─────────────────────────────────────────────────────────
+
+/// Persistent X11 connection used to snapshot keyboard modifiers for pointer
+/// reports. Flow already requires X11 global coordinates on Linux; native
+/// Wayland sessions without XWayland fall back to empty modifiers.
+struct X11ModifierSource {
+    conn: RustConnection,
+    root: Window,
+}
+
+impl X11ModifierSource {
+    fn connect() -> Option<Self> {
+        let (conn, screen_num) = RustConnection::connect(None)
+            .map_err(|error| debug!("X11 modifier state unavailable: {error}"))
+            .ok()?;
+        let root = conn.setup().roots[screen_num].root;
+        Some(Self { conn, root })
+    }
+
+    fn current(&self) -> KeyModifiers {
+        self.conn
+            .query_pointer(self.root)
+            .ok()
+            .and_then(|cookie| cookie.reply().ok())
+            .map_or_else(KeyModifiers::default, |reply| {
+                modifiers_from_mask(reply.mask)
+            })
+    }
+}
 
 // The frontmost-app reader is backend-driven so that Wayland support can be
 // added without touching callers. Exactly one backend is selected at startup
@@ -906,6 +971,38 @@ mod tests {
                 delta_y: -4,
                 ..
             })
+        );
+    }
+
+    #[test]
+    fn movement_preserves_current_modifiers() {
+        let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_X.0, 1);
+        let modifiers = KeyModifiers {
+            control: true,
+            ..KeyModifiers::default()
+        };
+
+        assert_matches!(
+            translate_with_modifiers(&event, false, modifiers),
+            Some(MouseEvent::Moved {
+                modifiers: observed,
+                ..
+            }) if observed == modifiers
+        );
+    }
+
+    #[test]
+    fn x11_modifier_mask_maps_to_hook_vocabulary() {
+        assert_eq!(
+            modifiers_from_mask(
+                KeyButMask::SHIFT | KeyButMask::CONTROL | KeyButMask::MOD1 | KeyButMask::MOD4
+            ),
+            KeyModifiers {
+                shift: true,
+                control: true,
+                option: true,
+                command: true,
+            }
         );
     }
 

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -38,12 +38,14 @@ use evdev::{
 use tracing::{debug, error, warn};
 use x11rb::connection::Connection as _;
 use x11rb::properties::WmClass;
+use x11rb::protocol::randr::ConnectionExt as _;
 use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Window};
 use x11rb::rust_connection::RustConnection;
 
+use crate::edge::DisplayRect;
 use crate::{
     ButtonId, CursorPosition, EventDisposition, ForegroundApp, HookBackend, HookError, HookEvent,
-    LOGITECH_VENDOR_ID, MouseEvent,
+    KeyModifiers, LOGITECH_VENDOR_ID, MouseEvent,
 };
 
 /// Prefix carried by every uinput device OpenLogi creates — the hook's
@@ -143,6 +145,45 @@ impl HookBackend for Backend {
             x: f64::from(reply.root_x),
             y: f64::from(reply.root_y),
         })
+    }
+
+    fn display_rects() -> Vec<DisplayRect> {
+        let Ok((connection, screen_index)) = RustConnection::connect(None) else {
+            return Vec::new();
+        };
+        let screen = &connection.setup().roots[screen_index];
+        let displays: Vec<_> = connection
+            .randr_get_monitors(screen.root, true)
+            .ok()
+            .and_then(|cookie| cookie.reply().ok())
+            .map(|reply| {
+                reply
+                    .monitors
+                    .into_iter()
+                    .filter_map(|monitor| {
+                        DisplayRect::new(
+                            f64::from(monitor.x),
+                            f64::from(monitor.y),
+                            f64::from(monitor.width),
+                            f64::from(monitor.height),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !displays.is_empty() {
+            return displays;
+        }
+        // RandR 1.5 is optional. Older X servers still provide one useful
+        // virtual-desktop rectangle through the core screen description.
+        DisplayRect::new(
+            0.0,
+            0.0,
+            f64::from(screen.width_in_pixels),
+            f64::from(screen.height_in_pixels),
+        )
+        .into_iter()
+        .collect()
     }
 }
 
@@ -382,10 +423,12 @@ fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent
             RelativeAxisCode::REL_X => Some(MouseEvent::Moved {
                 delta_x: value,
                 delta_y: 0,
+                modifiers: KeyModifiers::default(),
             }),
             RelativeAxisCode::REL_Y => Some(MouseEvent::Moved {
                 delta_x: 0,
                 delta_y: value,
+                modifiers: KeyModifiers::default(),
             }),
             _ => {
                 let v = f64::from(value);
@@ -847,7 +890,8 @@ mod tests {
             translate(&event, false),
             Some(MouseEvent::Moved {
                 delta_x: 7,
-                delta_y: 0
+                delta_y: 0,
+                ..
             })
         );
     }
@@ -859,7 +903,8 @@ mod tests {
             translate(&event, false),
             Some(MouseEvent::Moved {
                 delta_x: 0,
-                delta_y: -4
+                delta_y: -4,
+                ..
             })
         );
     }

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -20,6 +20,7 @@ use core_foundation::runloop::{
     CFRunLoop, CFRunLoopRunResult, kCFRunLoopCommonModes, kCFRunLoopDefaultMode,
 };
 use core_foundation::string::{CFString, CFStringRef};
+use core_graphics::display::{CGDisplayBounds, CGGetActiveDisplayList};
 use core_graphics::event::{
     CGEvent, CGEventField, CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions,
     CGEventTapPlacement, CGEventTapProxy, CGEventType, CallbackResult, EventField,
@@ -29,6 +30,7 @@ use foreign_types_shared::ForeignType as _;
 use objc2_application_services::{AXIsProcessTrusted, AXIsProcessTrustedWithOptions};
 use tracing::{debug, error, warn};
 
+use crate::edge::DisplayRect;
 use crate::{
     ButtonId, CursorPosition, EventDevice, EventDisposition, EventTapInfo, ForegroundApp,
     HookBackend, HookError, HookEvent, KeyEvent, KeyModifiers, MouseEvent, ScrollDelta,
@@ -280,12 +282,11 @@ fn translate_key(etype: CGEventType, event: &CGEvent) -> Option<KeyEvent> {
 }
 
 /// Convert a `CGEvent` to our [`MouseEvent`] vocabulary. Returns `None`
-/// for event types we don't translate (e.g. move events, unknown buttons).
+/// for event types we don't translate (for example, unknown buttons).
 fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
     // Skip events OpenLogi itself synthesised, so a remapped click or inverted
-    // scroll we posted doesn't re-enter the hook as real input. Gate the field
-    // read to events we synthesize — keeping the FFI call off the high-rate
-    // pointer-move stream.
+    // scroll we posted doesn't re-enter the hook as real input. MouseMoved is
+    // included because Flow cursor arrival uses one tagged synthetic move.
     let can_be_synthetic = matches!(
         etype,
         CGEventType::LeftMouseDown
@@ -295,6 +296,7 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             | CGEventType::OtherMouseDown
             | CGEventType::OtherMouseUp
             | CGEventType::ScrollWheel
+            | CGEventType::MouseMoved
     );
     if can_be_synthetic
         && event.get_integer_value_field(EventField::EVENT_SOURCE_USER_DATA)
@@ -387,6 +389,7 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             Some(MouseEvent::Moved {
                 delta_x: dx as i32,
                 delta_y: dy as i32,
+                modifiers: modifiers_from_flags(event.get_flags()),
             })
         }
         CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput => {
@@ -695,6 +698,30 @@ impl HookBackend for Backend {
             x: point.x,
             y: point.y,
         })
+    }
+
+    fn display_rects() -> Vec<DisplayRect> {
+        const MAX_DISPLAYS: u32 = 32;
+        let mut ids = [0u32; MAX_DISPLAYS as usize];
+        let mut count = 0;
+        // SAFETY: the list write is bounded by the capacity passed, and count
+        // reports how many active display ids CoreGraphics initialized.
+        if unsafe { CGGetActiveDisplayList(MAX_DISPLAYS, ids.as_mut_ptr(), &raw mut count) } != 0 {
+            return Vec::new();
+        }
+        ids.iter()
+            .take(count as usize)
+            .filter_map(|&id| {
+                // SAFETY: side-effect-free getter for an id from the active list.
+                let bounds = unsafe { CGDisplayBounds(id) };
+                DisplayRect::new(
+                    bounds.origin.x,
+                    bounds.origin.y,
+                    bounds.size.width,
+                    bounds.size.height,
+                )
+            })
+            .collect()
     }
 }
 

--- a/crates/openlogi-hook/src/tests.rs
+++ b/crates/openlogi-hook/src/tests.rs
@@ -36,6 +36,7 @@ fn mouse_event_clone_and_debug() {
         MouseEvent::Moved {
             delta_x: 3,
             delta_y: -2,
+            modifiers: KeyModifiers::default(),
         },
     ];
     for e in &events {

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -9,7 +9,10 @@ use std::cell::Cell;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
-use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, LPARAM, LRESULT, POINT, WPARAM};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, LPARAM, LRESULT, POINT, RECT, WPARAM,
+};
+use windows_sys::Win32::Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR};
 use windows_sys::Win32::System::Threading::{
     GetCurrentThreadId, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
 };
@@ -27,6 +30,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     WM_XBUTTONDOWN, WM_XBUTTONUP, XBUTTON1, XBUTTON2,
 };
 
+use crate::edge::DisplayRect;
 use crate::windows_worker::{WorkerEvent, WorkerPhase, WorkerStatus};
 use crate::{
     ButtonId, CursorPosition, EventDisposition, ForegroundApp, HookBackend, HookError, HookEvent,
@@ -186,6 +190,45 @@ impl HookBackend for Backend {
             y: f64::from(point.y),
         })
     }
+
+    fn display_rects() -> Vec<DisplayRect> {
+        let mut displays = Vec::new();
+        // SAFETY: null HDC/clip asks for every monitor; `displays` remains live
+        // and exclusively borrowed through dwData until this synchronous call
+        // returns, and the callback validates the RECT pointer before reading.
+        let result = unsafe {
+            EnumDisplayMonitors(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                Some(collect_display_rect),
+                std::ptr::from_mut(&mut displays).addr().cast_signed(),
+            )
+        };
+        if result == 0 { Vec::new() } else { displays }
+    }
+}
+
+unsafe extern "system" fn collect_display_rect(
+    _monitor: HMONITOR,
+    _device_context: HDC,
+    rect: *mut RECT,
+    displays: LPARAM,
+) -> i32 {
+    if rect.is_null() || displays == 0 {
+        return 0;
+    }
+    // SAFETY: EnumDisplayMonitors supplies a live RECT and the dwData pointer
+    // created from the exclusively borrowed Vec in `display_rects`.
+    let (rect, displays) = unsafe { (&*rect, &mut *(displays as *mut Vec<DisplayRect>)) };
+    if let Some(display) = DisplayRect::new(
+        f64::from(rect.left),
+        f64::from(rect.top),
+        f64::from(rect.right - rect.left),
+        f64::from(rect.bottom - rect.top),
+    ) {
+        displays.push(display);
+    }
+    1
 }
 
 #[expect(
@@ -461,7 +504,11 @@ fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
         }),
         WM_MOUSEMOVE => {
             let (delta_x, delta_y) = motion_delta(previous?, data.pt)?;
-            Some(MouseEvent::Moved { delta_x, delta_y })
+            Some(MouseEvent::Moved {
+                delta_x,
+                delta_y,
+                modifiers: current_modifiers(),
+            })
         }
         _ => None,
     }
@@ -637,7 +684,8 @@ mod tests {
             translate_event(WM_MOUSEMOVE as WPARAM, at(560, 395)),
             Some(MouseEvent::Moved {
                 delta_x: 60,
-                delta_y: -5
+                delta_y: -5,
+                ..
             })
         ));
         assert!(

--- a/crates/openlogi-inject/Cargo.toml
+++ b/crates/openlogi-inject/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = { workspace = true }
+x11rb = "0.13"
 zbus = "5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -42,4 +43,7 @@ objc2-core-graphics = { workspace = true, features = ["CGEvent"] }
 objc2-foundation = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys = { workspace = true, features = [
+  "Win32_UI_Input_KeyboardAndMouse",
+  "Win32_UI_WindowsAndMessaging",
+] }

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -330,6 +330,26 @@ pub fn ax_navigate_browser(pid: i32, forward: bool) -> bool {
     }
 }
 
+/// Move the system pointer to a global logical-pixel coordinate.
+///
+/// Returns `false` when the platform cannot provide global pointer control,
+/// notably on native Wayland. Invalid coordinates are rejected.
+#[must_use]
+pub fn warp_cursor(x: f64, y: f64) -> bool {
+    if !x.is_finite() || !y.is_finite() {
+        return false;
+    }
+    cfg_select! {
+        target_os = "macos" => { macos::warp_cursor(x, y) }
+        target_os = "linux" => { linux::warp_cursor(x, y) }
+        target_os = "windows" => { windows::warp_cursor(x, y) }
+        _ => {
+            let _ = (x, y);
+            false
+        }
+    }
+}
+
 /// Integer scroll units ready for a platform API.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct QuantizedScroll {

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -10,6 +10,9 @@ use std::sync::{LazyLock, Mutex};
 
 use evdev::uinput::VirtualDevice;
 use evdev::{AttributeSet, EventType, InputEvent, KeyCode, RelativeAxisCode};
+use x11rb::connection::Connection as _;
+use x11rb::protocol::xproto::ConnectionExt as _;
+use x11rb::rust_connection::RustConnection;
 use zbus::blocking::Connection as DbusConn;
 
 use openlogi_core::binding::{
@@ -29,6 +32,23 @@ struct ScrollOutput {
 
 static SCROLL_OUTPUT: LazyLock<Mutex<ScrollOutput>> =
     LazyLock::new(|| Mutex::new(ScrollOutput::default()));
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "X11's core pointer coordinates are i16; values are clamped before conversion"
+)]
+pub(super) fn warp_cursor(x: f64, y: f64) -> bool {
+    let Ok((connection, screen_index)) = RustConnection::connect(None) else {
+        return false;
+    };
+    let root = connection.setup().roots[screen_index].root;
+    let x = x.round().clamp(f64::from(i16::MIN), f64::from(i16::MAX)) as i16;
+    let y = y.round().clamp(f64::from(i16::MIN), f64::from(i16::MAX)) as i16;
+    let Ok(cookie) = connection.warp_pointer(x11rb::NONE, root, 0, 0, 0, 0, x, y) else {
+        return false;
+    };
+    cookie.check().is_ok() && connection.flush().is_ok()
+}
 
 /// Linux implementation: classify `action` into an [`Effect`] and inject the
 /// resulting events via a shared `uinput` virtual device.

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -26,6 +26,23 @@ static PIXEL_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
 static SMOOTH_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
     LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
 
+pub(super) fn warp_cursor(x: f64, y: f64) -> bool {
+    let Ok(source) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
+        return false;
+    };
+    let Ok(event) = CGEvent::new_mouse_event(
+        source,
+        CGEventType::MouseMoved,
+        CGPoint::new(x, y),
+        CGMouseButton::Left,
+    ) else {
+        return false;
+    };
+    tag_synthetic(&event);
+    event.post(CGEventTapLocation::HID);
+    true
+}
+
 // `core-graphics` 0.25 does not expose these `CGEventTypes.h` fields.
 const SCROLL_PHASE: u32 = 99; // kCGScrollWheelEventScrollPhase
 const MOMENTUM_PHASE: u32 = 123; // kCGScrollWheelEventMomentumPhase

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -10,6 +10,7 @@ use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
     MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL, MOUSEEVENTF_XDOWN,
     MOUSEEVENTF_XUP, MOUSEINPUT, SendInput,
 };
+use windows_sys::Win32::UI::WindowsAndMessaging::SetCursorPos;
 
 use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
@@ -23,6 +24,17 @@ const WHEEL_DELTA_F64: f64 = 120.0;
 
 static SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
     LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Win32 cursor coordinates are i32; values are clamped before conversion"
+)]
+pub(super) fn warp_cursor(x: f64, y: f64) -> bool {
+    let x = x.round().clamp(f64::from(i32::MIN), f64::from(i32::MAX)) as i32;
+    let y = y.round().clamp(f64::from(i32::MIN), f64::from(i32::MAX)) as i32;
+    // SAFETY: SetCursorPos takes two integer coordinates by value.
+    unsafe { SetCursorPos(x, y) != 0 }
+}
 
 const VK_D: u16 = 0x44;
 const VK_L: u16 = 0x4C;

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -4,7 +4,7 @@ mod inject;
 
 pub use inject::{
     HeldChord, SYNTHETIC_EVENT_USER_DATA, SmoothScrollPhase, ax_navigate_browser, execute,
-    post_scroll, post_smooth_scroll, press_hold,
+    post_scroll, post_smooth_scroll, press_hold, warp_cursor,
 };
 
 #[cfg(target_os = "linux")]

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -63,7 +63,9 @@ pub use succession::Identity;
 ///      the macOS dormancy gate.
 /// v30: `Agent::switch_host` + [`SwitchHostError`] appended — software-initiated
 ///      multi-host device switching.
-pub const PROTOCOL_VERSION: u32 = 30;
+/// v31: `AgentSnapshot::flow` appended — configured Flow peers and their
+///      coarse connection state.
+pub const PROTOCOL_VERSION: u32 = 31;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -140,6 +142,45 @@ pub struct AgentSnapshot {
     /// Which application per-app profiles are resolving against. See
     /// [`ForegroundApps`].
     pub foreground: ForegroundApps,
+    /// Cross-machine Flow availability and coarse peer connection state.
+    pub flow: FlowStatus,
+}
+
+/// Cross-machine Flow state suitable for the low-frequency agent snapshot.
+///
+/// Ping sequence numbers, RTT, and last-seen timestamps deliberately stay out
+/// of IPC: they would churn the observable generation without changing a UI
+/// decision.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlowStatus {
+    /// Whether the loaded config enables Flow.
+    pub enabled: bool,
+    /// Configured peers in config order.
+    pub peers: Vec<FlowPeerStatus>,
+}
+
+/// One configured Flow peer's display identity and coarse link state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlowPeerStatus {
+    /// User-visible name from `[flow].peers`.
+    pub name: String,
+    /// Canonical `ed25519:<64 lowercase hex>` pinned identity.
+    pub public_key: String,
+    /// Current application-level session state.
+    pub state: FlowLinkState,
+}
+
+/// Churn-safe state of one configured Flow peer session.
+///
+/// Variants are append-only because this enum crosses bincode IPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FlowLinkState {
+    /// QUIC and Flow Hello are established and application liveness is healthy.
+    Connected,
+    /// QUIC remains established, but application Pong liveness is stale.
+    Degraded,
+    /// No established Flow connection exists.
+    Lost,
 }
 
 /// The application the agent currently resolves per-app profiles against, and

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -45,9 +45,10 @@ use openlogi_core::hid::{
 };
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, ActionRingPresentation, AgentRequest,
-    AgentSnapshot, AgentStatus, ClientKind, ConfigReloadError, ForegroundApps, FoundDevice,
-    Identity, InventoryHealth, MonitorEvent, Observation, PROTOCOL_VERSION, PairingCommandError,
-    PairingFailure, PairingPhase, PairingUpdate, RingObservation, SwitchHostError,
+    AgentSnapshot, AgentStatus, ClientKind, ConfigReloadError, FlowLinkState, FlowPeerStatus,
+    FlowStatus, ForegroundApps, FoundDevice, Identity, InventoryHealth, MonitorEvent, Observation,
+    PROTOCOL_VERSION, PairingCommandError, PairingFailure, PairingPhase, PairingUpdate,
+    RingObservation, SwitchHostError,
 };
 use succession::{Compat, Run};
 
@@ -101,7 +102,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 30);
+    assert_eq!(PROTOCOL_VERSION, 31);
 }
 
 #[test]
@@ -361,15 +362,35 @@ fn agent_snapshot() {
         // Pinned on its own in `foreground_apps` below, like the inventory and
         // pairing fields.
         foreground: ForegroundApps::default(),
+        flow: FlowStatus::default(),
     };
-    assert_wire(&snapshot, "010001010705302e362e360100000000000000");
+    assert_wire(&snapshot, "010001010705302e362e3601000000000000000000");
 
     // The observation is the snapshot with its generation in front.
     let observed = Observation {
         generation: 3,
         snapshot,
     };
-    assert_wire(&observed, "03010001010705302e362e360100000000000000");
+    assert_wire(&observed, "03010001010705302e362e3601000000000000000000");
+}
+
+#[test]
+fn flow_status() {
+    assert_wire(&FlowStatus::default(), "0000");
+    assert_wire(
+        &FlowStatus {
+            enabled: true,
+            peers: vec![FlowPeerStatus {
+                name: "desk".into(),
+                public_key: format!("ed25519:{}", "ab".repeat(32)),
+                state: FlowLinkState::Degraded,
+            }],
+        },
+        "0101046465736b48656432353531393a6162616261626162616261626162616261626162616261626162616261626162616261626162616261626162616261626162616261626162616261626162616201",
+    );
+    assert_wire(&FlowLinkState::Connected, "00");
+    assert_wire(&FlowLinkState::Degraded, "01");
+    assert_wire(&FlowLinkState::Lost, "02");
 }
 
 /// The foreground application rides the snapshot, so both halves are pinned:


### PR DESCRIPTION
## Summary

Layer 5 of the Flow stack, on top of #1103. Connect configuration, edge detection, secure peer sessions, HID host switching, and receiver-side arrival evidence into the complete Flow handoff transaction.

## Changes

- `openlogi-agent-core`: load and hot-reload `[flow]`, persist the local Ed25519 identity, discover pinned peers, and publish coarse Flow status.
- Serialize runtime generations so stale sessions cannot publish state or perform host-switch transactions after reload.
- Connect `EdgeCrossing → HandoffRequest → Accept → switch_hosts → fresh receiver inventory → cursor warp → ARRIVED/PARTIAL/TIMEOUT acknowledgement`; send `Cancel` when switching fails.
- Register QUIC response waiters before requests so unordered streams cannot lose an early response.
- Batch multi-device host switching while preserving per-device outcomes.
- Add macOS, Windows, and X11 display geometry/cursor context and cursor warping; native Wayland reports unsupported.
- `openlogi-ipc`: append Flow peer state to `AgentSnapshot`, bump v30 to v31, and update wire goldens.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- Windows GNU cross-Clippy for hook, inject, agent-core, agent, device, HID, and IPC.
- `cargo xtask ci` — 11 passed, 0 failed, 1 skipped; only `tests (macos)` was not run in the Linux orb.

Not runtime-tested on real Easy-Switch hardware or across real hosts. The orb cannot exercise live mDNS multicast. macOS and Windows runtime paths were not executed; Windows GNU cross-Clippy passed. Bluetooth-direct arrival equivalence remains unverified. Native Wayland cannot provide global geometry/warp. Linux movement events currently cannot positively satisfy `require_modifier = true`. Pairing UI is not included; peers are configured with pinned keys.

Relates to #650
Fixes #253

Co-authored-by: Xuan Zhang <xuan@arcbox.dev>