### PR TITLE
fix(agent): restore diverted HID++ controls on a clean shutdown

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -39,6 +39,7 @@ use tracing::{debug, warn};
 
 use self::dispatch::InputDispatcher;
 use super::capture_session::{CaptureRecovery, CaptureSession, CaptureSlot, ReconcileAction};
+use super::shutdown::{ManagerCompletion, WatcherHandle};
 use crate::capture_plan::{CaptureTarget, DeviceCapturePlan, DispatchPlan, SharedCapturePlans};
 use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
 use crate::runtime::hook::SharedHookMaps;
@@ -87,6 +88,7 @@ impl GestureOutputs {
 /// Spawn the capture-manager thread. It owns a current-thread tokio runtime that
 /// keeps one capture session pointed at the active device and dispatches each
 /// captured input.
+#[must_use]
 pub fn spawn(
     capture_plans: &SharedCapturePlans,
     capture_channel: CaptureChannel,
@@ -94,9 +96,11 @@ pub fn spawn(
     channel_registry: openlogi_hid::ChannelRegistry,
     device_io: DeviceIoGate,
     outputs: GestureOutputs,
-) {
+) -> WatcherHandle {
     let plans = capture_plans.clone();
     let receiver_requests = receiver_access.subscribe_requests();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (shutdown_done_tx, shutdown_done_rx) = oneshot::channel();
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -105,19 +109,27 @@ pub fn spawn(
             Ok(rt) => rt,
             Err(e) => {
                 warn!(error = %e, "capture watcher: could not build tokio runtime");
+                let _ = shutdown_done_tx.send(ManagerCompletion::Graceful);
                 return;
             }
         };
-        runtime.block_on(manage(
-            plans,
+        let completion = runtime.block_on(manage(GestureManagerContext {
+            capture_plans: plans,
             capture_channel,
             receiver_access,
             receiver_requests,
             channel_registry,
             device_io,
             outputs,
-        ));
+            shutdown: shutdown_rx,
+        }));
+        // Detached session tasks belong to this current-thread runtime. Drop
+        // it before acknowledging so even an unexpected manager return cannot
+        // leave a late firmware writer behind the process boundary.
+        drop(runtime);
+        let _ = shutdown_done_tx.send(completion);
     });
+    WatcherHandle::new(shutdown_tx, shutdown_done_rx)
 }
 
 type RunningSession = CaptureSession<CaptureTarget, DispatchPlan>;
@@ -157,6 +169,17 @@ struct SessionChannels {
     capture: CaptureChannel,
     registry: openlogi_hid::ChannelRegistry,
     device_io: DeviceIoGate,
+}
+
+struct GestureManagerContext {
+    capture_plans: watch::Receiver<Arc<Vec<DeviceCapturePlan>>>,
+    capture_channel: CaptureChannel,
+    receiver_access: ReceiverAccess,
+    receiver_requests: watch::Receiver<ReceiverRequestState>,
+    channel_registry: openlogi_hid::ChannelRegistry,
+    device_io: DeviceIoGate,
+    outputs: GestureOutputs,
+    shutdown: oneshot::Receiver<()>,
 }
 
 /// Forward one capture session's inputs onto the manager's ordered event
@@ -527,18 +550,72 @@ impl GestureManagerState {
     }
 }
 
+/// Stop every tracked capture epoch and wait until each session task has
+/// reported ordered completion. Retain and retry pending restore tokens until
+/// the firmware ownership has been released.
+async fn drain_for_shutdown(
+    state: &mut GestureManagerState,
+    event_rx: &mut mpsc::UnboundedReceiver<SessionEvent>,
+    receiver_access: &ReceiverAccess,
+    receiver_requests: &watch::Receiver<ReceiverRequestState>,
+    capture_plans: &watch::Receiver<Arc<Vec<DeviceCapturePlan>>>,
+    channels: &SessionChannels,
+) {
+    for session in state
+        .slots
+        .values_mut()
+        .filter_map(GestureSlot::session_mut)
+    {
+        reconcile_session(session, None, &mut state.input_dispatcher);
+    }
+    while state.slots.values().any(|slot| slot.session().is_some()) {
+        let Some(event) = event_rx.recv().await else {
+            break;
+        };
+        state.handle_session_event(
+            event,
+            channels.device_io.allows_io(),
+            receiver_requests,
+            capture_plans,
+        );
+    }
+
+    state.expedite_pending_restores();
+    if state.has_pending_restores() {
+        warn!("capture watcher is waiting for pending firmware restoration before stopping");
+    }
+    let mut device_io = channels.device_io.clone();
+    while state.has_pending_restores() {
+        if !device_io.allows_io() && !device_io.wait_until_allowed().await {
+            // A closed suspended gate cannot prove firmware is native. The
+            // process lifecycle bounds terminal exits; confirmed replacement
+            // deliberately remains here rather than losing these tokens.
+            std::future::pending::<()>().await;
+        }
+        if let Some(_lease) = acquire_session_lease(receiver_access, &mut state.lease) {
+            retry_pending_restores(&mut state.slots, &channels.registry, Instant::now()).await;
+        }
+        if state.has_pending_restores() {
+            tokio::time::sleep(RETRY_DELAY).await;
+            state.expedite_pending_restores();
+        }
+    }
+}
+
 /// Keep one capture session alive per online device, restarting a session when
 /// its device's plan changes, and dispatch incoming inputs against the plan of
 /// the device they arrived on. Runs for the lifetime of the process.
-async fn manage(
-    mut capture_plans: watch::Receiver<Arc<Vec<DeviceCapturePlan>>>,
-    capture_channel: CaptureChannel,
-    receiver_access: ReceiverAccess,
-    mut receiver_requests: watch::Receiver<ReceiverRequestState>,
-    channel_registry: openlogi_hid::ChannelRegistry,
-    mut device_io: DeviceIoGate,
-    outputs: GestureOutputs,
-) {
+async fn manage(context: GestureManagerContext) -> ManagerCompletion {
+    let GestureManagerContext {
+        mut capture_plans,
+        capture_channel,
+        receiver_access,
+        mut receiver_requests,
+        channel_registry,
+        mut device_io,
+        outputs,
+        mut shutdown,
+    } = context;
     let (events, mut event_rx) = mpsc::unbounded_channel::<SessionEvent>();
     let mut registry_changes = channel_registry.subscribe();
     // Capture sessions run as detached tasks, so an unexpected exit (a transient
@@ -584,6 +661,20 @@ async fn manage(
         }
 
         tokio::select! {
+            biased;
+
+            _ = &mut shutdown => {
+                drain_for_shutdown(
+                    &mut state,
+                    &mut event_rx,
+                    &receiver_access,
+                    &receiver_requests,
+                    &capture_plans,
+                    &channels,
+                )
+                .await;
+                return ManagerCompletion::Graceful;
+            }
             Some(event) = event_rx.recv() => {
                 reconcile |= state.handle_session_event(
                     event,
@@ -594,23 +685,23 @@ async fn manage(
             }
             result = capture_plans.changed() => match result {
                 Ok(()) => reconcile = true,
-                Err(_) => return,
+                Err(_) => return ManagerCompletion::Unexpected,
             },
             result = receiver_requests.changed() => match result {
                 Ok(()) => reconcile = true,
-                Err(_) => return,
+                Err(_) => return ManagerCompletion::Unexpected,
             },
             allowed = device_io.changed() => match allowed {
                 Some(true) => reconcile = true,
                 Some(false) => {}
-                None => return,
+                None => return ManagerCompletion::Unexpected,
             },
             open = wait_for_registry_change(
                 &mut registry_changes,
                 state.has_pending_restores(),
             ) => {
                 if !open {
-                    return;
+                    return ManagerCompletion::Unexpected;
                 }
                 if device_io.allows_io() {
                     state.expedite_pending_restores();

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -11,6 +11,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::Instant;
 use tracing::{debug, warn};
 
+use super::shutdown::{ManagerCompletion, WatcherHandle};
 use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess, ReceiverRequestState};
 
 const DEPARTURE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -30,14 +31,17 @@ pub struct HostSwitchLink {
 pub type HostSwitchLinks = watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>;
 
 /// Spawn the host switch session manager.
+#[must_use]
 pub fn spawn(
     links: &HostSwitchLinks,
     channel_pool: ChannelPool,
     receiver_access: ReceiverAccess,
     device_io: DeviceIoGate,
-) {
+) -> WatcherHandle {
     let links = links.clone();
     let receiver_requests = receiver_access.subscribe_requests();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (shutdown_done_tx, shutdown_done_rx) = oneshot::channel();
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -46,17 +50,25 @@ pub fn spawn(
             Ok(runtime) => runtime,
             Err(error) => {
                 warn!(%error, "host switch watcher: could not build tokio runtime");
+                let _ = shutdown_done_tx.send(ManagerCompletion::Graceful);
                 return;
             }
         };
-        runtime.block_on(manage(
+        let completion = runtime.block_on(manage(
             links,
             channel_pool,
             receiver_access,
             receiver_requests,
             device_io,
+            shutdown_rx,
         ));
+        // A manager return can strand detached session tasks. Destroy their
+        // runtime before telling a recoverable process replacement that no old
+        // firmware writer remains.
+        drop(runtime);
+        let _ = shutdown_done_tx.send(completion);
     });
+    WatcherHandle::new(shutdown_tx, shutdown_done_rx)
 }
 
 struct HostSwitchManagerState {
@@ -141,7 +153,8 @@ async fn manage(
     receiver_access: ReceiverAccess,
     mut receiver_requests: watch::Receiver<ReceiverRequestState>,
     mut device_io: DeviceIoGate,
-) {
+    mut shutdown: oneshot::Receiver<()>,
+) -> ManagerCompletion {
     let (done_tx, mut done_rx) = mpsc::unbounded_channel::<SessionCompletion>();
     let mut state = HostSwitchManagerState::new();
     let mut reconcile = true;
@@ -174,6 +187,12 @@ async fn manage(
         }
 
         tokio::select! {
+            biased;
+
+            _ = &mut shutdown => {
+                stop_all(&mut state.sessions, HostSwitchStopReason::Graceful).await;
+                return ManagerCompletion::Graceful;
+            }
             Some(completion) = done_rx.recv() => {
                 if let Some(index) = state.sessions
                     .iter()
@@ -183,7 +202,7 @@ async fn manage(
                     let _ = completed.task.await;
                     if let Some((link, host)) = completion.request {
                         if !device_io.wait_until_allowed().await {
-                            return;
+                            return ManagerCompletion::Unexpected;
                         }
                         stop_all(&mut state.sessions, HostSwitchStopReason::Graceful).await;
                         run_transition(
@@ -202,20 +221,20 @@ async fn manage(
             }
             result = links.changed() => {
                 if result.is_err() {
-                    return;
+                    return ManagerCompletion::Unexpected;
                 }
                 reconcile = true;
             }
             result = receiver_requests.changed() => {
                 if result.is_err() {
-                    return;
+                    return ManagerCompletion::Unexpected;
                 }
                 reconcile = true;
             }
             allowed = device_io.changed() => match allowed {
                 Some(true) => reconcile = true,
                 Some(false) => {}
-                None => return,
+                None => return ManagerCompletion::Unexpected,
             },
             () = wait_for_deadline(deadline) => {
                 reconcile = true;

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -4,8 +4,8 @@ use std::thread;
 use std::time::Duration;
 
 use openlogi_hid::{
-    ChannelPool, DeviceIoGate, DeviceRoute, HostSwitchStopReason, run_host_switch_session,
-    switch_linked_hosts,
+    ChannelPool, ChannelRegistry, DeviceIoGate, DeviceRoute, HostSwitchRestoreOutcome,
+    HostSwitchStopReason, PendingHostSwitchRestore, run_host_switch_session, switch_linked_hosts,
 };
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::Instant;
@@ -30,12 +30,23 @@ pub struct HostSwitchLink {
 /// Read-only, lossless, coalescing view of resolved links.
 pub type HostSwitchLinks = watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>;
 
+struct HostSwitchManagerContext {
+    links: HostSwitchLinks,
+    channel_pool: ChannelPool,
+    registry: ChannelRegistry,
+    receiver_access: ReceiverAccess,
+    receiver_requests: watch::Receiver<ReceiverRequestState>,
+    device_io: DeviceIoGate,
+    shutdown: oneshot::Receiver<()>,
+}
+
 /// Spawn the host switch session manager.
 #[must_use]
 pub fn spawn(
     links: &HostSwitchLinks,
     channel_pool: ChannelPool,
     receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
     device_io: DeviceIoGate,
 ) -> WatcherHandle {
     let links = links.clone();
@@ -50,195 +61,607 @@ pub fn spawn(
             Ok(runtime) => runtime,
             Err(error) => {
                 warn!(%error, "host switch watcher: could not build tokio runtime");
-                let _ = shutdown_done_tx.send(ManagerCompletion::Graceful);
+                let _ = shutdown_done_tx.send(ManagerCompletion::Unexpected);
                 return;
             }
         };
-        let completion = runtime.block_on(manage(
+        let completion = runtime.block_on(manage(HostSwitchManagerContext {
             links,
             channel_pool,
+            registry,
             receiver_access,
             receiver_requests,
             device_io,
-            shutdown_rx,
-        ));
-        // A manager return can strand detached session tasks. Destroy their
-        // runtime before telling a recoverable process replacement that no old
-        // firmware writer remains.
+            shutdown: shutdown_rx,
+        }));
+        // A manager return can strand detached task supervisors. Destroy their
+        // runtime before reporting that no old firmware writer remains.
         drop(runtime);
         let _ = shutdown_done_tx.send(completion);
     });
     WatcherHandle::new(shutdown_tx, shutdown_done_rx)
 }
 
+enum SessionPhase {
+    Active(oneshot::Sender<HostSwitchStopReason>),
+    Draining,
+}
+
+struct RunningSession {
+    link: HostSwitchLink,
+    generation: u64,
+    phase: SessionPhase,
+}
+
+impl RunningSession {
+    fn stop(&mut self, reason: HostSwitchStopReason) {
+        let SessionPhase::Active(stop) = std::mem::replace(&mut self.phase, SessionPhase::Draining)
+        else {
+            return;
+        };
+        let _ = stop.send(reason);
+    }
+}
+
+enum RestorePhase {
+    Ready {
+        token: PendingHostSwitchRestore,
+        retry_at: Instant,
+    },
+    Restoring,
+}
+
+struct Recovery {
+    link: HostSwitchLink,
+    generation: u64,
+    requested_host: Option<u8>,
+    restore: RestorePhase,
+}
+
+enum HostSwitchSlot {
+    Running(RunningSession),
+    Recovering(Recovery),
+    Restarting {
+        link: HostSwitchLink,
+        retry_at: Instant,
+    },
+}
+
+impl HostSwitchSlot {
+    fn keyboard(&self) -> &DeviceRoute {
+        match self {
+            Self::Running(session) => &session.link.keyboard,
+            Self::Recovering(recovery) => &recovery.link.keyboard,
+            Self::Restarting { link, .. } => &link.keyboard,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct TransitionIntent {
+    link: HostSwitchLink,
+    host: u8,
+}
+
+enum TransitionPhase {
+    Waiting(TransitionIntent),
+    Running,
+}
+
+struct SessionCompletion {
+    generation: u64,
+    result: Result<SessionResult, tokio::task::JoinError>,
+}
+
+struct SessionResult {
+    requested_host: Option<u8>,
+    pending_restore: Option<PendingHostSwitchRestore>,
+    failed: bool,
+}
+
+struct RestoreCompletion {
+    generation: u64,
+    result: Result<HostSwitchRestoreOutcome, tokio::task::JoinError>,
+}
+
+enum ManagerEvent {
+    Session(SessionCompletion),
+    Restore(RestoreCompletion),
+    Transition(Result<(), tokio::task::JoinError>),
+}
+
+struct SessionServices {
+    channel_pool: ChannelPool,
+    registry: ChannelRegistry,
+    receiver_access: ReceiverAccess,
+    device_io: DeviceIoGate,
+    events: mpsc::UnboundedSender<ManagerEvent>,
+}
+
 struct HostSwitchManagerState {
-    sessions: Vec<RunningSession>,
+    slots: Vec<HostSwitchSlot>,
     next_generation: u64,
-    restart_after: Vec<(HostSwitchLink, Instant)>,
+    transition: Option<TransitionPhase>,
+    task_failed: bool,
 }
 
 impl HostSwitchManagerState {
     fn new() -> Self {
         Self {
-            sessions: Vec::new(),
+            slots: Vec::new(),
             next_generation: 0,
-            restart_after: Vec::new(),
+            transition: None,
+            task_failed: false,
         }
+    }
+
+    fn has_pending_restores(&self) -> bool {
+        self.slots
+            .iter()
+            .any(|slot| matches!(slot, HostSwitchSlot::Recovering(_)))
+    }
+
+    fn has_running_sessions(&self) -> bool {
+        self.slots
+            .iter()
+            .any(|slot| matches!(slot, HostSwitchSlot::Running(_)))
+    }
+
+    fn owns_keyboard(&self, keyboard: &DeviceRoute) -> bool {
+        self.slots.iter().any(|slot| slot.keyboard() == keyboard)
+    }
+
+    fn reconcile_transition(&mut self, published: &[HostSwitchLink], terminal: bool) {
+        if matches!(
+            &self.transition,
+            Some(TransitionPhase::Waiting(intent)) if terminal || !published.contains(&intent.link)
+        ) {
+            self.transition = None;
+        }
+    }
+
+    fn begin_transition(&mut self, terminal: bool) -> Option<TransitionIntent> {
+        if terminal || self.has_running_sessions() || self.has_pending_restores() {
+            return None;
+        }
+        let Some(TransitionPhase::Waiting(intent)) = self
+            .transition
+            .take_if(|phase| matches!(phase, TransitionPhase::Waiting(_)))
+        else {
+            return None;
+        };
+        self.transition = Some(TransitionPhase::Running);
+        Some(intent)
+    }
+
+    fn terminal_completion(&self, terminal: bool) -> Option<ManagerCompletion> {
+        (terminal
+            && !self.has_running_sessions()
+            && !self.has_pending_restores()
+            && self.transition.is_none())
+        .then_some(if self.task_failed {
+            ManagerCompletion::Unexpected
+        } else {
+            ManagerCompletion::Graceful
+        })
     }
 
     fn deadline(&self, requests: ReceiverRequestState, device_io_allowed: bool) -> Option<Instant> {
         if requests.any() || !device_io_allowed {
             return None;
         }
-        self.restart_after
+        self.slots
             .iter()
-            .map(|(_, deadline)| *deadline)
+            .filter_map(|slot| match slot {
+                HostSwitchSlot::Recovering(Recovery {
+                    restore: RestorePhase::Ready { retry_at, .. },
+                    ..
+                })
+                | HostSwitchSlot::Restarting { retry_at, .. } => Some(*retry_at),
+                HostSwitchSlot::Running(_) | HostSwitchSlot::Recovering(_) => None,
+            })
             .min()
     }
 
-    async fn reconcile(
-        &mut self,
-        requests: ReceiverRequestState,
-        published: &std::sync::Arc<Vec<HostSwitchLink>>,
-        receiver_access: &ReceiverAccess,
-        channel_pool: &ChannelPool,
-        done: &mpsc::UnboundedSender<SessionCompletion>,
-        device_io: &DeviceIoGate,
-    ) {
-        // Keep armed listeners passive while sleeping. A reconcile to an
-        // empty/changed link set would restore firmware controls and a retry
-        // would reopen the HID transport during DarkWake.
-        if !device_io.allows_io() {
-            return;
+    fn stop_sessions(&mut self, wanted: &[HostSwitchLink], terminal: bool) {
+        for slot in &mut self.slots {
+            let HostSwitchSlot::Running(session) = slot else {
+                continue;
+            };
+            if terminal || !wanted.contains(&session.link) {
+                session.stop(HostSwitchStopReason::Graceful);
+            }
         }
+    }
+
+    fn reconcile_recoveries(
+        &mut self,
+        published: &[HostSwitchLink],
+        requests: ReceiverRequestState,
+        services: &SessionServices,
+        terminal: bool,
+    ) {
         let now = Instant::now();
-        let wanted = if requests.any() {
-            &[][..]
-        } else {
-            published.as_slice()
-        };
-        stop_unwanted(&mut self.sessions, wanted).await;
-        self.restart_after
-            .retain(|(link, _)| published.contains(link));
-        for link in wanted {
-            if self.sessions.iter().any(|session| session.link == *link)
-                || self
-                    .restart_after
-                    .iter()
-                    .any(|(delayed, deadline)| delayed == link && *deadline > now)
-            {
+        self.slots.retain(|slot| match slot {
+            HostSwitchSlot::Restarting { link, retry_at } => {
+                !terminal && published.contains(link) && (*retry_at > now || requests.any())
+            }
+            HostSwitchSlot::Running(_) | HostSwitchSlot::Recovering(_) => true,
+        });
+        for slot in &mut self.slots {
+            let HostSwitchSlot::Recovering(recovery) = slot else {
+                continue;
+            };
+            if !published.contains(&recovery.link) {
+                recovery.requested_host = None;
+            }
+            let RestorePhase::Ready { retry_at, .. } = &recovery.restore else {
+                continue;
+            };
+            if *retry_at > now || requests.any() {
                 continue;
             }
-            self.restart_after.retain(|(delayed, _)| delayed != link);
-            let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
-                self.restart_after.push((link.clone(), now + RETRY_DELAY));
+            let Some(lease) = services.receiver_access.try_acquire_for_session() else {
+                break;
+            };
+            let generation = recovery.generation;
+            let RestorePhase::Ready { token, .. } =
+                std::mem::replace(&mut recovery.restore, RestorePhase::Restoring)
+            else {
+                continue;
+            };
+            let registry = services.registry.clone();
+            let device_io = services.device_io.clone();
+            let events = services.events.clone();
+            tokio::spawn(async move {
+                let task = tokio::spawn(async move {
+                    let _lease = lease;
+                    if device_io.allows_io() {
+                        token.retry(&registry).await
+                    } else {
+                        HostSwitchRestoreOutcome::RestorePending(token)
+                    }
+                });
+                let _ = events.send(ManagerEvent::Restore(RestoreCompletion {
+                    generation,
+                    result: task.await,
+                }));
+            });
+        }
+    }
+
+    fn spawn_successors(&mut self, wanted: &[HostSwitchLink], services: &SessionServices) {
+        for link in wanted {
+            if self.owns_keyboard(&link.keyboard) {
+                continue;
+            }
+            let Some(lease) = services.receiver_access.try_acquire_for_session() else {
                 break;
             };
             self.next_generation = self.next_generation.wrapping_add(1);
-            self.sessions.push(spawn_session(
+            self.slots.push(HostSwitchSlot::Running(spawn_session(
                 link.clone(),
                 self.next_generation,
-                receiver_lease,
-                channel_pool.clone(),
-                done.clone(),
-                device_io.clone(),
-            ));
+                lease,
+                services,
+            )));
+        }
+    }
+
+    fn handle_session_completion(
+        &mut self,
+        completion: SessionCompletion,
+        published: &[HostSwitchLink],
+        terminal: bool,
+    ) {
+        let Some(index) = self.slots.iter().position(|slot| {
+            matches!(slot, HostSwitchSlot::Running(session) if session.generation == completion.generation)
+        }) else {
+            return;
+        };
+        let HostSwitchSlot::Running(session) = self.slots.remove(index) else {
+            return;
+        };
+        let result = match completion.result {
+            Ok(result) => result,
+            Err(error) => {
+                warn!(%error, route = %session.link.keyboard, "host switch session task failed");
+                self.task_failed = true;
+                return;
+            }
+        };
+        if result.failed {
+            debug!(route = %session.link.keyboard, "host switch session ended");
+        }
+        let request_is_current = !terminal && published.contains(&session.link);
+        if let Some(token) = result.pending_restore {
+            self.slots.push(HostSwitchSlot::Recovering(Recovery {
+                link: session.link,
+                generation: session.generation,
+                requested_host: result.requested_host.filter(|_| request_is_current),
+                restore: RestorePhase::Ready {
+                    token,
+                    retry_at: Instant::now() + RETRY_DELAY,
+                },
+            }));
+        } else if let Some(host) = result.requested_host.filter(|_| request_is_current) {
+            self.transition = Some(TransitionPhase::Waiting(TransitionIntent {
+                link: session.link,
+                host,
+            }));
+        } else if result.failed && request_is_current {
+            self.slots.push(HostSwitchSlot::Restarting {
+                link: session.link,
+                retry_at: Instant::now() + RETRY_DELAY,
+            });
+        }
+    }
+
+    fn handle_restore_completion(
+        &mut self,
+        completion: RestoreCompletion,
+        published: &[HostSwitchLink],
+        terminal: bool,
+    ) {
+        let Some(index) = self.slots.iter().position(|slot| {
+            matches!(slot, HostSwitchSlot::Recovering(recovery) if recovery.generation == completion.generation)
+        }) else {
+            return;
+        };
+        let HostSwitchSlot::Recovering(mut recovery) = self.slots.remove(index) else {
+            return;
+        };
+        match completion.result {
+            Ok(HostSwitchRestoreOutcome::RestorePending(token)) => {
+                recovery.restore = RestorePhase::Ready {
+                    token,
+                    retry_at: Instant::now() + RETRY_DELAY,
+                };
+                self.slots.push(HostSwitchSlot::Recovering(recovery));
+            }
+            Ok(HostSwitchRestoreOutcome::Restored) => {
+                let request_is_current = !terminal && published.contains(&recovery.link);
+                if let Some(host) = recovery.requested_host.filter(|_| request_is_current) {
+                    self.transition = Some(TransitionPhase::Waiting(TransitionIntent {
+                        link: recovery.link,
+                        host,
+                    }));
+                }
+            }
+            Err(error) => {
+                warn!(%error, route = %recovery.link.keyboard, "host switch restore task failed");
+                self.task_failed = true;
+            }
         }
     }
 }
 
-async fn manage(
-    mut links: watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
-    channel_pool: ChannelPool,
-    receiver_access: ReceiverAccess,
-    mut receiver_requests: watch::Receiver<ReceiverRequestState>,
-    mut device_io: DeviceIoGate,
-    mut shutdown: oneshot::Receiver<()>,
-) -> ManagerCompletion {
-    let (done_tx, mut done_rx) = mpsc::unbounded_channel::<SessionCompletion>();
+async fn manage(context: HostSwitchManagerContext) -> ManagerCompletion {
+    let HostSwitchManagerContext {
+        mut links,
+        channel_pool,
+        registry,
+        receiver_access,
+        mut receiver_requests,
+        mut device_io,
+        mut shutdown,
+    } = context;
+    let (events, mut event_rx) = mpsc::unbounded_channel();
+    let mut registry_changes = registry.subscribe();
+    let services = SessionServices {
+        channel_pool,
+        registry,
+        receiver_access,
+        device_io: device_io.clone(),
+        events,
+    };
     let mut state = HostSwitchManagerState::new();
-    let mut reconcile = true;
+    let mut terminal = false;
 
     loop {
-        if reconcile {
-            reconcile = false;
-            let device_io_allowed = device_io.allows_io();
-            if device_io_allowed {
-                let requests = *receiver_requests.borrow_and_update();
-                let published = std::sync::Arc::clone(&links.borrow_and_update());
-                state
-                    .reconcile(
-                        requests,
-                        &published,
-                        &receiver_access,
-                        &channel_pool,
-                        &done_tx,
-                        &device_io,
-                    )
-                    .await;
+        let requests = *receiver_requests.borrow_and_update();
+        let published = std::sync::Arc::clone(&links.borrow_and_update());
+        let io_allowed = device_io.allows_io();
+        state.reconcile_transition(&published, terminal);
+        let wanted = if terminal || requests.any() || state.transition.is_some() {
+            &[][..]
+        } else {
+            published.as_slice()
+        };
+        if io_allowed || terminal {
+            state.stop_sessions(wanted, terminal);
+        }
+        if io_allowed {
+            state.reconcile_recoveries(&published, requests, &services, terminal);
+            if !terminal && state.transition.is_none() {
+                state.spawn_successors(wanted, &services);
             }
         }
+        if let Some(completion) = state.terminal_completion(terminal) {
+            return completion;
+        }
+        maybe_spawn_transition(&mut state, &links, &services, terminal);
 
-        let requests = *receiver_requests.borrow();
-        let deadline = state.deadline(requests, device_io.allows_io());
+        let deadline = state.deadline(*receiver_requests.borrow(), device_io.allows_io());
         if deadline.is_some_and(|deadline| deadline <= Instant::now()) {
-            reconcile = true;
             continue;
         }
 
         tokio::select! {
             biased;
 
-            _ = &mut shutdown => {
-                stop_all(&mut state.sessions, HostSwitchStopReason::Graceful).await;
-                return ManagerCompletion::Graceful;
+            _ = &mut shutdown, if !terminal => {
+                terminal = true;
             }
-            Some(completion) = done_rx.recv() => {
-                if let Some(index) = state.sessions
-                    .iter()
-                    .position(|session| session.generation == completion.generation)
-                {
-                    let completed = state.sessions.remove(index);
-                    let _ = completed.task.await;
-                    if let Some((link, host)) = completion.request {
-                        if !device_io.wait_until_allowed().await {
-                            return ManagerCompletion::Unexpected;
-                        }
-                        stop_all(&mut state.sessions, HostSwitchStopReason::Graceful).await;
-                        run_transition(
-                            &mut links,
-                            &channel_pool,
-                            &receiver_access,
-                            link,
-                            host,
-                        )
-                        .await;
-                    } else if device_io.allows_io() {
-                        state.restart_after.push((completed.link, Instant::now() + RETRY_DELAY));
-                    }
-                    reconcile = true;
-                }
+            Some(event) = event_rx.recv() => {
+                let published = links.borrow().clone();
+                handle_manager_event(&mut state, event, &published, terminal);
             }
             result = links.changed() => {
                 if result.is_err() {
                     return ManagerCompletion::Unexpected;
                 }
-                reconcile = true;
             }
             result = receiver_requests.changed() => {
                 if result.is_err() {
                     return ManagerCompletion::Unexpected;
                 }
-                reconcile = true;
             }
             allowed = device_io.changed() => match allowed {
-                Some(true) => reconcile = true,
-                Some(false) => {}
+                Some(_) => {}
                 None => return ManagerCompletion::Unexpected,
             },
-            () = wait_for_deadline(deadline) => {
-                reconcile = true;
+            changed = registry_changes.changed() => {
+                if changed.is_err() {
+                    return ManagerCompletion::Unexpected;
+                }
+                expedite_pending_restores(&mut state);
             }
+            () = wait_for_deadline(deadline) => {}
+        }
+    }
+}
+
+fn handle_manager_event(
+    state: &mut HostSwitchManagerState,
+    event: ManagerEvent,
+    published: &[HostSwitchLink],
+    terminal: bool,
+) {
+    match event {
+        ManagerEvent::Session(completion) => {
+            state.handle_session_completion(completion, published, terminal);
+        }
+        ManagerEvent::Restore(completion) => {
+            state.handle_restore_completion(completion, published, terminal);
+        }
+        ManagerEvent::Transition(result) => {
+            if let Err(error) = result {
+                warn!(%error, "host transition task failed");
+                state.task_failed = true;
+            }
+            state.transition = None;
+        }
+    }
+}
+
+fn spawn_session(
+    link: HostSwitchLink,
+    generation: u64,
+    receiver_lease: crate::receiver_access::SessionReceiverLease,
+    services: &SessionServices,
+) -> RunningSession {
+    let (stop, stop_rx) = oneshot::channel();
+    let session_link = link.clone();
+    let registry = services.registry.clone();
+    let device_io = services.device_io.clone();
+    let events = services.events.clone();
+    tokio::spawn(async move {
+        let task = tokio::spawn(async move {
+            let _receiver_lease = receiver_lease;
+            match run_host_switch_session(
+                session_link.keyboard.clone(),
+                stop_rx,
+                &registry,
+                device_io,
+            )
+            .await
+            {
+                Ok(outcome) => {
+                    let (requested_host, pending_restore) = outcome.into_parts();
+                    SessionResult {
+                        requested_host,
+                        pending_restore,
+                        failed: false,
+                    }
+                }
+                Err(failure) => {
+                    let (error, pending_restore) = failure.into_parts();
+                    debug!(%error, route = %session_link.keyboard, "host switch session ended");
+                    SessionResult {
+                        requested_host: None,
+                        pending_restore,
+                        failed: true,
+                    }
+                }
+            }
+        });
+        let _ = events.send(ManagerEvent::Session(SessionCompletion {
+            generation,
+            result: task.await,
+        }));
+    });
+    RunningSession {
+        link,
+        generation,
+        phase: SessionPhase::Active(stop),
+    }
+}
+
+fn maybe_spawn_transition(
+    state: &mut HostSwitchManagerState,
+    links: &HostSwitchLinks,
+    services: &SessionServices,
+    terminal: bool,
+) {
+    let Some(intent) = state.begin_transition(terminal) else {
+        return;
+    };
+    let links = links.clone();
+    let pool = services.channel_pool.clone();
+    let receiver_access = services.receiver_access.clone();
+    let device_io = services.device_io.clone();
+    let events = services.events.clone();
+    tokio::spawn(async move {
+        let task = tokio::spawn(run_transition(
+            links,
+            pool,
+            receiver_access,
+            device_io,
+            intent,
+        ));
+        let _ = events.send(ManagerEvent::Transition(task.await));
+    });
+}
+
+async fn run_transition(
+    mut links: HostSwitchLinks,
+    channel_pool: ChannelPool,
+    receiver_access: ReceiverAccess,
+    device_io: DeviceIoGate,
+    intent: TransitionIntent,
+) {
+    let _lease = receiver_access
+        .acquire_exclusive(ExclusiveAccessReason::HostTransition)
+        .await;
+    if !device_io.allows_io() || !links.borrow().contains(&intent.link) {
+        return;
+    }
+    match switch_linked_hosts(
+        &intent.link.keyboard,
+        &intent.link.targets,
+        intent.host,
+        &channel_pool,
+    )
+    .await
+    {
+        Ok(true) => wait_for_departure(&mut links, &intent.link.keyboard).await,
+        Ok(false) => {}
+        Err(error) => {
+            debug!(%error, route = %intent.link.keyboard, host = intent.host, "keyboard host switch failed");
+        }
+    }
+}
+
+fn expedite_pending_restores(state: &mut HostSwitchManagerState) {
+    let now = Instant::now();
+    for slot in &mut state.slots {
+        if let HostSwitchSlot::Recovering(Recovery {
+            restore: RestorePhase::Ready { retry_at, .. },
+            ..
+        }) = slot
+        {
+            *retry_at = now;
         }
     }
 }
@@ -251,102 +674,7 @@ async fn wait_for_deadline(deadline: Option<Instant>) {
     }
 }
 
-fn spawn_session(
-    link: HostSwitchLink,
-    generation: u64,
-    receiver_lease: crate::receiver_access::SessionReceiverLease,
-    pool: ChannelPool,
-    done: mpsc::UnboundedSender<SessionCompletion>,
-    device_io: DeviceIoGate,
-) -> RunningSession {
-    let (stop, stop_rx) = oneshot::channel();
-    let session_link = link.clone();
-    let task = tokio::spawn(async move {
-        let _receiver_lease = receiver_lease;
-        let keyboard = session_link.keyboard.clone();
-        let request =
-            match run_host_switch_session(session_link.keyboard.clone(), stop_rx, pool, device_io)
-                .await
-            {
-                Ok(host) => host.map(|host| (session_link, host)),
-                Err(error) => {
-                    debug!(%error, route = %keyboard, "host switch session ended");
-                    None
-                }
-            };
-        let _ = done.send(SessionCompletion {
-            generation,
-            request,
-        });
-    });
-    RunningSession {
-        link,
-        generation,
-        stop,
-        task,
-    }
-}
-
-struct RunningSession {
-    link: HostSwitchLink,
-    generation: u64,
-    stop: oneshot::Sender<HostSwitchStopReason>,
-    task: tokio::task::JoinHandle<()>,
-}
-
-struct SessionCompletion {
-    generation: u64,
-    request: Option<(HostSwitchLink, u8)>,
-}
-
-async fn stop_all(sessions: &mut Vec<RunningSession>, reason: HostSwitchStopReason) {
-    let running = std::mem::take(sessions);
-    let mut tasks = Vec::with_capacity(running.len());
-    for RunningSession { stop, task, .. } in running {
-        let _ = stop.send(reason);
-        tasks.push(task);
-    }
-    for task in tasks {
-        let _ = task.await;
-    }
-}
-
-async fn stop_unwanted(sessions: &mut Vec<RunningSession>, wanted: &[HostSwitchLink]) {
-    let mut index = 0;
-    while index < sessions.len() {
-        if wanted.contains(&sessions[index].link) {
-            index += 1;
-            continue;
-        }
-        let RunningSession { stop, task, .. } = sessions.remove(index);
-        let _ = stop.send(HostSwitchStopReason::Graceful);
-        let _ = task.await;
-    }
-}
-
-async fn run_transition(
-    links: &mut watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
-    channel_pool: &ChannelPool,
-    receiver_access: &ReceiverAccess,
-    link: HostSwitchLink,
-    host: u8,
-) {
-    let _lease = receiver_access
-        .acquire_exclusive(ExclusiveAccessReason::HostTransition)
-        .await;
-    match switch_linked_hosts(&link.keyboard, &link.targets, host, channel_pool).await {
-        Ok(true) => wait_for_departure(links, &link.keyboard).await,
-        Ok(false) => {}
-        Err(error) => {
-            debug!(%error, route = %link.keyboard, host, "keyboard host switch failed");
-        }
-    }
-}
-
-async fn wait_for_departure(
-    links: &mut watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
-    keyboard: &DeviceRoute,
-) {
+async fn wait_for_departure(links: &mut HostSwitchLinks, keyboard: &DeviceRoute) {
     let deadline = tokio::time::sleep(DEPARTURE_TIMEOUT);
     tokio::pin!(deadline);
     loop {
@@ -382,37 +710,193 @@ mod tests {
         }
     }
 
+    fn link(target: u8) -> HostSwitchLink {
+        HostSwitchLink {
+            keyboard: route(1),
+            targets: vec![route(target)],
+        }
+    }
+
+    #[test]
+    fn target_change_drains_old_session_before_successor_can_arm() {
+        let (stop, mut stop_rx) = oneshot::channel();
+        let mut state = HostSwitchManagerState::new();
+        state.slots.push(HostSwitchSlot::Running(RunningSession {
+            link: link(2),
+            generation: 1,
+            phase: SessionPhase::Active(stop),
+        }));
+
+        state.stop_sessions(&[link(3)], false);
+
+        assert_eq!(
+            stop_rx
+                .try_recv()
+                .expect("old session should begin draining"),
+            HostSwitchStopReason::Graceful,
+        );
+        assert!(state.slots.iter().any(|slot| slot.keyboard() == &route(1)));
+    }
+
+    #[test]
+    fn stale_link_invalidates_transition_intent() {
+        let mut state = HostSwitchManagerState::new();
+        state.transition = Some(TransitionPhase::Waiting(TransitionIntent {
+            link: link(2),
+            host: 1,
+        }));
+
+        state.reconcile_transition(&[link(3)], false);
+        assert!(state.transition.is_none());
+        assert!(state.begin_transition(false).is_none());
+    }
+
+    #[test]
+    fn restoring_firmware_blocks_a_changed_link_for_the_same_keyboard() {
+        let mut state = HostSwitchManagerState::new();
+        state.slots.push(HostSwitchSlot::Recovering(Recovery {
+            link: link(2),
+            generation: 1,
+            requested_host: None,
+            restore: RestorePhase::Restoring,
+        }));
+
+        assert!(
+            state.owns_keyboard(&link(3).keyboard),
+            "target changes must not permit re-arm over pending keyboard firmware"
+        );
+    }
+
+    #[test]
+    fn terminal_completion_waits_for_restore_acknowledgement() {
+        let mut state = HostSwitchManagerState::new();
+        state.slots.push(HostSwitchSlot::Recovering(Recovery {
+            link: link(2),
+            generation: 1,
+            requested_host: None,
+            restore: RestorePhase::Restoring,
+        }));
+
+        assert!(state.terminal_completion(true).is_none());
+        state.handle_restore_completion(
+            RestoreCompletion {
+                generation: 0,
+                result: Ok(HostSwitchRestoreOutcome::Restored),
+            },
+            &[],
+            true,
+        );
+        assert!(
+            state.terminal_completion(true).is_none(),
+            "stale completion cannot discard recovery"
+        );
+        state.handle_restore_completion(
+            RestoreCompletion {
+                generation: 1,
+                result: Ok(HostSwitchRestoreOutcome::Restored),
+            },
+            &[],
+            true,
+        );
+        assert!(matches!(
+            state.terminal_completion(true),
+            Some(ManagerCompletion::Graceful)
+        ));
+    }
+
+    #[test]
+    fn transition_waits_for_restoration_and_keeps_running_until_acknowledged() {
+        let mut state = HostSwitchManagerState::new();
+        state.slots.push(HostSwitchSlot::Recovering(Recovery {
+            link: link(2),
+            generation: 1,
+            requested_host: None,
+            restore: RestorePhase::Restoring,
+        }));
+        state.transition = Some(TransitionPhase::Waiting(TransitionIntent {
+            link: link(2),
+            host: 2,
+        }));
+        assert!(state.begin_transition(false).is_none());
+        assert!(matches!(
+            state.transition,
+            Some(TransitionPhase::Waiting(_))
+        ));
+
+        state.handle_restore_completion(
+            RestoreCompletion {
+                generation: 1,
+                result: Ok(HostSwitchRestoreOutcome::Restored),
+            },
+            &[link(2)],
+            false,
+        );
+        assert_eq!(state.begin_transition(false).unwrap().host, 2);
+        // Another manager wake while switching must not remove Running.
+        assert!(state.begin_transition(false).is_none());
+        assert!(state.terminal_completion(true).is_none());
+        handle_manager_event(&mut state, ManagerEvent::Transition(Ok(())), &[], true);
+        assert!(matches!(
+            state.terminal_completion(true),
+            Some(ManagerCompletion::Graceful)
+        ));
+    }
+
+    #[tokio::test]
+    async fn completed_session_releases_receiver_lease_before_manager_acknowledgement() {
+        let access = ReceiverAccess::default();
+        let registry = ChannelRegistry::default();
+        let (_signal, gate) = openlogi_hid::device_io_channel();
+        let (events, mut received) = mpsc::unbounded_channel();
+        let services = SessionServices {
+            channel_pool: openlogi_hid::channel_pool(),
+            registry,
+            receiver_access: access.clone(),
+            device_io: gate,
+            events,
+        };
+        let _session = spawn_session(
+            link(2),
+            1,
+            access.try_acquire_for_session().unwrap(),
+            &services,
+        );
+        let _exclusive = tokio::time::timeout(
+            Duration::from_secs(1),
+            access.acquire_exclusive(ExclusiveAccessReason::Pairing),
+        )
+        .await
+        .expect("the failed session must release its lease even before the manager consumes Done");
+        let Some(ManagerEvent::Session(completion)) = received.recv().await else {
+            panic!("expected session completion");
+        };
+        assert!(completion.result.unwrap().failed);
+    }
+
     #[test]
     fn suspended_device_io_disables_retry_deadlines() {
         let retry_at = Instant::now() + RETRY_DELAY;
         let mut state = HostSwitchManagerState::new();
-        state.restart_after.push((
-            HostSwitchLink {
-                keyboard: route(1),
-                targets: vec![route(2)],
-            },
+        state.slots.push(HostSwitchSlot::Restarting {
+            link: link(2),
             retry_at,
-        ));
+        });
 
         assert_eq!(
             state.deadline(ReceiverRequestState::default(), true),
-            Some(retry_at),
+            Some(retry_at)
         );
-        assert_eq!(
-            state.deadline(ReceiverRequestState::default(), false),
-            None,
-            "host-switch retries must stay dormant until visible resume",
-        );
+        assert_eq!(state.deadline(ReceiverRequestState::default(), false), None);
     }
 
     #[tokio::test(start_paused = true)]
     async fn departure_publication_finishes_wait_without_advancing_time() {
         let keyboard = route(1);
-        let link = HostSwitchLink {
+        let active = HostSwitchLink {
             keyboard: keyboard.clone(),
             targets: vec![route(2)],
         };
-        let (links, mut published) = watch::channel(std::sync::Arc::new(vec![link]));
+        let (links, mut published) = watch::channel(std::sync::Arc::new(vec![active]));
         let started = Instant::now();
         let waiting = tokio::spawn(async move {
             wait_for_departure(&mut published, &keyboard).await;

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -25,6 +25,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, info, warn};
 
 use super::capture_session::{CaptureRecovery, CaptureSession, CaptureSlot, ReconcileAction};
+use super::shutdown::{ManagerCompletion, WatcherHandle};
 use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
 use crate::runtime::{ActionDispatcher, HidppSessionId};
 
@@ -105,11 +106,23 @@ struct KeyboardSessionChannels {
     events: mpsc::UnboundedSender<KeyboardSessionEvent>,
 }
 
+struct KeyboardManagerContext {
+    spec: watch::Receiver<Option<Arc<KeyboardSpec>>>,
+    keyboard_channel: CaptureChannel,
+    receiver_access: ReceiverAccess,
+    receiver_requests: watch::Receiver<ReceiverRequestState>,
+    registry: ChannelRegistry,
+    device_io: DeviceIoGate,
+    dispatcher: ActionDispatcher,
+    shutdown: oneshot::Receiver<()>,
+}
+
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Spawn the keyboard-capture manager thread. It owns a current-thread tokio
 /// runtime that keeps one capture session pointed at the bound keyboard and
 /// dispatches each captured key press.
+#[must_use]
 pub fn spawn(
     spec: &SharedKeyboardSpec,
     keyboard_channel: CaptureChannel,
@@ -117,9 +130,11 @@ pub fn spawn(
     registry: ChannelRegistry,
     device_io: DeviceIoGate,
     dispatcher: ActionDispatcher,
-) {
+) -> WatcherHandle {
     let spec = spec.clone();
     let receiver_requests = receiver_access.subscribe_requests();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (shutdown_done_tx, shutdown_done_rx) = oneshot::channel();
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -128,10 +143,11 @@ pub fn spawn(
             Ok(rt) => rt,
             Err(e) => {
                 warn!(error = %e, "keyboard watcher: could not build tokio runtime");
+                let _ = shutdown_done_tx.send(ManagerCompletion::Graceful);
                 return;
             }
         };
-        runtime.block_on(manage(
+        let completion = runtime.block_on(manage(KeyboardManagerContext {
             spec,
             keyboard_channel,
             receiver_access,
@@ -139,8 +155,15 @@ pub fn spawn(
             registry,
             device_io,
             dispatcher,
-        ));
+            shutdown: shutdown_rx,
+        }));
+        // Completion is a process-replacement boundary: acknowledge only
+        // after the runtime has cancelled any detached task left by an
+        // unexpected manager return.
+        drop(runtime);
+        let _ = shutdown_done_tx.send(completion);
     });
+    WatcherHandle::new(shutdown_tx, shutdown_done_rx)
 }
 
 /// Route one accepted keyboard edge through the shared HID++ lifecycle.
@@ -425,18 +448,73 @@ fn next_deadline(
         .min()
 }
 
+/// Retire the tracked keyboard epoch, preserve its ordered input ownership
+/// until completion, then retain and retry any firmware restore token until
+/// ownership has been released.
+async fn drain_for_shutdown(
+    state: &mut KeyboardManagerState,
+    event_rx: &mut mpsc::UnboundedReceiver<KeyboardSessionEvent>,
+    receiver_access: &ReceiverAccess,
+    receiver_requests: &watch::Receiver<ReceiverRequestState>,
+    spec: &watch::Receiver<Option<Arc<KeyboardSpec>>>,
+    channels: &KeyboardSessionChannels,
+) {
+    if let Some(running) = state.slot.as_mut().and_then(KeyboardSlot::session_mut) {
+        reconcile_session(running, None, &state.dispatcher);
+    }
+    while state
+        .slot
+        .as_ref()
+        .and_then(KeyboardSlot::session)
+        .is_some()
+    {
+        let Some(event) = event_rx.recv().await else {
+            break;
+        };
+        state.handle_session_event(
+            event,
+            channels.device_io.allows_io(),
+            receiver_requests,
+            spec,
+        );
+    }
+
+    if state.has_pending_restore() {
+        warn!("keyboard watcher is waiting for pending firmware restoration before stopping");
+    }
+    let mut device_io = channels.device_io.clone();
+    while state.has_pending_restore() {
+        if !device_io.allows_io() && !device_io.wait_until_allowed().await {
+            // A closed suspended gate cannot prove firmware is native. The
+            // process lifecycle bounds terminal exits; confirmed replacement
+            // deliberately remains here rather than losing this token.
+            std::future::pending::<()>().await;
+        }
+        state.expedite_pending_restore();
+        let requests = *receiver_requests.borrow();
+        state
+            .reconcile(requests, true, false, None, receiver_access, channels)
+            .await;
+        if state.has_pending_restore() {
+            tokio::time::sleep(RETRY_DELAY).await;
+        }
+    }
+}
+
 /// Keep one keyboard capture session alive for the published spec, restarting
 /// it when the keyboard or its bound-key set changes, and dispatch incoming
 /// presses. Runs for the lifetime of the process.
-async fn manage(
-    mut spec: watch::Receiver<Option<Arc<KeyboardSpec>>>,
-    keyboard_channel: CaptureChannel,
-    receiver_access: ReceiverAccess,
-    mut receiver_requests: watch::Receiver<ReceiverRequestState>,
-    registry: ChannelRegistry,
-    mut device_io: DeviceIoGate,
-    dispatcher: ActionDispatcher,
-) {
+async fn manage(context: KeyboardManagerContext) -> ManagerCompletion {
+    let KeyboardManagerContext {
+        mut spec,
+        keyboard_channel,
+        receiver_access,
+        mut receiver_requests,
+        registry,
+        mut device_io,
+        dispatcher,
+        mut shutdown,
+    } = context;
     let (events, mut event_rx) = mpsc::unbounded_channel::<KeyboardSessionEvent>();
     let mut registry_changes = registry.subscribe();
     let channels = KeyboardSessionChannels {
@@ -477,6 +555,20 @@ async fn manage(
         }
 
         tokio::select! {
+            biased;
+
+            _ = &mut shutdown => {
+                drain_for_shutdown(
+                    &mut state,
+                    &mut event_rx,
+                    &receiver_access,
+                    &receiver_requests,
+                    &spec,
+                    &channels,
+                )
+                .await;
+                return ManagerCompletion::Graceful;
+            }
             Some(event) = event_rx.recv() => {
                 reconcile |= state.handle_session_event(
                     event,
@@ -487,23 +579,23 @@ async fn manage(
             }
             result = spec.changed() => match result {
                 Ok(()) => reconcile = true,
-                Err(_) => return,
+                Err(_) => return ManagerCompletion::Unexpected,
             },
             result = receiver_requests.changed() => match result {
                 Ok(()) => reconcile = true,
-                Err(_) => return,
+                Err(_) => return ManagerCompletion::Unexpected,
             },
             allowed = device_io.changed() => match allowed {
                 Some(true) => reconcile = true,
                 Some(false) => {}
-                None => return,
+                None => return ManagerCompletion::Unexpected,
             },
             open = wait_for_registry_change(
                 &mut registry_changes,
                 state.has_pending_restore(),
             ) => {
                 if !open {
-                    return;
+                    return ManagerCompletion::Unexpected;
                 }
                 if device_io.allows_io() {
                     state.expedite_pending_restore();

--- a/crates/openlogi-agent-core/src/watchers/mod.rs
+++ b/crates/openlogi-agent-core/src/watchers/mod.rs
@@ -13,3 +13,4 @@ pub mod inventory;
 pub mod keyboard;
 pub mod pairing;
 mod poll;
+pub mod shutdown;

--- a/crates/openlogi-agent-core/src/watchers/shutdown.rs
+++ b/crates/openlogi-agent-core/src/watchers/shutdown.rs
@@ -1,0 +1,179 @@
+//! Graceful-stop primitive shared by the HID++ watcher managers.
+//!
+//! Each manager runs on its own thread and current-thread Tokio runtime, so
+//! dropping the process's main runtime does not ask its active sessions to
+//! restore firmware diversion. [`WatcherHandle`] gives the process lifecycle
+//! one explicit stop request and one acknowledgement that the manager no
+//! longer owns a task capable of writing the device.
+
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use tracing::warn;
+
+/// How long a terminal process exit waits for one watcher manager to stop.
+///
+/// HID++ restore writes normally take tens of milliseconds. A bounded exit
+/// prevents one disconnected device from keeping an uninstalled or quitting
+/// process alive indefinitely; process replacement uses the confirmed form
+/// because it must not hand unresolved firmware ownership to a new image.
+const STOP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Whether a watcher manager acknowledged that it no longer owns live
+/// firmware-writing tasks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StopOutcome {
+    /// The manager completed its requested graceful stop.
+    Stopped,
+    /// A terminal exit reached its watcher-shutdown deadline.
+    TimedOut,
+    /// The manager ended through another control-plane channel before it could
+    /// perform the requested graceful stop.
+    Unclean,
+    /// The manager thread ended without sending its acknowledgement.
+    CompletionLost,
+}
+
+/// How a manager loop returned before its runtime was destroyed.
+#[derive(Debug)]
+pub(super) enum ManagerCompletion {
+    /// The process stop request drove the manager's teardown.
+    Graceful,
+    /// Another control-plane source closed first.
+    Unexpected,
+}
+
+impl StopOutcome {
+    /// Whether the manager explicitly acknowledged that it stopped.
+    #[must_use]
+    pub const fn is_stopped(self) -> bool {
+        matches!(self, Self::Stopped)
+    }
+}
+
+/// Process-lifecycle handle for one HID++ watcher manager.
+pub struct WatcherHandle {
+    stop: Option<oneshot::Sender<()>>,
+    done: oneshot::Receiver<ManagerCompletion>,
+}
+
+impl WatcherHandle {
+    /// Pair the manager's stop request with its completion acknowledgement.
+    #[must_use]
+    pub(super) fn new(
+        stop: oneshot::Sender<()>,
+        done: oneshot::Receiver<ManagerCompletion>,
+    ) -> Self {
+        Self {
+            stop: Some(stop),
+            done,
+        }
+    }
+
+    /// Request an ordered stop and wait up to the terminal-exit deadline.
+    pub async fn stop_and_wait(mut self, watcher: &'static str) -> StopOutcome {
+        self.request_stop();
+        if let Ok(result) = tokio::time::timeout(STOP_TIMEOUT, &mut self.done).await {
+            completion(result, watcher)
+        } else {
+            warn!(
+                watcher,
+                timeout = ?STOP_TIMEOUT,
+                "watcher did not stop before process-exit deadline"
+            );
+            StopOutcome::TimedOut
+        }
+    }
+
+    /// Request an ordered stop and continue waiting after the diagnostic
+    /// deadline until the manager is known to have ended.
+    ///
+    /// Process replacement uses this form on every platform: firmware state
+    /// outlives a process image, so replacement must not discard unresolved
+    /// restore ownership merely because the terminal-exit deadline elapsed.
+    pub async fn stop_and_wait_confirmed(mut self, watcher: &'static str) -> StopOutcome {
+        self.request_stop();
+        if let Ok(result) = tokio::time::timeout(STOP_TIMEOUT, &mut self.done).await {
+            completion(result, watcher)
+        } else {
+            tracing::info!(
+                watcher,
+                timeout = ?STOP_TIMEOUT,
+                "watcher shutdown is slow — continuing to wait before process replacement"
+            );
+            completion(self.done.await, watcher)
+        }
+    }
+
+    fn request_stop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+    }
+}
+
+fn completion(
+    result: Result<ManagerCompletion, oneshot::error::RecvError>,
+    watcher: &'static str,
+) -> StopOutcome {
+    match result {
+        Ok(ManagerCompletion::Graceful) => StopOutcome::Stopped,
+        Ok(ManagerCompletion::Unexpected) => {
+            warn!(watcher, "watcher ended before its graceful stop request");
+            StopOutcome::Unclean
+        }
+        Err(error) => {
+            warn!(%error, watcher, "watcher ended without acknowledging its completion");
+            StopOutcome::CompletionLost
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn explicit_completion_is_stopped() {
+        let (stop_tx, stop_rx) = oneshot::channel();
+        let (done_tx, done_rx) = oneshot::channel();
+        done_tx
+            .send(ManagerCompletion::Graceful)
+            .expect("completion receiver should be open");
+
+        let outcome = WatcherHandle::new(stop_tx, done_rx)
+            .stop_and_wait("test")
+            .await;
+
+        assert_eq!(outcome, StopOutcome::Stopped);
+        stop_rx.await.expect("stop request should be sent");
+    }
+
+    #[tokio::test]
+    async fn dropped_completion_is_not_reported_as_stopped() {
+        let (stop_tx, _stop_rx) = oneshot::channel();
+        let (done_tx, done_rx) = oneshot::channel();
+        drop(done_tx);
+
+        let outcome = WatcherHandle::new(stop_tx, done_rx)
+            .stop_and_wait("test")
+            .await;
+
+        assert_eq!(outcome, StopOutcome::CompletionLost);
+    }
+
+    #[tokio::test]
+    async fn unexpected_manager_return_is_not_reported_as_stopped() {
+        let (stop_tx, _stop_rx) = oneshot::channel();
+        let (done_tx, done_rx) = oneshot::channel();
+        done_tx
+            .send(ManagerCompletion::Unexpected)
+            .expect("completion receiver should be open");
+
+        let outcome = WatcherHandle::new(stop_tx, done_rx)
+            .stop_and_wait("test")
+            .await;
+
+        assert_eq!(outcome, StopOutcome::Unclean);
+    }
+}

--- a/crates/openlogi-agent-core/src/watchers/shutdown.rs
+++ b/crates/openlogi-agent-core/src/watchers/shutdown.rs
@@ -6,18 +6,8 @@
 //! one explicit stop request and one acknowledgement that the manager no
 //! longer owns a task capable of writing the device.
 
-use std::time::Duration;
-
 use tokio::sync::oneshot;
 use tracing::warn;
-
-/// How long a terminal process exit waits for one watcher manager to stop.
-///
-/// HID++ restore writes normally take tens of milliseconds. A bounded exit
-/// prevents one disconnected device from keeping an uninstalled or quitting
-/// process alive indefinitely; process replacement uses the confirmed form
-/// because it must not hand unresolved firmware ownership to a new image.
-const STOP_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Whether a watcher manager acknowledged that it no longer owns live
 /// firmware-writing tasks.
@@ -25,8 +15,6 @@ const STOP_TIMEOUT: Duration = Duration::from_secs(3);
 pub enum StopOutcome {
     /// The manager completed its requested graceful stop.
     Stopped,
-    /// A terminal exit reached its watcher-shutdown deadline.
-    TimedOut,
     /// The manager ended through another control-plane channel before it could
     /// perform the requested graceful stop.
     Unclean,
@@ -53,7 +41,7 @@ impl StopOutcome {
 
 /// Process-lifecycle handle for one HID++ watcher manager.
 pub struct WatcherHandle {
-    stop: Option<oneshot::Sender<()>>,
+    stop: oneshot::Sender<()>,
     done: oneshot::Receiver<ManagerCompletion>,
 }
 
@@ -64,51 +52,17 @@ impl WatcherHandle {
         stop: oneshot::Sender<()>,
         done: oneshot::Receiver<ManagerCompletion>,
     ) -> Self {
-        Self {
-            stop: Some(stop),
-            done,
-        }
+        Self { stop, done }
     }
 
-    /// Request an ordered stop and wait up to the terminal-exit deadline.
-    pub async fn stop_and_wait(mut self, watcher: &'static str) -> StopOutcome {
-        self.request_stop();
-        if let Ok(result) = tokio::time::timeout(STOP_TIMEOUT, &mut self.done).await {
-            completion(result, watcher)
-        } else {
-            warn!(
-                watcher,
-                timeout = ?STOP_TIMEOUT,
-                "watcher did not stop before process-exit deadline"
-            );
-            StopOutcome::TimedOut
-        }
-    }
-
-    /// Request an ordered stop and continue waiting after the diagnostic
-    /// deadline until the manager is known to have ended.
+    /// Request an ordered stop and wait for confirmed teardown.
     ///
-    /// Process replacement uses this form on every platform: firmware state
-    /// outlives a process image, so replacement must not discard unresolved
-    /// restore ownership merely because the terminal-exit deadline elapsed.
-    pub async fn stop_and_wait_confirmed(mut self, watcher: &'static str) -> StopOutcome {
-        self.request_stop();
-        if let Ok(result) = tokio::time::timeout(STOP_TIMEOUT, &mut self.done).await {
-            completion(result, watcher)
-        } else {
-            tracing::info!(
-                watcher,
-                timeout = ?STOP_TIMEOUT,
-                "watcher shutdown is slow — continuing to wait before process replacement"
-            );
-            completion(self.done.await, watcher)
-        }
-    }
-
-    fn request_stop(&mut self) {
-        if let Some(stop) = self.stop.take() {
-            let _ = stop.send(());
-        }
+    /// The process lifecycle owns the deadline policy. It must retain this
+    /// future across control-plane events during replacement, and may abandon
+    /// it at a deadline only when the process is about to exit.
+    pub async fn stop_and_wait(self, watcher: &'static str) -> StopOutcome {
+        let _ = self.stop.send(());
+        completion(self.done.await, watcher)
     }
 }
 

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -70,3 +70,4 @@ workspace = true
 
 [dev-dependencies]
 tempfile = "3.27.0"
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/openlogi-agent/src/binary_watch.rs
+++ b/crates/openlogi-agent/src/binary_watch.rs
@@ -29,13 +29,17 @@
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
-use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tracing::{info, warn};
 
 mod relaunch;
 
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) use relaunch::replace_process;
 #[cfg(target_os = "macos")]
-pub use relaunch::relaunch_after_input_monitoring_grant;
+pub(crate) use relaunch::{schedule, schedule_after_input_monitoring_grant};
+
+use crate::shutdown::{ShutdownRequest, ShutdownRequestSender};
 
 /// How often to stat the executable: one `metadata` call per tick — noise next
 /// to the 2 s HID enumerate — while keeping the update-to-restart window short.
@@ -169,23 +173,20 @@ fn is_translocated(path: &Path) -> bool {
 /// are resolved once, up front; if either fails the watch is disabled (logged)
 /// rather than guessing at a path.
 ///
-/// The returned receiver fires once, when the executable has been gone long
-/// enough to mean the app was uninstalled. The agent core shuts down on it —
-/// that path, and not a bare `process::exit`, is what drops the hook and
-/// detaches the macOS event tap. A disabled watch simply drops the sender, so
-/// the receiver never fires.
-pub fn spawn() -> mpsc::UnboundedReceiver<()> {
-    let (uninstalled_tx, uninstalled_rx) = mpsc::unbounded_channel();
+/// Settled replacement and uninstall decisions are sent to the lifecycle
+/// owner. This thread never replaces or exits the process itself: doing so
+/// would bypass the HID++ managers that own firmware diversion.
+pub fn spawn(requests: ShutdownRequestSender) {
     let Ok(path) = std::env::current_exe() else {
         warn!("could not resolve own executable — binary-update watch disabled");
-        return uninstalled_rx;
+        return;
     };
     let Sighting::Seen(baseline) = sight(&path) else {
         warn!(
             path = %path.display(),
             "could not stat own executable — binary-update watch disabled"
         );
-        return uninstalled_rx;
+        return;
     };
     // A translocated bundle already lives on a randomized, ephemeral mount, so
     // its path disappearing says nothing about whether the app is installed.
@@ -198,11 +199,22 @@ pub fn spawn() -> mpsc::UnboundedReceiver<()> {
                 match watch.tick(baseline, sight(&path)) {
                     Tick::Watch => {}
                     Tick::Restart => {
-                        relaunch::restart(&path);
-                        // Only reached when the exec failed (a broken or still-
-                        // churning file). Disarm so the retry needs a fresh
-                        // two-tick settle — staying alive on the old image beats
-                        // dying in setups with no respawner.
+                        let (retry_tx, retry_rx) = oneshot::channel();
+                        if requests
+                            .send(ShutdownRequest::Restart {
+                                path: path.clone(),
+                                retry: retry_tx,
+                            })
+                            .is_err()
+                        {
+                            return;
+                        }
+                        // A successful replacement ends this process. The only
+                        // reply means scheduling or exec failed and this old
+                        // image safely resumed its watcher fleet.
+                        if retry_rx.blocking_recv().is_err() {
+                            return;
+                        }
                         watch.pending = None;
                     }
                     Tick::Uninstalled => {
@@ -210,9 +222,7 @@ pub fn spawn() -> mpsc::UnboundedReceiver<()> {
                             path = %path.display(),
                             "own executable is gone — the app was removed; shutting down"
                         );
-                        // A closed receiver means the core is already going
-                        // down; either way this watcher is finished.
-                        let _ = uninstalled_tx.send(());
+                        let _ = requests.send(ShutdownRequest::Uninstalled);
                         return;
                     }
                 }
@@ -221,7 +231,6 @@ pub fn spawn() -> mpsc::UnboundedReceiver<()> {
     if let Err(e) = spawn_result {
         warn!(error = %e, "could not spawn the binary-update watch thread");
     }
-    uninstalled_rx
 }
 
 #[cfg(test)]

--- a/crates/openlogi-agent/src/binary_watch/relaunch.rs
+++ b/crates/openlogi-agent/src/binary_watch/relaunch.rs
@@ -8,111 +8,97 @@
 //!   the pid, the singleton lock, and the IPC socket.
 //! - **macOS** cannot: after `exec` the new program continues on the calling
 //!   thread, while AppKit insists the status item be created from the process
-//!   main thread. So it schedules a detached successor and exits, and the
-//!   successor waits for this process to release the singleton lock. Going
-//!   through LaunchServices (`open`) rather than spawning the binary directly
-//!   is what preserves the helper's TCC identity — see
+//!   main thread. So it schedules a detached successor that waits for this
+//!   process to exit. Going through LaunchServices (`open`) rather than
+//!   spawning the binary directly preserves the helper's TCC identity — see
 //!   `.claude/rules/objc-ffi.md` and the permissions skill.
-//! - **Windows** has no `exec` at all: it exits and lets the GUI's socket-down
-//!   spawn (or the next login) start the replacement.
+//! - **Windows** has no `exec`; the lifecycle exits after teardown and lets
+//!   the GUI's socket-down spawn (or the next login) start the replacement.
 //!
 //! The macOS path also serves the Input Monitoring grant, which needs the same
 //! "leave and come back" move for an unrelated reason.
 
+#[cfg(unix)]
 use std::path::Path;
 
+#[cfg(all(unix, not(target_os = "macos")))]
 use tracing::info;
-// Only the unix relaunches can fail in a way worth reporting; Windows just
-// exits.
-#[cfg(unix)]
-use tracing::warn;
 
 /// Restart this process as the new binary at `path`.
 ///
-/// The singleton file lock and the IPC socket close with the old image and are
-/// re-acquired by the new one; the listener unlinks the stale socket file on
-/// bind. If scheduling the restart fails the process is still intact, so return
-/// and let the watch loop retry once the file settles again.
+/// The lifecycle has already confirmed every HID++ manager stopped before
+/// calling this. If `exec` fails, return the error so it can safely start a new
+/// manager fleet before asking the binary watcher to retry.
 #[cfg(all(unix, not(target_os = "macos")))]
-pub(super) fn restart(path: &Path) {
+pub(crate) fn replace_process(path: &Path) -> std::io::Error {
     use std::os::unix::process::CommandExt as _;
     info!(
         path = %path.display(),
         "executable changed on disk — restarting as the new binary"
     );
     // Forward our argv (none today) so a future flag survives the restart.
-    let err = std::process::Command::new(path)
+    std::process::Command::new(path)
         .args(std::env::args_os().skip(1))
-        .exec();
-    warn!(error = %err, "exec of the updated agent failed — keeping the current image and retrying");
+        .exec()
 }
 
-/// macOS cannot safely `exec` the replacement from this watcher thread: after
-/// `exec`, the new program continues on the calling thread, while AppKit expects
-/// the status item to be created from the process main thread. Relaunch the
-/// packaged helper through LaunchServices (preserving its TCC identity), or a
-/// bare dev binary directly, after this process has had time to exit and release
-/// the singleton lock.
-#[cfg(target_os = "macos")]
-pub(super) fn restart(path: &Path) {
-    info!(
-        path = %path.display(),
-        "executable changed on disk — relaunching as the new macOS agent"
-    );
-    if let Err(e) = schedule_macos_relaunch_and_exit(path) {
-        warn!(error = %e, "could not schedule updated agent relaunch — keeping the current image and retrying");
-    }
-}
-
-/// Relaunch the macOS agent after Input Monitoring is granted.
+/// Schedule a macOS successor without ending the current process.
 ///
-/// macOS does not apply a new Input Monitoring grant to the running process.
-/// The successor starts only after this process exits and releases its
-/// singleton lock and IPC socket. If the relaunch cannot be scheduled, the
-/// current process stays alive so the user can restart it manually.
+/// The packaged helper goes through LaunchServices to preserve its TCC
+/// identity; a bare dev binary starts directly. The successor waits for this
+/// exact PID rather than a fixed delay, so graceful firmware teardown cannot
+/// make it lose the singleton-lock race and disappear.
 #[cfg(target_os = "macos")]
-pub fn relaunch_after_input_monitoring_grant() {
-    let path = match std::env::current_exe() {
-        Ok(path) => path,
-        Err(e) => {
-            warn!(error = %e, "could not resolve own executable after Input Monitoring was granted — restart the agent manually");
-            return;
-        }
-    };
-    info!("Input Monitoring granted — relaunching the macOS agent");
-    if let Err(e) = schedule_macos_relaunch_and_exit(&path) {
-        warn!(error = %e, "could not schedule agent relaunch after Input Monitoring was granted — restart the agent manually");
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn schedule_macos_relaunch(path: &Path) -> std::io::Result<()> {
+pub(crate) fn schedule(path: &Path) -> std::io::Result<()> {
     let mut command = std::process::Command::new("/bin/sh");
+    let pid = std::process::id().to_string();
     if let Some(bundle) = helper_bundle(path) {
         command
             .arg("-c")
-            .arg("sleep 0.5; exec /usr/bin/open -g -n \"$1\"")
+            .arg(
+                "pid=$1; bundle=$2; while /bin/kill -0 \"$pid\" 2>/dev/null; do /bin/sleep 0.1; done; exec /usr/bin/open -g -n \"$bundle\"",
+            )
             .arg("openlogi-relaunch")
+            .arg(&pid)
             .arg(bundle);
     } else {
         command
             .arg("-c")
-            .arg("path=$1; shift; sleep 0.5; exec \"$path\" \"$@\"")
+            .arg(
+                "pid=$1; path=$2; shift 2; while /bin/kill -0 \"$pid\" 2>/dev/null; do /bin/sleep 0.1; done; exec \"$path\" \"$@\"",
+            )
             .arg("openlogi-relaunch")
+            .arg(&pid)
             .arg(path)
             .args(std::env::args_os().skip(1));
     }
     command.spawn().map(|_| ())
 }
 
+/// Schedule the macOS agent's required relaunch after Input Monitoring is
+/// granted. Returns whether scheduling succeeded; the lifecycle performs the
+/// actual graceful exit.
+///
+/// macOS does not apply a new Input Monitoring grant to the running process.
 #[cfg(target_os = "macos")]
-fn schedule_macos_relaunch_and_exit(path: &Path) -> std::io::Result<()> {
-    schedule_macos_relaunch(path)?;
-    #[expect(
-        clippy::exit,
-        reason = "the delayed successor is already scheduled and waits for this process to release the singleton lock and IPC socket"
-    )]
-    std::process::exit(0)
+pub(crate) fn schedule_after_input_monitoring_grant() -> bool {
+    use tracing::{info, warn};
+
+    let path = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(e) => {
+            warn!(error = %e, "could not resolve own executable after Input Monitoring was granted — restart the agent manually");
+            return false;
+        }
+    };
+    info!("Input Monitoring granted — relaunching the macOS agent");
+    match schedule(&path) {
+        Ok(()) => true,
+        Err(e) => {
+            warn!(error = %e, "could not schedule agent relaunch after Input Monitoring was granted — restart the agent manually");
+            false
+        }
+    }
 }
 
 /// The `.app` root of a packaged helper binary, `None` for a bare dev binary.
@@ -120,23 +106,6 @@ fn schedule_macos_relaunch_and_exit(path: &Path) -> std::io::Result<()> {
 fn helper_bundle(path: &Path) -> Option<&Path> {
     let bundle = path.ancestors().nth(3)?;
     (bundle.extension()? == "app").then_some(bundle)
-}
-
-/// Windows has no `exec`: exit cleanly and let the GUI's socket-down spawn
-/// retry (or the next login's autostart) start the replaced binary. A
-/// spawn-before-exit handover would lose the race against the singleton lock
-/// this process still holds.
-#[cfg(windows)]
-pub(super) fn restart(path: &Path) {
-    info!(
-        path = %path.display(),
-        "executable changed on disk — exiting so the new binary can start"
-    );
-    #[expect(
-        clippy::exit,
-        reason = "windows has no `exec`, and this watcher thread cannot return a status to `main`, which is blocked on the agent core; releasing the singleton lock by exiting is what lets the replaced binary start"
-    )]
-    std::process::exit(0);
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -5,15 +5,15 @@
 //! ```text
 //! startup::bootstrap ──► Booted ──gate──► Wanted ──arm──► Armed ──► Running ──► exit
 //!         │                 │                                         │
-//!         └─ init failed    └─ dormant start nobody wanted            └─ signal / uninstall
+//!         └─ init failed    └─ dormant start nobody wanted            └─ signal / process request
 //! ```
 //!
 //! The moves are the type protection for these lifecycle contracts: the
-//! uninstall receiver travels inside the states (gate consumes it first, then
-//! the run loop — no third consumer can exist), the demand channel dies at
+//! shutdown-request receiver travels inside the states (gate consumes it first,
+//! then the run loop — no third consumer can exist), the demand channel dies at
 //! [`Wanted::arm`], and arming without settling the dormancy question is
-//! unrepresentable — `arm` exists only on [`Wanted`], whose sole producer is
-//! the gate. Moving `Armed` into `Running` also hands the single-consumer resume
+//! unrepresentable — `arm` exists only on [`Wanted`], whose sole producer is the
+//! gate. Moving `Armed` into `Running` also hands the single-consumer resume
 //! stream to inventory exactly once. The gate *waits* only on macOS, where the
 //! sunk launch-at-login switch makes an unwanted login start possible; Windows
 //! and Linux only ever start wanted, so their gate passes unconditionally.
@@ -32,16 +32,13 @@ use openlogi_agent_core::watchers::inventory::{InventoryEvent, InventoryRefresh}
 use openlogi_core::config::Config;
 use openlogi_hook::Hook;
 use tokio::sync::Mutex;
-use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{debug, info, warn};
 
 #[cfg(target_os = "macos")]
 use openlogi_ipc::ClientKind;
 
-#[cfg(target_os = "macos")]
-use crate::binary_watch;
-use crate::shutdown::{self, ShutdownSignals};
-use crate::startup::{self, Core, InputServices};
+use crate::shutdown::{self, ShutdownRequest, ShutdownRequests, ShutdownSignals};
+use crate::startup::{self, Core, HidppWatcherHandles, InputServices};
 use crate::{autostart, overlay, server};
 
 /// How long a dormant agent waits before leaving — generous next to the
@@ -54,7 +51,7 @@ const DORMANT_DEADLINE: Duration = Duration::from_secs(60);
 /// core's entry point; `main` only decides which thread it runs on.
 pub(crate) async fn run(
     config: Config,
-    uninstalled: UnboundedReceiver<()>,
+    shutdown_requests: ShutdownRequests,
     #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
 ) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
@@ -63,7 +60,7 @@ pub(crate) async fn run(
 
     let Some(booted) = Booted::bootstrap(
         config,
-        uninstalled,
+        shutdown_requests,
         #[cfg(target_os = "macos")]
         armed_tx,
     )
@@ -86,7 +83,9 @@ pub(crate) async fn run(
 struct Booted {
     core: Core,
     signals: ShutdownSignals,
-    uninstalled: UnboundedReceiver<()>,
+    /// The sole receiver for tray, uninstall, and replacement requests. It
+    /// moves through the typestates with process-resource ownership.
+    shutdown_requests: ShutdownRequests,
     /// The hook kill-switch, startup-only on purpose: flipping it requires
     /// an agent restart, which the config docs state.
     capture_mouse_events: bool,
@@ -100,7 +99,7 @@ struct Booted {
 impl Booted {
     async fn bootstrap(
         config: Config,
-        uninstalled: UnboundedReceiver<()>,
+        shutdown_requests: ShutdownRequests,
         #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
     ) -> Option<Self> {
         // Read before `config` moves into the orchestrator.
@@ -111,7 +110,7 @@ impl Booted {
         Some(Self {
             core,
             signals: ShutdownSignals::install(),
-            uninstalled,
+            shutdown_requests,
             capture_mouse_events,
             #[cfg(target_os = "macos")]
             launch_at_login,
@@ -154,9 +153,25 @@ impl Booted {
                     info!("shutdown signal while dormant — exiting");
                     return None;
                 }
-                Some(()) = self.uninstalled.recv() => {
-                    info!("uninstalled while dormant — exiting");
-                    return None;
+                Some(request) = self.shutdown_requests.recv() => match request {
+                    ShutdownRequest::TrayQuit { core_guard } => {
+                        let _core_guard = core_guard;
+                        info!("tray quit while dormant — exiting");
+                        return None;
+                    }
+                    ShutdownRequest::Uninstalled => {
+                        info!("uninstalled while dormant — exiting");
+                        return None;
+                    }
+                    ShutdownRequest::Restart { path, retry } => {
+                        info!(path = %path.display(), "executable changed while dormant — scheduling relaunch");
+                        if let Err(error) = crate::binary_watch::schedule(&path) {
+                            warn!(%error, "could not schedule updated agent relaunch — keeping the current image and retrying");
+                            let _ = retry.send(());
+                        } else {
+                            return None;
+                        }
+                    }
                 }
             }
         }
@@ -182,7 +197,7 @@ impl Wanted {
         let Booted {
             core,
             signals,
-            uninstalled,
+            shutdown_requests,
             capture_mouse_events,
             #[cfg(target_os = "macos")]
             armed_tx,
@@ -214,7 +229,8 @@ impl Wanted {
                 inputs,
                 ring_haptics,
                 signals,
-                uninstalled,
+                shutdown_requests,
+                hidpp_watchers: None,
                 hook: None,
                 capture_mouse_events,
             },
@@ -238,7 +254,8 @@ struct Running {
     inputs: InputServices,
     ring_haptics: server::RingHapticPlayer,
     signals: ShutdownSignals,
-    uninstalled: UnboundedReceiver<()>,
+    shutdown_requests: ShutdownRequests,
+    hidpp_watchers: Option<HidppWatcherHandles>,
     /// The OS hook, installed once Accessibility is granted and dropped on
     /// revoke (dropping the handle stops its thread).
     hook: Option<Hook>,
@@ -251,10 +268,17 @@ impl Armed {
     async fn run(self) {
         let Self { mut running } = self;
         #[cfg(target_os = "macos")]
-        request_input_monitoring().await;
+        if request_input_monitoring_and_schedule_relaunch().await {
+            running
+                .shut_down("Input Monitoring permission relaunch", None)
+                .await;
+        }
 
         // HID++ watchers need no Accessibility — start them up front.
-        startup::spawn_hidpp_watchers(&running.shared, &running.inputs);
+        running.hidpp_watchers = Some(startup::spawn_hidpp_watchers(
+            &running.shared,
+            &running.inputs,
+        ));
         let (mut watchers, inventory_refresh) = startup::spawn_state_watchers(&running.shared);
 
         info!("openlogi-agent started");
@@ -266,10 +290,12 @@ impl Armed {
                 Some(device_key) = running.inputs.triggers.recv() => {
                     running.begin_action_ring(device_key.as_deref()).await;
                 }
-                () = running.signals.recv() => running.shut_down("shutdown signal"),
-                // Uninstalled while running — leave through the same door so
-                // the event tap goes with us (#807).
-                Some(()) = running.uninstalled.recv() => running.shut_down("the app was uninstalled"),
+                () = running.signals.recv() => {
+                    running.shut_down("shutdown signal", None).await;
+                }
+                Some(request) = running.shutdown_requests.recv() => {
+                    running.handle_shutdown_request(request).await;
+                }
                 else => break,
             }
         }
@@ -439,8 +465,119 @@ impl Running {
         self.inputs.scroll_input.cancel_hooks();
     }
 
-    fn shut_down(&mut self, reason: &str) -> ! {
-        shutdown::release_hook_and_exit(self.hook.take(), &mut self.inputs, reason)
+    async fn handle_shutdown_request(&mut self, request: ShutdownRequest) {
+        match request {
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            ShutdownRequest::TrayQuit { core_guard } => {
+                self.shut_down("tray quit", Some(core_guard)).await;
+            }
+            // Uninstalled while running — leave through the same door so the
+            // event tap and firmware diversions go with us (#807, #1097).
+            ShutdownRequest::Uninstalled => {
+                self.shut_down("the app was uninstalled", None).await;
+            }
+            ShutdownRequest::Restart { path, retry } => self.restart(path, retry).await,
+        }
+    }
+
+    /// Stop the HID++ watcher fleet with the bounded policy for a terminal
+    /// process exit. `None` means arming never reached watcher startup.
+    async fn stop_hidpp_watchers(&mut self) {
+        let Some(watchers) = self.hidpp_watchers.take() else {
+            return;
+        };
+        watchers.stop_and_wait().await;
+    }
+
+    /// A new process image must not inherit unresolved firmware ownership,
+    /// even when restoring it exceeds the terminal-exit deadline.
+    async fn stop_hidpp_watchers_confirmed(&mut self) -> bool {
+        let Some(watchers) = self.hidpp_watchers.take() else {
+            return true;
+        };
+        watchers.stop_and_wait_confirmed().await
+    }
+
+    /// Resolve firmware ownership before replacement and restore the current
+    /// image's managers if ordered teardown could not be confirmed.
+    async fn prepare_process_replacement(&mut self) -> bool {
+        let stopped = self.stop_hidpp_watchers_confirmed().await;
+        if !stopped {
+            self.restart_hidpp_watchers();
+        }
+        stopped
+    }
+
+    fn restart_hidpp_watchers(&mut self) {
+        self.hidpp_watchers = Some(startup::spawn_hidpp_watchers(&self.shared, &self.inputs));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    async fn restart(&mut self, path: std::path::PathBuf, retry: tokio::sync::oneshot::Sender<()>) {
+        info!(path = %path.display(), "executable changed — draining HID++ sessions before exec");
+        if !self.prepare_process_replacement().await {
+            warn!(
+                path = %path.display(),
+                "one or more HID++ managers did not complete graceful teardown — refusing exec and retrying"
+            );
+            let _ = retry.send(());
+            return;
+        }
+
+        let error = crate::binary_watch::replace_process(&path);
+        warn!(%error, path = %path.display(), "exec of the updated agent failed — restoring the current image and retrying");
+        self.restart_hidpp_watchers();
+        let _ = retry.send(());
+    }
+
+    #[cfg(target_os = "macos")]
+    async fn restart(&mut self, path: std::path::PathBuf, retry: tokio::sync::oneshot::Sender<()>) {
+        info!(path = %path.display(), "executable changed — draining HID++ sessions before macOS relaunch");
+        if !self.prepare_process_replacement().await {
+            warn!(
+                path = %path.display(),
+                "one or more HID++ managers did not complete graceful teardown — refusing relaunch and retrying"
+            );
+            let _ = retry.send(());
+            return;
+        }
+        if let Err(error) = crate::binary_watch::schedule(&path) {
+            warn!(%error, "could not schedule updated agent relaunch — keeping the current image and retrying");
+            self.restart_hidpp_watchers();
+            let _ = retry.send(());
+            return;
+        }
+        self.exit_after_replacement_teardown("binary update");
+    }
+
+    #[cfg(not(unix))]
+    async fn restart(&mut self, path: std::path::PathBuf, retry: tokio::sync::oneshot::Sender<()>) {
+        info!(path = %path.display(), "executable changed — draining HID++ sessions before the updated agent starts");
+        if !self.prepare_process_replacement().await {
+            warn!(
+                path = %path.display(),
+                "one or more HID++ managers did not complete graceful teardown — refusing replacement and retrying"
+            );
+            let _ = retry.send(());
+            return;
+        }
+        self.exit_after_replacement_teardown("binary update");
+    }
+
+    async fn shut_down(
+        &mut self,
+        reason: &str,
+        tray_guard: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> ! {
+        self.stop_hidpp_watchers().await;
+        shutdown::release_hook_and_exit(self.hook.take(), &mut self.inputs, reason, tray_guard)
+    }
+
+    /// End after [`Self::prepare_process_replacement`] resolved firmware
+    /// ownership, so a successor starts from native device state.
+    #[cfg(any(target_os = "macos", not(unix)))]
+    fn exit_after_replacement_teardown(&mut self, reason: &str) -> ! {
+        shutdown::release_hook_and_exit(self.hook.take(), &mut self.inputs, reason, None)
     }
 }
 
@@ -459,7 +596,7 @@ fn prompt_missing_accessibility(capture_mouse_events: bool) {
 /// binary the user authorizes. A newly granted permission requires a process
 /// relaunch before macOS lets the agent open HID devices.
 #[cfg(target_os = "macos")]
-async fn request_input_monitoring() {
+async fn request_input_monitoring_and_schedule_relaunch() -> bool {
     // Without this, macOS never registers a decision at all:
     // `IOHIDDeviceOpen` is silently denied, the permission never appears in
     // System Settings for the user to grant, and no HID++ device is ever
@@ -472,11 +609,12 @@ async fn request_input_monitoring() {
         })
         .await;
         match access_after_prompt {
-            Ok(true) => binary_watch::relaunch_after_input_monitoring_grant(),
+            Ok(true) => return crate::binary_watch::schedule_after_input_monitoring_grant(),
             Ok(false) => {}
             Err(e) => {
                 warn!(error = %e, "Input Monitoring permission request task failed");
             }
         }
     }
+    false
 }

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -18,6 +18,8 @@
 //! sunk launch-at-login switch makes an unwanted login start possible; Windows
 //! and Linux only ever start wanted, so their gate passes unconditionally.
 
+mod transition;
+
 use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use std::time::Duration;
@@ -37,8 +39,9 @@ use tracing::{debug, info, warn};
 #[cfg(target_os = "macos")]
 use openlogi_ipc::ClientKind;
 
+use self::transition::{Replacement, WatcherFleet};
 use crate::shutdown::{self, ShutdownRequest, ShutdownRequests, ShutdownSignals};
-use crate::startup::{self, Core, HidppWatcherHandles, InputServices};
+use crate::startup::{self, Core, InputServices};
 use crate::{autostart, overlay, server};
 
 /// How long a dormant agent waits before leaving — generous next to the
@@ -230,7 +233,7 @@ impl Wanted {
                 ring_haptics,
                 signals,
                 shutdown_requests,
-                hidpp_watchers: None,
+                hidpp_watchers: WatcherFleet::Inactive,
                 hook: None,
                 capture_mouse_events,
             },
@@ -255,7 +258,7 @@ struct Running {
     ring_haptics: server::RingHapticPlayer,
     signals: ShutdownSignals,
     shutdown_requests: ShutdownRequests,
-    hidpp_watchers: Option<HidppWatcherHandles>,
+    hidpp_watchers: WatcherFleet,
     /// The OS hook, installed once Accessibility is granted and dropped on
     /// revoke (dropping the handle stops its thread).
     hook: Option<Hook>,
@@ -275,26 +278,28 @@ impl Armed {
         }
 
         // HID++ watchers need no Accessibility — start them up front.
-        running.hidpp_watchers = Some(startup::spawn_hidpp_watchers(
-            &running.shared,
-            &running.inputs,
-        ));
+        running.restart_hidpp_watchers();
         let (mut watchers, inventory_refresh) = startup::spawn_state_watchers(&running.shared);
 
         info!("openlogi-agent started");
         loop {
             tokio::select! {
-                Some(event) = watchers.next() => {
-                    running.apply_watcher(event, &inventory_refresh).await;
-                }
-                Some(device_key) = running.inputs.triggers.recv() => {
-                    running.begin_action_ring(device_key.as_deref()).await;
-                }
+                biased;
+
                 () = running.signals.recv() => {
                     running.shut_down("shutdown signal", None).await;
                 }
                 Some(request) = running.shutdown_requests.recv() => {
                     running.handle_shutdown_request(request).await;
+                }
+                (request, stopped) = running.hidpp_watchers.replacement_ready() => {
+                    running.complete_replacement(request, stopped);
+                }
+                Some(event) = watchers.next() => {
+                    running.apply_watcher(event, &inventory_refresh).await;
+                }
+                Some(device_key) = running.inputs.triggers.recv() => {
+                    running.begin_action_ring(device_key.as_deref()).await;
                 }
                 else => break,
             }
@@ -476,54 +481,32 @@ impl Running {
             ShutdownRequest::Uninstalled => {
                 self.shut_down("the app was uninstalled", None).await;
             }
-            ShutdownRequest::Restart { path, retry } => self.restart(path, retry).await,
+            ShutdownRequest::Restart { path, retry } => {
+                self.hidpp_watchers
+                    .begin_replacement(Replacement { path, retry });
+            }
         }
     }
 
-    /// Stop the HID++ watcher fleet with the bounded policy for a terminal
-    /// process exit. `None` means arming never reached watcher startup.
-    async fn stop_hidpp_watchers(&mut self) {
-        let Some(watchers) = self.hidpp_watchers.take() else {
-            return;
-        };
-        watchers.stop_and_wait().await;
-    }
-
-    /// A new process image must not inherit unresolved firmware ownership,
-    /// even when restoring it exceeds the terminal-exit deadline.
-    async fn stop_hidpp_watchers_confirmed(&mut self) -> bool {
-        let Some(watchers) = self.hidpp_watchers.take() else {
-            return true;
-        };
-        watchers.stop_and_wait_confirmed().await
-    }
-
-    /// Resolve firmware ownership before replacement and restore the current
-    /// image's managers if ordered teardown could not be confirmed.
-    async fn prepare_process_replacement(&mut self) -> bool {
-        let stopped = self.stop_hidpp_watchers_confirmed().await;
+    /// Called only after the old fleet has acknowledged teardown. Failed
+    /// teardown resumes the current image instead of replacing it.
+    fn complete_replacement(&mut self, request: Replacement, stopped: bool) {
         if !stopped {
+            warn!("HID++ teardown was unclean — refusing replacement and retrying");
             self.restart_hidpp_watchers();
+            let _ = request.retry.send(());
+            return;
         }
-        stopped
+        self.restart(request);
     }
 
     fn restart_hidpp_watchers(&mut self) {
-        self.hidpp_watchers = Some(startup::spawn_hidpp_watchers(&self.shared, &self.inputs));
+        self.hidpp_watchers =
+            WatcherFleet::Running(startup::spawn_hidpp_watchers(&self.shared, &self.inputs));
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
-    async fn restart(&mut self, path: std::path::PathBuf, retry: tokio::sync::oneshot::Sender<()>) {
-        info!(path = %path.display(), "executable changed — draining HID++ sessions before exec");
-        if !self.prepare_process_replacement().await {
-            warn!(
-                path = %path.display(),
-                "one or more HID++ managers did not complete graceful teardown — refusing exec and retrying"
-            );
-            let _ = retry.send(());
-            return;
-        }
-
+    fn restart(&mut self, Replacement { path, retry }: Replacement) {
         let error = crate::binary_watch::replace_process(&path);
         warn!(%error, path = %path.display(), "exec of the updated agent failed — restoring the current image and retrying");
         self.restart_hidpp_watchers();
@@ -531,16 +514,7 @@ impl Running {
     }
 
     #[cfg(target_os = "macos")]
-    async fn restart(&mut self, path: std::path::PathBuf, retry: tokio::sync::oneshot::Sender<()>) {
-        info!(path = %path.display(), "executable changed — draining HID++ sessions before macOS relaunch");
-        if !self.prepare_process_replacement().await {
-            warn!(
-                path = %path.display(),
-                "one or more HID++ managers did not complete graceful teardown — refusing relaunch and retrying"
-            );
-            let _ = retry.send(());
-            return;
-        }
+    fn restart(&mut self, Replacement { path, retry }: Replacement) {
         if let Err(error) = crate::binary_watch::schedule(&path) {
             warn!(%error, "could not schedule updated agent relaunch — keeping the current image and retrying");
             self.restart_hidpp_watchers();
@@ -551,16 +525,7 @@ impl Running {
     }
 
     #[cfg(not(unix))]
-    async fn restart(&mut self, path: std::path::PathBuf, retry: tokio::sync::oneshot::Sender<()>) {
-        info!(path = %path.display(), "executable changed — draining HID++ sessions before the updated agent starts");
-        if !self.prepare_process_replacement().await {
-            warn!(
-                path = %path.display(),
-                "one or more HID++ managers did not complete graceful teardown — refusing replacement and retrying"
-            );
-            let _ = retry.send(());
-            return;
-        }
+    fn restart(&mut self, _request: Replacement) {
         self.exit_after_replacement_teardown("binary update");
     }
 
@@ -569,11 +534,13 @@ impl Running {
         reason: &str,
         tray_guard: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> ! {
-        self.stop_hidpp_watchers().await;
+        std::mem::replace(&mut self.hidpp_watchers, WatcherFleet::Inactive)
+            .stop_for_exit()
+            .await;
         shutdown::release_hook_and_exit(self.hook.take(), &mut self.inputs, reason, tray_guard)
     }
 
-    /// End after [`Self::prepare_process_replacement`] resolved firmware
+    /// End after [`Self::complete_replacement`] resolved firmware
     /// ownership, so a successor starts from native device state.
     #[cfg(any(target_os = "macos", not(unix)))]
     fn exit_after_replacement_teardown(&mut self, reason: &str) -> ! {

--- a/crates/openlogi-agent/src/lifecycle/transition.rs
+++ b/crates/openlogi-agent/src/lifecycle/transition.rs
@@ -1,0 +1,155 @@
+//! Ownership of the watcher fleet during process replacement and terminal exit.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use futures::FutureExt as _;
+use futures::future::BoxFuture;
+use tokio::sync::oneshot;
+use tracing::{info, warn};
+
+use crate::startup::HidppWatcherHandles;
+
+const STOP_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub(super) struct Replacement {
+    pub(super) path: PathBuf,
+    pub(super) retry: oneshot::Sender<()>,
+}
+
+pub(super) enum WatcherFleet {
+    Inactive,
+    Running(HidppWatcherHandles),
+    Replacing {
+        request: Replacement,
+        teardown: BoxFuture<'static, bool>,
+    },
+}
+
+impl WatcherFleet {
+    /// Begin teardown without blocking the lifecycle's other event sources.
+    pub(super) fn begin_replacement(&mut self, request: Replacement) {
+        match std::mem::replace(self, Self::Inactive) {
+            Self::Running(handles) => {
+                info!(path = %request.path.display(), "executable changed — draining HID++ sessions before replacement");
+                *self = Self::Replacing {
+                    request,
+                    teardown: handles.stop_and_wait().boxed(),
+                };
+            }
+            state => {
+                // The binary watcher normally has only one outstanding
+                // request. Do not discard an existing drain if one overlaps.
+                *self = state;
+                let _ = request.retry.send(());
+            }
+        }
+    }
+
+    /// Poll the owned teardown in the main select loop. Losing a select race
+    /// drops only this borrow, not the managers' completion receivers.
+    pub(super) async fn replacement_ready(&mut self) -> (Replacement, bool) {
+        let Self::Replacing { teardown, .. } = self else {
+            return std::future::pending().await;
+        };
+        let stopped = teardown.await;
+        match std::mem::replace(self, Self::Inactive) {
+            Self::Replacing { request, .. } => (request, stopped),
+            _ => unreachable!("exclusive borrow preserves the replacement until completion"),
+        }
+    }
+
+    /// A terminal exit keeps polling the same drain, but no longer waits
+    /// indefinitely for disconnected hardware. Never use this for replacement.
+    pub(super) async fn stop_for_exit(self) {
+        let teardown = match self {
+            Self::Inactive => return,
+            Self::Running(handles) => handles.stop_and_wait().boxed(),
+            Self::Replacing { teardown, .. } => teardown,
+        };
+        if tokio::time::timeout(STOP_TIMEOUT, teardown).await.is_err() {
+            warn!(timeout = ?STOP_TIMEOUT, "watcher teardown exceeded the process-exit deadline");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shutdown::{ShutdownRequest, request_channel};
+
+    fn replacing() -> (WatcherFleet, oneshot::Sender<bool>, oneshot::Receiver<()>) {
+        let (completed, completion) = oneshot::channel();
+        let (retry, retried) = oneshot::channel();
+        let fleet = WatcherFleet::Replacing {
+            request: Replacement {
+                path: PathBuf::from("replacement-agent"),
+                retry,
+            },
+            teardown: async move { completion.await.expect("test controls completion") }.boxed(),
+        };
+        (fleet, completed, retried)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_replacement_keeps_accepting_exit_requests_and_bounds_the_same_drain() {
+        let (mut fleet, completed, _retried) = replacing();
+        let (requests, mut incoming) = request_channel();
+        let quit = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            requests.send(ShutdownRequest::Uninstalled).unwrap();
+        });
+
+        tokio::select! {
+            _ = fleet.replacement_ready() => panic!("replacement cannot proceed without teardown"),
+            request = incoming.recv() => assert!(matches!(request, Some(ShutdownRequest::Uninstalled))),
+        }
+        quit.await.unwrap();
+        assert!(
+            !completed.is_closed(),
+            "accepting Quit must retain the existing cleanup"
+        );
+
+        let started = tokio::time::Instant::now();
+        fleet.stop_for_exit().await;
+        assert_eq!(started.elapsed(), STOP_TIMEOUT);
+        assert!(
+            completed.is_closed(),
+            "terminal timeout may abandon completion before exit"
+        );
+    }
+
+    #[tokio::test]
+    async fn losing_select_polls_retains_completion_and_its_failure_status() {
+        for stopped in [false, true] {
+            let (mut fleet, completed, mut retried) = replacing();
+            for _ in 0..3 {
+                assert!(fleet.replacement_ready().now_or_never().is_none());
+            }
+            completed.send(stopped).unwrap();
+            let (request, actual) = fleet.replacement_ready().await;
+            assert_eq!(actual, stopped);
+            assert_eq!(request.path, PathBuf::from("replacement-agent"));
+            assert!(matches!(fleet, WatcherFleet::Inactive));
+            assert!(matches!(
+                retried.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            ));
+            request.retry.send(()).unwrap();
+            retried.await.unwrap();
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_exit_accepts_existing_cleanup_before_its_deadline() {
+        let (fleet, completed, _retried) = replacing();
+        let started = tokio::time::Instant::now();
+        let completion = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1200)).await;
+            completed.send(true).unwrap();
+        });
+        fleet.stop_for_exit().await;
+        completion.await.unwrap();
+        assert_eq!(started.elapsed(), Duration::from_millis(1200));
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -73,12 +73,14 @@ fn main() {
         }
     };
 
-    // Watch our own executable and restart as the new image when an app update
-    // replaces it — see `binary_watch`. Only the lock-holding (real) agent
-    // watches, so a losing duplicate can't restart anything. The overlay is
-    // spawned later, once the lifecycle decides the agent is actually wanted —
-    // a dormant agent must not bring a helper up.
-    let uninstalled = binary_watch::spawn();
+    // Every non-signal process transition reports to the lifecycle owner. In
+    // particular, the binary watcher must not exec or exit from its own thread:
+    // an armed lifecycle first releases firmware diversion.
+    let (shutdown_tx, shutdown_requests) = shutdown::request_channel();
+    // Only the lock-holding (real) agent watches, so a losing duplicate cannot
+    // restart anything. The overlay spawns only after the lifecycle decides the
+    // agent is wanted; a dormant agent must not bring a helper up.
+    binary_watch::spawn(shutdown_tx.clone());
 
     let config = Config::load_or_default().unwrap_or_else(|e| {
         warn!(error = %e, "could not load config.toml; using defaults");
@@ -125,14 +127,14 @@ fn main() {
         if let Err(e) = std::thread::Builder::new()
             .name("openlogi-agent-core".into())
             .spawn(move || {
-                runtime.block_on(lifecycle::run(config, uninstalled, armed_tx));
+                runtime.block_on(lifecycle::run(config, shutdown_requests, armed_tx));
             })
         {
             warn!(error = %e, "could not spawn the agent core thread; exiting");
             return;
         }
         if armed_rx.recv().is_ok() {
-            tray::run_app_loop(show_in_menu_bar, app_icon, device_io_signal);
+            tray::run_app_loop(show_in_menu_bar, app_icon, device_io_signal, shutdown_tx);
         }
     }
     #[cfg(not(target_os = "macos"))]
@@ -141,7 +143,7 @@ fn main() {
         // (message pump included); the async core keeps the main thread.
         #[cfg(target_os = "windows")]
         {
-            tray_windows::spawn(config.app_settings.show_in_menu_bar);
+            tray_windows::spawn(config.app_settings.show_in_menu_bar, shutdown_tx.clone());
             // Native resume notifications feed the same event seam as macOS
             // and Linux: inventory wakes immediately and replays volatile
             // settings on its settled authoritative snapshot.
@@ -151,7 +153,7 @@ fn main() {
         resume_linux::register(device_io_signal.clone());
         #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         drop(device_io_signal);
-        runtime.block_on(lifecycle::run(config, uninstalled));
+        runtime.block_on(lifecycle::run(config, shutdown_requests));
     }
 }
 

--- a/crates/openlogi-agent/src/shutdown.rs
+++ b/crates/openlogi-agent/src/shutdown.rs
@@ -1,12 +1,86 @@
-//! Signal-driven shutdown: the `SIGTERM`/`SIGINT` listeners and the exit
-//! path that releases the input hook before the process ends.
+//! Process-shutdown requests, `SIGTERM`/`SIGINT` listeners, and the one exit
+//! path that releases firmware capture and the input hook before process end.
+
+use std::path::PathBuf;
 
 use openlogi_hook::Hook;
+use tokio::sync::{mpsc, oneshot};
 use tracing::info;
 #[cfg(unix)]
 use tracing::warn;
 
 use crate::startup::InputServices;
+
+/// A non-signal request for the process lifecycle owner.
+pub(crate) enum ShutdownRequest {
+    /// The user chose Quit from the macOS or Windows tray.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    TrayQuit {
+        /// Kept alive through graceful teardown. The tray only falls back to
+        /// direct exit if this sender is dropped because the core returned or
+        /// panicked instead of ending the process.
+        core_guard: oneshot::Sender<()>,
+    },
+    /// The installed application disappeared from disk.
+    Uninstalled,
+    /// The executable was replaced and the process should become `path`.
+    Restart {
+        path: PathBuf,
+        /// Sent only when scheduling or `exec` failed and the binary watcher
+        /// should resume observing for another settled replacement.
+        retry: oneshot::Sender<()>,
+    },
+}
+
+/// Sender cloned into the tray and executable watcher. Those threads request
+/// transitions; the lifecycle remains the sole authority that performs them.
+pub(crate) type ShutdownRequestSender = mpsc::UnboundedSender<ShutdownRequest>;
+
+/// The single non-signal shutdown source carried through every lifecycle
+/// stage so process replacement cannot bypass armed firmware ownership.
+pub(crate) struct ShutdownRequests(mpsc::UnboundedReceiver<ShutdownRequest>);
+
+impl ShutdownRequests {
+    pub(crate) async fn recv(&mut self) -> Option<ShutdownRequest> {
+        self.0.recv().await
+    }
+}
+
+/// Build the process-wide non-signal shutdown channel.
+pub(crate) fn request_channel() -> (ShutdownRequestSender, ShutdownRequests) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (tx, ShutdownRequests(rx))
+}
+
+/// Ask the async lifecycle to quit, then block this tray thread until the
+/// process ends. There is deliberately no elapsed-time fallback: a timer
+/// cannot distinguish a dead core from legitimate firmware restoration and
+/// can preempt the exact cleanup this handoff exists to protect.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+pub(crate) fn request_tray_quit(
+    requests: Option<&ShutdownRequestSender>,
+    fallback_status: i32,
+) -> ! {
+    let (core_guard, core_ended) = oneshot::channel();
+    let sent = requests.is_some_and(|requests| {
+        requests
+            .send(ShutdownRequest::TrayQuit { core_guard })
+            .is_ok()
+    });
+    if sent {
+        // Successful graceful shutdown calls `process::exit`, so this returns
+        // only when unwinding or an early core return drops the guard.
+        let _ = core_ended.blocking_recv();
+        tracing::warn!("agent core ended without exiting after tray Quit — exiting directly");
+    } else {
+        tracing::warn!("no live agent core to accept tray Quit — exiting directly");
+    }
+    #[expect(
+        clippy::exit,
+        reason = "fallback only: a missing or unwound core cannot return a status through an AppKit or win32 tray callback"
+    )]
+    std::process::exit(fallback_status)
+}
 
 /// A future that fires when `signal` does, or never when the handler could not
 /// be installed.
@@ -76,6 +150,7 @@ pub(crate) fn release_hook_and_exit(
     hook: Option<Hook>,
     inputs: &mut InputServices,
     reason: &str,
+    _tray_guard: Option<oneshot::Sender<()>>,
 ) -> ! {
     info!(reason, "releasing the input hook and exiting");
     drop(hook);

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -16,6 +16,7 @@ use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::runtime::scroll::{ScrollInputHandle, ScrollRuntime};
 use openlogi_agent_core::runtime::{ActionDispatcher, ActionRuntime};
+use openlogi_agent_core::watchers::shutdown::{StopOutcome, WatcherHandle};
 use openlogi_agent_core::watchers::{self, gesture::GestureOutputs};
 use openlogi_core::config::Config;
 #[cfg(target_os = "macos")]
@@ -168,9 +169,46 @@ impl InputServices {
     }
 }
 
+/// Graceful-shutdown handles for the three firmware-owning HID++ managers.
+pub(crate) struct HidppWatcherHandles {
+    gesture: WatcherHandle,
+    host_switch: WatcherHandle,
+    keyboard: WatcherHandle,
+}
+
+impl HidppWatcherHandles {
+    /// Stop all managers concurrently with the bounded policy for a terminal
+    /// process exit.
+    pub(crate) async fn stop_and_wait(self) {
+        let _outcomes = tokio::join!(
+            self.gesture.stop_and_wait("gesture"),
+            self.host_switch.stop_and_wait("host-switch"),
+            self.keyboard.stop_and_wait("keyboard"),
+        );
+    }
+
+    /// Stop all managers concurrently and retain firmware ownership past the
+    /// diagnostic deadline before starting any replacement process image.
+    pub(crate) async fn stop_and_wait_confirmed(self) -> bool {
+        let (gesture, host_switch, keyboard) = tokio::join!(
+            self.gesture.stop_and_wait_confirmed("gesture"),
+            self.host_switch.stop_and_wait_confirmed("host-switch"),
+            self.keyboard.stop_and_wait_confirmed("keyboard"),
+        );
+        all_stopped(gesture, host_switch, keyboard)
+    }
+}
+
+fn all_stopped(gesture: StopOutcome, host_switch: StopOutcome, keyboard: StopOutcome) -> bool {
+    gesture.is_stopped() && host_switch.is_stopped() && keyboard.is_stopped()
+}
+
 /// Start the HID++ background sessions that do not need Accessibility.
-pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputServices) {
-    watchers::gesture::spawn(
+pub(crate) fn spawn_hidpp_watchers(
+    shared: &SharedRuntime,
+    inputs: &InputServices,
+) -> HidppWatcherHandles {
+    let gesture = watchers::gesture::spawn(
         &shared.capture_plans,
         shared.capture_channel.clone(),
         shared.receiver_access.clone(),
@@ -182,13 +220,13 @@ pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputService
             shared.hook_maps.clone(),
         ),
     );
-    watchers::host_switch::spawn(
+    let host_switch = watchers::host_switch::spawn(
         &shared.host_switch_links,
         shared.channel_pool.clone(),
         shared.receiver_access.clone(),
         shared.device_io.clone(),
     );
-    watchers::keyboard::spawn(
+    let keyboard = watchers::keyboard::spawn(
         &shared.keyboard_spec,
         shared.keyboard_channel.clone(),
         shared.receiver_access.clone(),
@@ -196,6 +234,11 @@ pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputService
         shared.device_io.clone(),
         inputs.dispatcher.clone(),
     );
+    HidppWatcherHandles {
+        gesture,
+        host_switch,
+        keyboard,
+    }
 }
 
 /// One tagged event from the per-source state watchers.

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -177,30 +177,18 @@ pub(crate) struct HidppWatcherHandles {
 }
 
 impl HidppWatcherHandles {
-    /// Stop all managers concurrently with the bounded policy for a terminal
-    /// process exit.
-    pub(crate) async fn stop_and_wait(self) {
-        let _outcomes = tokio::join!(
+    /// Stop all managers concurrently and confirm firmware teardown. The
+    /// lifecycle retains this future and owns the terminal-exit deadline.
+    pub(crate) async fn stop_and_wait(self) -> bool {
+        let (gesture, host_switch, keyboard) = tokio::join!(
             self.gesture.stop_and_wait("gesture"),
             self.host_switch.stop_and_wait("host-switch"),
             self.keyboard.stop_and_wait("keyboard"),
         );
+        [gesture, host_switch, keyboard]
+            .into_iter()
+            .all(StopOutcome::is_stopped)
     }
-
-    /// Stop all managers concurrently and retain firmware ownership past the
-    /// diagnostic deadline before starting any replacement process image.
-    pub(crate) async fn stop_and_wait_confirmed(self) -> bool {
-        let (gesture, host_switch, keyboard) = tokio::join!(
-            self.gesture.stop_and_wait_confirmed("gesture"),
-            self.host_switch.stop_and_wait_confirmed("host-switch"),
-            self.keyboard.stop_and_wait_confirmed("keyboard"),
-        );
-        all_stopped(gesture, host_switch, keyboard)
-    }
-}
-
-fn all_stopped(gesture: StopOutcome, host_switch: StopOutcome, keyboard: StopOutcome) -> bool {
-    gesture.is_stopped() && host_switch.is_stopped() && keyboard.is_stopped()
 }
 
 /// Start the HID++ background sessions that do not need Accessibility.

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -224,6 +224,7 @@ pub(crate) fn spawn_hidpp_watchers(
         &shared.host_switch_links,
         shared.channel_pool.clone(),
         shared.receiver_access.clone(),
+        shared.channel_registry.clone(),
         shared.device_io.clone(),
     );
     let keyboard = watchers::keyboard::spawn(

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -43,6 +43,7 @@ use openlogi_core::config::AppIcon;
 use openlogi_hid::DeviceIoSignal;
 use tracing::{info, warn};
 
+use crate::shutdown::{self, ShutdownRequestSender};
 use crate::status_item;
 
 /// The installed menu-bar item plus the action target its menu items weakly
@@ -59,6 +60,10 @@ thread_local! {
     /// on the main thread, which is the same thread that installed it, so the
     /// affinity AppKit demands is the affinity the storage already has.
     static TRAY: RefCell<Option<TrayState>> = const { RefCell::new(None) };
+    /// Where menu actions hand process termination to the async lifecycle.
+    /// Kept separately because the AppKit loop still exists when the status
+    /// item is hidden by preference.
+    static SHUTDOWN_TX: RefCell<Option<ShutdownRequestSender>> = const { RefCell::new(None) };
 }
 
 /// The menu-bar glyph for `icon`: a monochrome template the system tints for
@@ -268,7 +273,8 @@ fn open_command(command: DeeplinkCommand) {
     open_url(&command.to_url());
 }
 
-/// Menu-bar Quit: take a running GUI with us, then end the process.
+/// Menu-bar Quit: take a running GUI with us, then hand process termination to
+/// the lifecycle that owns firmware capture and the input hook.
 ///
 /// Kept out of `define_class!` so the lint set actually sees the exit — clippy
 /// does not look inside macro expansions.
@@ -285,12 +291,9 @@ fn quit_agent() -> ! {
             .output();
     }
     crate::overlay::evict_on_quit();
-    info!("menu-bar Quit — exiting agent");
-    #[expect(
-        clippy::exit,
-        reason = "reached from an AppKit menu action on the main thread: the run loop owns `main`'s stack frame, so no status can travel back to it"
-    )]
-    std::process::exit(0)
+    info!("menu-bar Quit — requesting graceful agent shutdown");
+    let requests = SHUTDOWN_TX.with_borrow(Clone::clone);
+    shutdown::request_tray_quit(requests.as_ref(), 0)
 }
 
 /// Whether an OpenLogi GUI process is currently running (prod or dev bundle).
@@ -322,14 +325,13 @@ pub fn run_app_loop(
     show_in_menu_bar: bool,
     app_icon: AppIcon,
     device_io_signal: DeviceIoSignal,
+    shutdown_tx: ShutdownRequestSender,
 ) -> ! {
+    SHUTDOWN_TX.with_borrow_mut(|slot| *slot = Some(shutdown_tx));
     let Some(mtm) = MainThreadMarker::new() else {
         warn!("agent AppKit loop not started off the main thread — exiting");
-        #[expect(
-            clippy::exit,
-            reason = "this branch means `run_app_loop` was called off the process main thread, where AppKit cannot run at all; the function is `-> !` and `main` returns `()`, so a failure status has nowhere to propagate"
-        )]
-        std::process::exit(1);
+        let requests = SHUTDOWN_TX.with_borrow(Clone::clone);
+        shutdown::request_tray_quit(requests.as_ref(), 1);
     };
     let app = NSApplication::sharedApplication(mtm);
     app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
@@ -349,11 +351,9 @@ pub fn run_app_loop(
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
-    #[expect(
-        clippy::exit,
-        reason = "AppKit only returns from `run()` once the loop is torn down, and the agent core is still running on another thread; this function is `-> !` with no return path, so the process ends here"
-    )]
-    std::process::exit(0);
+    info!("agent AppKit loop ended — requesting graceful core shutdown");
+    let requests = SHUTDOWN_TX.with_borrow(Clone::clone);
+    shutdown::request_tray_quit(requests.as_ref(), 0);
 }
 
 /// Observe display/session sleep and user-visible resume transitions. Generic

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -23,6 +23,7 @@
     unsafe_code,
     reason = "raw win32: Shell_NotifyIconW + a hidden window's message pump — localized here"
 )]
+use std::cell::RefCell;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use tracing::{info, warn};
@@ -42,6 +43,8 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     WS_OVERLAPPED,
 };
 
+use crate::shutdown::{self, ShutdownRequestSender};
+
 /// Tray callback message the icon posts to the hidden window.
 const WM_TRAY: u32 = WM_APP + 1;
 /// Menu command ids returned by `TrackPopupMenu`.
@@ -53,20 +56,26 @@ const ID_QUIT: usize = 2;
 /// 0xC000).
 static TASKBAR_CREATED: AtomicU32 = AtomicU32::new(0);
 
+thread_local! {
+    /// Where the win32 tray callback hands process termination to the async
+    /// lifecycle. The callback and message pump share this one tray thread.
+    static SHUTDOWN_TX: RefCell<Option<ShutdownRequestSender>> = const { RefCell::new(None) };
+}
+
 /// Host the tray icon on its own thread. No-op when the user disabled the
 /// menu-bar/tray preference (same `show_in_menu_bar` setting macOS honors;
 /// takes effect on the agent's next launch, as there).
 ///
 /// Failures are logged, never fatal — the agent's real work (hook, HID++,
 /// IPC) must not die because a shell icon couldn't be installed.
-pub fn spawn(show_in_tray: bool) {
+pub fn spawn(show_in_tray: bool, shutdown_tx: ShutdownRequestSender) {
     if !show_in_tray {
         info!("tray icon disabled by preference — agent stays invisible");
         return;
     }
     if let Err(e) = std::thread::Builder::new()
         .name("openlogi-tray".into())
-        .spawn(run_tray_loop)
+        .spawn(move || run_tray_loop(shutdown_tx))
     {
         warn!(error = %e, "could not spawn the tray thread");
     }
@@ -74,7 +83,8 @@ pub fn spawn(show_in_tray: bool) {
 
 /// Create the hidden window, install the icon, and pump messages for the
 /// agent's lifetime.
-fn run_tray_loop() {
+fn run_tray_loop(shutdown_tx: ShutdownRequestSender) {
+    SHUTDOWN_TX.with_borrow_mut(|slot| *slot = Some(shutdown_tx));
     let class_name = wide("OpenLogiAgentTray");
     // SAFETY: plain win32 registration/creation calls with pointers that
     // outlive the calls; the class name buffer lives until thread exit.
@@ -444,12 +454,9 @@ fn quit(hwnd: HWND) {
         Shell_NotifyIconW(NIM_DELETE, &raw const nid);
     }
     crate::overlay::evict_on_quit();
-    info!("tray Quit — exiting agent");
-    #[expect(
-        clippy::exit,
-        reason = "reached from the window procedure on the tray thread: the status cannot travel back through an `extern \"system\"` callback, and ending the message pump would only end this thread while `main` keeps running the agent core"
-    )]
-    std::process::exit(0);
+    info!("tray Quit — requesting graceful agent shutdown");
+    let requests = SHUTDOWN_TX.with_borrow(Clone::clone);
+    shutdown::request_tray_quit(requests.as_ref(), 0);
 }
 
 /// NUL-terminated UTF-16 for win32 W-APIs.

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -55,7 +55,8 @@ pub use session::gesture::{
     PendingCaptureRestore, run_capture_session, run_capture_session_with_registry_spec,
 };
 pub use session::host_switch::{
-    HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
+    HostSwitchError, HostSwitchRestoreOutcome, HostSwitchSessionFailure, HostSwitchSessionOutcome,
+    HostSwitchStopReason, PendingHostSwitchRestore, run_host_switch_session, switch_linked_hosts,
 };
 pub use session::keyboard::{
     KEYBOARD_KEY_CIDS, run_keyboard_capture_session, run_keyboard_capture_session_with_registry,

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -51,6 +51,7 @@ const HOST_TASK_IDS: [(reprog_controls::TaskId, u8); 3] = [
     (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_3, 2),
 ];
 const HIDPP_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
+const RESTORE_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy)]
 enum ReportingMode {
@@ -129,7 +130,7 @@ pub async fn run_host_switch_session(
     .ok_or(HostSwitchError::UnsupportedKeyboard)?;
     let controls = ReprogControlsV4::new(Arc::clone(&channel), keyboard_index, feature.index);
 
-    let armed = arm_host_controls(&controls).await?;
+    let armed = arm_host_controls(&controls, &mut device_io).await?;
     if armed.is_empty() {
         return Err(HostSwitchError::UnsupportedKeyboard);
     }
@@ -166,8 +167,8 @@ pub async fn run_host_switch_session(
     };
 
     drop(listener);
-    if outcome.1 && device_io.wait_until_allowed().await {
-        restore_host_controls(&controls, armed).await;
+    if outcome.1 {
+        restore_host_controls_until_complete(&controls, armed, &mut device_io).await;
     }
     Ok(outcome.0)
 }
@@ -212,10 +213,11 @@ pub async fn switch_linked_hosts(
 
 async fn arm_host_controls(
     controls: &ReprogControlsV4,
+    device_io: &mut DeviceIoGate,
 ) -> Result<Vec<ArmedControl>, HostSwitchError> {
     let mut armed = Vec::new();
     if let Err(error) = arm_host_controls_inner(controls, &mut armed).await {
-        restore_host_controls(controls, armed).await;
+        restore_host_controls_until_complete(controls, armed, device_io).await;
         return Err(error);
     }
     Ok(armed)
@@ -288,7 +290,11 @@ async fn arm_host_controls_inner(
     Ok(())
 }
 
-async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedControl>) {
+async fn restore_host_controls(
+    controls: &ReprogControlsV4,
+    armed: Vec<ArmedControl>,
+) -> Vec<ArmedControl> {
+    let mut pending = Vec::new();
     for control in armed {
         let mut restored = restore_host_control(controls, control).await;
         if restored.is_err() {
@@ -300,6 +306,27 @@ async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedCont
                 cid = control.cid,
                 "could not restore host switch control"
             );
+            pending.push(control);
+        }
+    }
+    pending
+}
+
+async fn restore_host_controls_until_complete(
+    controls: &ReprogControlsV4,
+    mut pending: Vec<ArmedControl>,
+    device_io: &mut DeviceIoGate,
+) {
+    while !pending.is_empty() {
+        if !device_io.wait_until_allowed().await {
+            // Firmware ownership cannot be discarded. A terminal process exit
+            // is bounded by its caller; a process replacement waits here
+            // rather than starting from a still-diverted baseline.
+            std::future::pending::<()>().await;
+        }
+        pending = restore_host_controls(controls, pending).await;
+        if !pending.is_empty() {
+            tokio::time::sleep(RESTORE_RETRY_DELAY).await;
         }
     }
 }

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -107,8 +107,11 @@ pub enum HostSwitchError {
     },
 }
 
-/// Capture host switch keys on `keyboard` until one is pressed or `shutdown`
-/// resolves. Controls are restored before a requested host is returned.
+/// Capture host switch keys until a press, shutdown, or channel retirement.
+///
+/// Returns any requested host together with the restoration outcome. The caller
+/// must retain pending restoration and finish it before switching hosts or
+/// starting a successor session.
 pub async fn run_host_switch_session(
     keyboard: DeviceRoute,
     shutdown: oneshot::Receiver<HostSwitchStopReason>,

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -25,8 +25,16 @@ use tokio::{
 };
 use tracing::{debug, info};
 
+mod restore;
+
+use restore::rollback_host_switch_start;
+pub use restore::{
+    HostSwitchRestoreOutcome, HostSwitchSessionFailure, HostSwitchSessionOutcome,
+    PendingHostSwitchRestore,
+};
+
 use crate::{
-    ChannelPool, DeviceIoGate, DeviceRoute,
+    ChannelPool, ChannelRegistry, DeviceIoGate, DeviceRoute, SharedChannel,
     backend::BackendError,
     reprog_controls::{self, ReprogControlsV4},
 };
@@ -51,7 +59,6 @@ const HOST_TASK_IDS: [(reprog_controls::TaskId, u8); 3] = [
     (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_3, 2),
 ];
 const HIDPP_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
-const RESTORE_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy)]
 enum ReportingMode {
@@ -105,18 +112,20 @@ pub enum HostSwitchError {
 pub async fn run_host_switch_session(
     keyboard: DeviceRoute,
     shutdown: oneshot::Receiver<HostSwitchStopReason>,
-    channel_pool: ChannelPool,
-    mut device_io: DeviceIoGate,
-) -> Result<Option<u8>, HostSwitchError> {
+    registry: &ChannelRegistry,
+    device_io: DeviceIoGate,
+) -> Result<HostSwitchSessionOutcome, HostSwitchSessionFailure> {
     if !device_io.allows_io() {
         return Err(HostSwitchError::Hid(BackendError::Backend(
             "host device I/O is suspended".into(),
-        )));
+        ))
+        .into());
     }
-    let channel = open_channel(&channel_pool, &keyboard, "opening keyboard channel")
-        .await?
+    let shared = registry
+        .lookup(&keyboard)
         .ok_or(HostSwitchError::KeyboardNotFound)?;
-    let keyboard_index = keyboard.device_index();
+    let channel = Arc::clone(shared.channel());
+    let keyboard_index = shared.device_index();
     let device = timed_hidpp(
         "opening keyboard device",
         Device::new(Arc::clone(&channel), keyboard_index),
@@ -130,9 +139,13 @@ pub async fn run_host_switch_session(
     .ok_or(HostSwitchError::UnsupportedKeyboard)?;
     let controls = ReprogControlsV4::new(Arc::clone(&channel), keyboard_index, feature.index);
 
-    let armed = arm_host_controls(&controls, &mut device_io).await?;
+    let mut armed = Vec::new();
+    if let Err(error) = arm_host_controls_inner(&controls, &mut armed).await {
+        let pending = PendingHostSwitchRestore::new(&shared, controls.feature_index(), armed);
+        return Err(rollback_host_switch_start(error, pending, registry, &device_io).await);
+    }
     if armed.is_empty() {
-        return Err(HostSwitchError::UnsupportedKeyboard);
+        return Err(HostSwitchError::UnsupportedKeyboard.into());
     }
 
     let (press_tx, mut press_rx) = mpsc::unbounded_channel();
@@ -158,19 +171,79 @@ pub async fn run_host_switch_session(
         controls = armed.len(),
         "host switch link active"
     );
-    let outcome = tokio::select! {
-        reason = shutdown => {
-            let reason = reason.unwrap_or(HostSwitchStopReason::DeviceLost);
-            (None, reason == HostSwitchStopReason::Graceful)
-        },
-        Some(host) = press_rx.recv() => (Some(host), true),
-    };
+    let (requested_host, permit_retired_channel) = monitor_host_switch(
+        shutdown,
+        &mut press_rx,
+        registry,
+        &shared,
+        device_io.clone(),
+    )
+    .await;
 
     drop(listener);
-    if outcome.1 {
-        restore_host_controls_until_complete(&controls, armed, &mut device_io).await;
+    let Some(mut pending) = PendingHostSwitchRestore::new(&shared, controls.feature_index(), armed)
+    else {
+        return Ok(HostSwitchSessionOutcome::Restored { requested_host });
+    };
+    if permit_retired_channel {
+        pending = pending.allow_current_channel();
     }
-    Ok(outcome.0)
+    if !device_io.allows_io() {
+        return Ok(HostSwitchSessionOutcome::RestorePending {
+            requested_host,
+            restore: pending,
+        });
+    }
+    Ok(match pending.retry(registry).await {
+        HostSwitchRestoreOutcome::Restored => HostSwitchSessionOutcome::Restored { requested_host },
+        HostSwitchRestoreOutcome::RestorePending(restore) => {
+            HostSwitchSessionOutcome::RestorePending {
+                requested_host,
+                restore,
+            }
+        }
+    })
+}
+
+async fn monitor_host_switch(
+    mut shutdown: oneshot::Receiver<HostSwitchStopReason>,
+    presses: &mut mpsc::UnboundedReceiver<u8>,
+    registry: &ChannelRegistry,
+    shared: &SharedChannel,
+    mut device_io: DeviceIoGate,
+) -> (Option<u8>, bool) {
+    let mut registry_changes = registry.subscribe();
+    loop {
+        if !registry.is_current(shared) {
+            info!(route = %shared.route(), "inventory replaced or removed host-switch channel");
+            return (None, false);
+        }
+        tokio::select! {
+            biased;
+
+            changed = registry_changes.changed() => {
+                if changed.is_err() {
+                    return (None, false);
+                }
+            }
+            reason = &mut shutdown => {
+                let reason = reason.unwrap_or(HostSwitchStopReason::DeviceLost);
+                let current = registry.is_current(shared);
+                return (
+                    None,
+                    reason == HostSwitchStopReason::Graceful && current,
+                );
+            }
+            host = presses.recv() => {
+                return (host, registry.is_current(shared));
+            }
+            allowed = device_io.changed() => {
+                if allowed.is_none() {
+                    return (None, registry.is_current(shared));
+                }
+            }
+        }
+    }
 }
 
 /// Move reachable targets to `host`, then move the keyboard last.
@@ -209,18 +282,6 @@ pub async fn switch_linked_hosts(
         debug!(host, route = %keyboard, "keyboard host switched");
     }
     Ok(changed)
-}
-
-async fn arm_host_controls(
-    controls: &ReprogControlsV4,
-    device_io: &mut DeviceIoGate,
-) -> Result<Vec<ArmedControl>, HostSwitchError> {
-    let mut armed = Vec::new();
-    if let Err(error) = arm_host_controls_inner(controls, &mut armed).await {
-        restore_host_controls_until_complete(controls, armed, device_io).await;
-        return Err(error);
-    }
-    Ok(armed)
 }
 
 async fn arm_host_controls_inner(
@@ -290,12 +351,9 @@ async fn arm_host_controls_inner(
     Ok(())
 }
 
-async fn restore_host_controls(
-    controls: &ReprogControlsV4,
-    armed: Vec<ArmedControl>,
-) -> Vec<ArmedControl> {
-    let mut pending = Vec::new();
-    for control in armed {
+async fn restore_host_controls(controls: &ReprogControlsV4, armed: &[ArmedControl]) -> bool {
+    let mut complete = true;
+    for &control in armed {
         let mut restored = restore_host_control(controls, control).await;
         if restored.is_err() {
             restored = restore_host_control(controls, control).await;
@@ -306,29 +364,10 @@ async fn restore_host_controls(
                 cid = control.cid,
                 "could not restore host switch control"
             );
-            pending.push(control);
+            complete = false;
         }
     }
-    pending
-}
-
-async fn restore_host_controls_until_complete(
-    controls: &ReprogControlsV4,
-    mut pending: Vec<ArmedControl>,
-    device_io: &mut DeviceIoGate,
-) {
-    while !pending.is_empty() {
-        if !device_io.wait_until_allowed().await {
-            // Firmware ownership cannot be discarded. A terminal process exit
-            // is bounded by its caller; a process replacement waits here
-            // rather than starting from a still-diverted baseline.
-            std::future::pending::<()>().await;
-        }
-        pending = restore_host_controls(controls, pending).await;
-        if !pending.is_empty() {
-            tokio::time::sleep(RESTORE_RETRY_DELAY).await;
-        }
-    }
+    complete
 }
 
 async fn restore_host_control(
@@ -555,14 +594,18 @@ mod tests {
     use hidpp::channel::HidppChannel;
 
     use super::{
-        ArmedControl, HostSwitchError, ReportingMode, event_host, host_change_required,
-        host_channel, prepare_host_change_on, restoration_change, shares_channel,
+        ArmedControl, HostSwitchError, HostSwitchRestoreOutcome, PendingHostSwitchRestore,
+        ReportingMode, event_host, host_change_required, host_channel, prepare_host_change_on,
+        restoration_change, rollback_host_switch_start, shares_channel,
     };
-    use crate::DeviceRoute;
-    use crate::channel::scripted::{ScriptedRawHidChannel, feature_error};
+    use crate::backend::NodeId;
+    use crate::channel::scripted::{
+        ScriptedRawHidChannel, feature_error, scripted_channel as raw_scripted_channel,
+    };
     use crate::reprog_controls::{
         AnalyticsKeyEvent, CidReporting, ControlId, CtrlIdInfo, ReprogControlsEvent,
     };
+    use crate::{ChannelRegistry, DeviceRoute, SharedChannel, device_io_channel};
 
     /// Feature index the scripted keyboard reports for `0x1814 ChangeHost`.
     const CHANGE_HOST_INDEX: u8 = 0x04;
@@ -749,6 +792,97 @@ mod tests {
             analytics_key_events: false,
             raw_wheel: true,
         }
+    }
+
+    fn direct_route() -> DeviceRoute {
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        }
+    }
+
+    fn armed_control() -> ArmedControl {
+        ArmedControl {
+            cid: 0x00d3,
+            host: 0,
+            mode: ReportingMode::Diverted,
+            original: noisy_reporting(),
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_restore_recovers_only_through_a_new_current_publication() {
+        let route = direct_route();
+        let node = NodeId::from("keyboard-node".to_owned());
+        let registry = ChannelRegistry::default();
+        let (retired_raw, retired_handle) = ScriptedRawHidChannel::with_responder(|_| None);
+        let retired_channel = raw_scripted_channel(retired_raw).await;
+        let retired = SharedChannel::new(retired_channel.clone(), route.clone());
+        registry.replace_node(node.clone(), [route.clone()], retired_channel);
+        let pending = PendingHostSwitchRestore::new(&retired, 0x22, vec![armed_control()])
+            .expect("one armed control must require restoration");
+
+        let pending = match pending.retry(&registry).await {
+            HostSwitchRestoreOutcome::RestorePending(pending) => pending,
+            HostSwitchRestoreOutcome::Restored => {
+                panic!("the retired publication must not restore itself")
+            }
+        };
+        assert!(retired_handle.written_reports().is_empty());
+
+        let (failed_raw, failed_handle) =
+            ScriptedRawHidChannel::with_failing_writes(|request| Some(request.to_vec()), |_| true);
+        let failed = raw_scripted_channel(failed_raw).await;
+        registry.replace_node(node.clone(), [route.clone()], failed);
+        let pending = match pending.retry(&registry).await {
+            HostSwitchRestoreOutcome::RestorePending(pending) => pending,
+            HostSwitchRestoreOutcome::Restored => panic!("failed writes cannot restore firmware"),
+        };
+        assert_eq!(failed_handle.written_reports().len(), 2);
+
+        let (fresh_raw, fresh_handle) =
+            ScriptedRawHidChannel::with_responder(|request| Some(request.to_vec()));
+        registry.replace_node(node, [route], raw_scripted_channel(fresh_raw).await);
+
+        assert!(matches!(
+            pending.retry(&registry).await,
+            HostSwitchRestoreOutcome::Restored
+        ));
+        assert_eq!(fresh_handle.written_reports().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn suspended_partial_arm_rollback_returns_pending_without_writes() {
+        let route = direct_route();
+        let node = NodeId::from("keyboard-node".to_owned());
+        let registry = ChannelRegistry::default();
+        let (raw, handle) = ScriptedRawHidChannel::with_responder(|request| Some(request.to_vec()));
+        let channel = raw_scripted_channel(raw).await;
+        let shared = SharedChannel::new(channel.clone(), route.clone());
+        registry.replace_node(node, [route], channel);
+        let pending = PendingHostSwitchRestore::new(&shared, 0x22, vec![armed_control()]);
+        let (signal, gate) = device_io_channel();
+        assert!(signal.suspend());
+
+        let failure = rollback_host_switch_start(
+            HostSwitchError::Hidpp("partial arm failed".into()),
+            pending,
+            &registry,
+            &gate,
+        )
+        .await;
+        let (_, pending) = failure.into_parts();
+
+        assert!(handle.written_reports().is_empty());
+        assert!(signal.resume());
+        assert!(matches!(
+            pending
+                .expect("failed rollback must retain ownership")
+                .retry(&registry)
+                .await,
+            HostSwitchRestoreOutcome::Restored
+        ));
+        assert_eq!(handle.written_reports().len(), 1);
     }
 
     #[test]

--- a/crates/openlogi-device/src/session/host_switch/restore.rs
+++ b/crates/openlogi-device/src/session/host_switch/restore.rs
@@ -1,0 +1,393 @@
+//! Owned firmware restoration state for host-switch capture.
+
+use std::{
+    fmt,
+    sync::{Arc, Weak},
+};
+
+use hidpp::channel::HidppChannel;
+use thiserror::Error;
+
+use super::{ArmedControl, HostSwitchError, restore_host_controls};
+use crate::{
+    ChannelRegistry, DeviceIoGate, DeviceRoute, SharedChannel, reprog_controls::ReprogControlsV4,
+};
+
+/// How a host-switch session released its temporary firmware reporting state.
+#[must_use = "pending firmware restoration must be retained by the session manager"]
+pub enum HostSwitchSessionOutcome {
+    /// Every host control was restored before the session returned.
+    Restored {
+        /// Host requested by the keyboard, if the session ended on a key press.
+        requested_host: Option<u8>,
+    },
+    /// Restoration is incomplete and must precede any successor session.
+    RestorePending {
+        /// Host requested before teardown began, if any.
+        requested_host: Option<u8>,
+        /// Owned capability for retrying restoration on a current publication.
+        restore: PendingHostSwitchRestore,
+    },
+}
+
+impl HostSwitchSessionOutcome {
+    /// Split the transition intent from any retained firmware ownership.
+    #[must_use]
+    pub fn into_parts(self) -> (Option<u8>, Option<PendingHostSwitchRestore>) {
+        match self {
+            Self::Restored { requested_host } => (requested_host, None),
+            Self::RestorePending {
+                requested_host,
+                restore,
+            } => (requested_host, Some(restore)),
+        }
+    }
+}
+
+/// A host-switch setup failure plus any rollback state still owned by OpenLogi.
+#[derive(Debug, Error)]
+#[error("{error}")]
+pub struct HostSwitchSessionFailure {
+    #[source]
+    error: HostSwitchError,
+    pending_restore: Option<PendingHostSwitchRestore>,
+}
+
+impl HostSwitchSessionFailure {
+    pub(super) fn clean(error: HostSwitchError) -> Self {
+        Self {
+            error,
+            pending_restore: None,
+        }
+    }
+
+    pub(super) fn with_pending(
+        error: HostSwitchError,
+        pending_restore: PendingHostSwitchRestore,
+    ) -> Self {
+        Self {
+            error,
+            pending_restore: Some(pending_restore),
+        }
+    }
+
+    /// Split the setup error from firmware ownership the caller must retain.
+    #[must_use]
+    pub fn into_parts(self) -> (HostSwitchError, Option<PendingHostSwitchRestore>) {
+        (self.error, self.pending_restore)
+    }
+}
+
+impl From<HostSwitchError> for HostSwitchSessionFailure {
+    fn from(error: HostSwitchError) -> Self {
+        Self::clean(error)
+    }
+}
+
+/// Result of one bounded pending-restoration attempt.
+#[must_use = "a failed restoration returns ownership that must be retained"]
+pub enum HostSwitchRestoreOutcome {
+    /// Every host control was restored on a publication that remained current.
+    Restored,
+    /// Restoration remains incomplete.
+    RestorePending(PendingHostSwitchRestore),
+}
+
+#[derive(Clone, Copy)]
+enum RetiredChannelPolicy {
+    ReplacementOnly,
+    CurrentAllowed,
+}
+
+/// Opaque host-control restoration state that outlives its original channel.
+///
+/// The token retains the exact route, feature index, reporting mode, and
+/// original reporting bits. It deliberately holds only a weak reference to
+/// the retired channel; every retry resolves the exact-route winner from the
+/// current inventory publication.
+pub struct PendingHostSwitchRestore {
+    route: DeviceRoute,
+    retired_channel: Weak<HidppChannel>,
+    retired_policy: RetiredChannelPolicy,
+    feature_index: u8,
+    controls: Vec<ArmedControl>,
+}
+
+impl fmt::Debug for PendingHostSwitchRestore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingHostSwitchRestore")
+            .field("route", &self.route)
+            .field("reporting_count", &self.controls.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PendingHostSwitchRestore {
+    pub(super) fn new(
+        retired: &SharedChannel,
+        feature_index: u8,
+        controls: Vec<ArmedControl>,
+    ) -> Option<Self> {
+        (!controls.is_empty()).then(|| Self {
+            route: retired.route().clone(),
+            retired_channel: Arc::downgrade(retired.channel()),
+            retired_policy: RetiredChannelPolicy::ReplacementOnly,
+            feature_index,
+            controls,
+        })
+    }
+
+    pub(super) fn allow_current_channel(mut self) -> Self {
+        self.retired_policy = RetiredChannelPolicy::CurrentAllowed;
+        self
+    }
+
+    /// Retry through the exact-route channel currently published by inventory.
+    ///
+    /// A successful write is accepted only if that same publication remains
+    /// current after all awaited writes. If it was replaced during the pass,
+    /// all original controls remain pending for the replacement.
+    pub async fn retry(self, registry: &ChannelRegistry) -> HostSwitchRestoreOutcome {
+        let Some(current) = registry.lookup(&self.route) else {
+            return HostSwitchRestoreOutcome::RestorePending(self);
+        };
+        if matches!(self.retired_policy, RetiredChannelPolicy::ReplacementOnly)
+            && self
+                .retired_channel
+                .upgrade()
+                .is_some_and(|retired| Arc::ptr_eq(current.channel(), &retired))
+        {
+            return HostSwitchRestoreOutcome::RestorePending(self);
+        }
+
+        let controls = ReprogControlsV4::new(
+            Arc::clone(current.channel()),
+            current.device_index(),
+            self.feature_index,
+        );
+        let restored = restore_host_controls(&controls, &self.controls).await;
+        if restored && registry.is_current(&current) {
+            HostSwitchRestoreOutcome::Restored
+        } else {
+            HostSwitchRestoreOutcome::RestorePending(self)
+        }
+    }
+}
+
+pub(super) async fn rollback_host_switch_start(
+    error: HostSwitchError,
+    pending: Option<PendingHostSwitchRestore>,
+    registry: &ChannelRegistry,
+    device_io: &DeviceIoGate,
+) -> HostSwitchSessionFailure {
+    let Some(pending) = pending else {
+        return HostSwitchSessionFailure::clean(error);
+    };
+    let pending = pending.allow_current_channel();
+    if !device_io.allows_io() {
+        return HostSwitchSessionFailure::with_pending(error, pending);
+    }
+    match pending.retry(registry).await {
+        HostSwitchRestoreOutcome::Restored => HostSwitchSessionFailure::clean(error),
+        HostSwitchRestoreOutcome::RestorePending(pending) => {
+            HostSwitchSessionFailure::with_pending(error, pending)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{HostSwitchStopReason, monitor_host_switch, run_host_switch_session};
+    use super::*;
+    use crate::backend::NodeId;
+    use crate::channel::scripted::{ScriptedRawHidChannel, feature_error, scripted_channel};
+    use crate::reprog_controls::{CidReporting, ControlId};
+    use crate::session::host_switch::{ArmedControl, ReportingMode};
+
+    fn capture_keyboard(request: &[u8], fail_second_control: bool) -> Option<Vec<u8>> {
+        let mut response = vec![0; 20];
+        response[0] = 0x11;
+        response[1..4].copy_from_slice(&request[1..4]);
+        match (request[2], request[3] >> 4) {
+            (0, 1) => response[4] = 4,
+            (0, 0) => response[4] = 0x22,
+            (0x22, 0) => response[4] = if fail_second_control { 2 } else { 1 },
+            (0x22, 1) => {
+                if request[4] == 1 {
+                    return Some(feature_error(request, 0x08));
+                }
+                // Host key 1, divertable. Unrelated task/group fields are zero.
+                response[4..9].copy_from_slice(&[0, 0xd1, 0, 0, 0x20]);
+            }
+            (0x22, 2) => {
+                response[4..6].copy_from_slice(&request[4..6]);
+                // Original raw XY, persistent diversion, and force raw XY set.
+                response[6] = 0x54;
+            }
+            (0x22, 3) => return Some(request.to_vec()),
+            _ => return None,
+        }
+        Some(response)
+    }
+
+    #[tokio::test]
+    async fn failed_session_and_partial_arm_release_old_channels_and_restore_on_reconnect() {
+        for partial_arm in [false, true] {
+            let route = DeviceRoute::Direct {
+                vendor_id: 0x046d,
+                product_id: 0xb35b,
+            };
+            let node = NodeId::from("host-keyboard".to_owned());
+            let registry = ChannelRegistry::default();
+            let (raw, writes) = ScriptedRawHidChannel::with_dynamic_responder(move |request| {
+                if request[2] == 0x22 && request[3] >> 4 == 3 && request[6] & 1 == 0 {
+                    Some(feature_error(request, 0x08))
+                } else {
+                    capture_keyboard(request, partial_arm)
+                }
+            });
+            let channel = scripted_channel(raw).await;
+            let retired = Arc::downgrade(&channel);
+            registry.replace_node(node.clone(), [route.clone()], channel);
+            let (stop, stopped) = tokio::sync::oneshot::channel();
+            stop.send(HostSwitchStopReason::Graceful).unwrap();
+            let (_signal, gate) = crate::device_io_channel();
+
+            let outcome = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                run_host_switch_session(route.clone(), stopped, &registry, gate),
+            )
+            .await
+            .expect("failed restoration must return ownership instead of looping");
+            let pending = match outcome {
+                Ok(HostSwitchSessionOutcome::RestorePending {
+                    requested_host,
+                    restore,
+                }) => {
+                    assert!(!partial_arm);
+                    assert_eq!(requested_host, None);
+                    restore
+                }
+                Err(failure) => {
+                    assert!(partial_arm);
+                    failure
+                        .into_parts()
+                        .1
+                        .expect("partial arm rollback must retain firmware ownership")
+                }
+                Ok(HostSwitchSessionOutcome::Restored { .. }) => {
+                    panic!("failed writes cannot be clean")
+                }
+            };
+            let reporting: Vec<_> = writes
+                .written_reports()
+                .into_iter()
+                .filter(|request| request[2] == 0x22 && request[3] >> 4 == 3)
+                .collect();
+            assert_eq!(
+                reporting.len(),
+                3,
+                "one arm, then two failed bounded restores"
+            );
+            assert_eq!(&reporting[0][4..7], &[0, 0xd1, 0x23]);
+            assert_eq!(&reporting[1][4..7], &[0, 0xd1, 0x32]);
+
+            registry.remove_node(&node);
+            assert!(
+                retired.upgrade().is_none(),
+                "pending ownership must release the dead channel"
+            );
+            let pending = match pending.retry(&registry).await {
+                HostSwitchRestoreOutcome::RestorePending(pending) => pending,
+                HostSwitchRestoreOutcome::Restored => panic!("absent route cannot be restored"),
+            };
+            let (raw, fresh) =
+                ScriptedRawHidChannel::with_responder(|request| Some(request.to_vec()));
+            registry.replace_node(node, [route], scripted_channel(raw).await);
+            assert!(matches!(
+                pending.retry(&registry).await,
+                HostSwitchRestoreOutcome::Restored
+            ));
+            let reporting = fresh.written_reports();
+            assert_eq!(reporting.len(), 1);
+            assert_eq!(&reporting[0][4..10], &[0, 0xd1, 0x32, 0, 0, 0]);
+        }
+    }
+
+    #[tokio::test]
+    async fn retirement_before_listener_subscription_is_observed_without_another_event() {
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        };
+        let registry = ChannelRegistry::default();
+        let (raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+        let retired = SharedChannel::new(scripted_channel(raw).await, route);
+        let (_stop, stopped) = tokio::sync::oneshot::channel();
+        let (_presses, mut presses) = tokio::sync::mpsc::unbounded_channel();
+        let (_signal, gate) = crate::device_io_channel();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            monitor_host_switch(stopped, &mut presses, &registry, &retired, gate),
+        )
+        .await
+        .expect("a retired publication needs no further notification");
+        assert_eq!(result, (None, false));
+    }
+
+    #[tokio::test]
+    async fn replaced_publication_during_successful_write_remains_pending() {
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        };
+        let node = NodeId::from("keyboard-node".to_owned());
+        let registry = ChannelRegistry::default();
+        let (retired_raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+        let retired = SharedChannel::new(scripted_channel(retired_raw).await, route.clone());
+        let control = ArmedControl {
+            cid: 0x00d3,
+            host: 0,
+            mode: ReportingMode::Diverted,
+            original: CidReporting {
+                cid: ControlId(0x00d3),
+                diverted: false,
+                persistently_diverted: true,
+                force_raw_xy: true,
+                raw_xy: false,
+                remap: Some(ControlId(0x1234)),
+                analytics_key_events: false,
+                raw_wheel: true,
+            },
+        };
+        let pending = PendingHostSwitchRestore::new(&retired, 0x22, vec![control])
+            .expect("one armed control must require restoration");
+        let (winner_raw, winner_handle) =
+            ScriptedRawHidChannel::with_responder(|request| Some(request.to_vec()));
+        let winner = scripted_channel(winner_raw).await;
+        let replacement_registry = registry.clone();
+        let replacement_node = node.clone();
+        let replacement_route = route.clone();
+        let (superseded_raw, superseded_handle) =
+            ScriptedRawHidChannel::with_dynamic_responder(move |request| {
+                replacement_registry.replace_node(
+                    replacement_node.clone(),
+                    [replacement_route.clone()],
+                    winner.clone(),
+                );
+                Some(request.to_vec())
+            });
+        registry.replace_node(node, [route], scripted_channel(superseded_raw).await);
+
+        let pending = match pending.retry(&registry).await {
+            HostSwitchRestoreOutcome::RestorePending(pending) => pending,
+            HostSwitchRestoreOutcome::Restored => panic!("superseded write counted as final"),
+        };
+        assert_eq!(superseded_handle.written_reports().len(), 1);
+        assert!(matches!(
+            pending.retry(&registry).await,
+            HostSwitchRestoreOutcome::Restored
+        ));
+        assert_eq!(winner_handle.written_reports().len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Restore firmware-side HID++ control reporting before a clean agent exit. Quit, signals, uninstall, and binary replacement now reach the lifecycle that owns watcher teardown.

Terminal exit has a shared three-second watcher budget; binary replacement requires confirmed teardown. A pending replacement stays interruptible by terminal shutdown requests.

## Changes

- **openlogi-agent:** centralize process-transition ownership, route tray Quit through lifecycle cleanup, preserve teardown futures across cancelled `select!` polls, and restore watchers plus update retries if replacement cannot proceed. Tray fallback no longer races an independently timed cleanup.
- **openlogi-agent-core:** give each watcher an explicit stop/completion contract. Drain running captures and pending recovery before acknowledging shutdown, using the current `CaptureSlot`/`CaptureRecovery` model. Host-switch sessions release receiver access before handing failed restoration to retry state, so reconnect and pairing can proceed.
- **openlogi-device:** preserve exact original host-switch reporting in a typed pending-restore token without retaining a retired channel. Retry against the current exact-route publication, reject stale successes, retain partial rollback obligations, and prevent rearming or switching hosts until restoration completes.
- Preserve the original contribution and resolve its conflicts with the refactored capture managers. Regression tests cover interrupted replacement, lost acknowledgements, partial arm/restore failures, retirement/reconnect, stale publications, suspension/resume, and receiver-lease release.

## Testing

Passed on the final branch tree in a Linux orb, with `RUSTFLAGS=-D warnings` for compiler checks:

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent
cargo clippy --target aarch64-apple-darwin -p openlogi-agent --all-targets -- -D warnings
cargo clippy --target x86_64-pc-windows-gnu -p openlogi-agent --all-targets -- -D warnings
cargo xtask ci wasm msrv publish-closure
```

The extra CI runner reported **3 passed, 0 failed, 0 skipped**. Focused regression suites also passed: device host-switch **20**, watcher **74**, and lifecycle-transition **3** tests. `git diff --check` passed. A merge-tree check against the refreshed master found no conflicts; master advanced only by the Windows cursor-coordinate fix after the rebase.

Not run locally: typos, shellcheck/shfmt, and cargo-deny (tools unavailable); native macOS/Windows runtime checks and the full native Windows workspace CI lane. Cross-target Clippy is not a native runtime test. New GitHub CI/review results must be evaluated for the updated PR head, not the previous green head.

**Not runtime-tested on hardware.** The original author's earlier SIGTERM smoke test reported an approximately 64 ms clean exit, but did not establish restoration on a reachable diverted device and does not validate this revision. Hardware verification should arm diverted controls, exercise tray Quit and SIGTERM, and confirm native button/key behavior and reporting restoration. Also disconnect/reconnect during restoration, start pairing while recovery is pending, and request Quit while binary replacement is waiting: pairing/terminal shutdown must remain responsive and replacement must not start with unresolved restoration.

Fixes #1097
