### PR TITLE
feat(cli): inspect Easy-Switch host slots

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -59,7 +59,7 @@ warning that host clippy `-D warnings` does not surface still fails CI.
 | `tests (linux)` | `cargo test --workspace --exclude openlogi-desktop` | Linux |
 | `tests (macos, <arch>)` | `cargo test --workspace --all-targets` | macOS. CI matrix is arm64 (`macos-latest`) and x86_64 (`macos-15-intel`) |
 | `cargo-deny` | `cargo deny --config .cargo/deny.toml --all-features --manifest-path crates/openlogi/Cargo.toml check` | any (needs `cargo-deny`; `nix run nixpkgs#cargo-deny -- …` also works) |
-| `clippy (windows)` | `cargo clippy --workspace --all-targets -- -D warnings` | **Windows**. Elsewhere: `devenv tasks run openlogi:check-windows` (ring-free subset, not the full workspace) |
+| `clippy (windows)` | `cargo clippy --workspace --all-targets -- -D warnings`, then the `rustdoc` job's `cargo doc` line | **Windows**. Also carries the Windows rustdoc gate: a `cfg`-gated doc target missing only on Windows resolves fine in the Linux `rustdoc` job. Elsewhere: `devenv tasks run openlogi:check-windows` (ring-free subset, not the full workspace) |
 | `wasm (portable crates)` | `cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown` then `cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown` | any (needs the `wasm32-unknown-unknown` std; devenv installs it) |
 
 CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, and
@@ -68,7 +68,8 @@ CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, and
 job deliberately skips sccache setup. `rust-cache` stores only Cargo registry/git
 inputs (`cache-targets: false`); sccache owns compiler outputs. PRs read the
 default branch's sccache objects but do not write their isolated merge-ref cache.
-There is no Windows test job — only `clippy (windows)`.
+There is no Windows test job — only `clippy (windows)`, which runs clippy and
+rustdoc but no tests.
 
 ### MSRV trap
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,10 @@ jobs:
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D warnings"
+        # This job's default shell is pwsh, where a trailing backslash is not a
+        # line continuation and `--exclude` parses as a unary operator. bash keeps
+        # this command byte-identical to the Linux rustdoc job it mirrors.
+        shell: bash
         run: |
           cargo doc --workspace --no-deps --document-private-items \
             --exclude openlogi-ui \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,22 @@ jobs:
       # and the agent's HKCU-Run autostart) that the Linux/macOS clippy jobs
       # never compile.
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # The same docs the Linux `rustdoc` job builds, built again here because
+      # a `cfg`-gated doc target can exist on Linux and macOS yet be missing on
+      # Windows — an intra-doc link that then resolves everywhere CI looked.
+      # That is neither a compile error nor a clippy lint, so without this step
+      # nothing stands between such a break and a Windows contributor finding
+      # it by hand, which is how `PermissionStatus::Unknown` (fixed in this PR)
+      # reached master.
+      - name: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          cargo doc --workspace --no-deps --document-private-items \
+            --exclude openlogi-ui \
+            --exclude openlogi-desktop \
+            --exclude openlogi-overlay \
+            --exclude openlogi-agent
 
   wasm:
     name: wasm (portable crates)

--- a/crates/openlogi-cli/src/cmd/diag.rs
+++ b/crates/openlogi-cli/src/cmd/diag.rs
@@ -14,6 +14,7 @@ pub mod battery;
 pub mod controls;
 pub mod dpi;
 pub mod features;
+pub mod hosts;
 pub mod lighting;
 pub mod smartshift;
 pub mod wheel;
@@ -24,6 +25,8 @@ pub enum DiagCmd {
     Features(features::FeaturesArgs),
     /// Dump HID++ 0x1b04 reprogrammable controls and capability flags.
     Controls(controls::ControlsArgs),
+    /// Read the HID++ 0x1815 Easy-Switch host table without changing hosts.
+    Hosts(hosts::HostsArgs),
     /// Read the raw battery report (0x1004 or 0x1000 fields).
     Battery(battery::BatteryArgs),
     /// Read DPI → write a small delta → read back → restore → report.
@@ -41,6 +44,7 @@ impl DiagCmd {
         match self {
             Self::Features(args) => features::run(args).await,
             Self::Controls(args) => controls::run(args).await,
+            Self::Hosts(args) => hosts::run(args).await,
             Self::Battery(args) => battery::run(args).await,
             Self::Dpi(args) => dpi::run(args).await,
             Self::Smartshift(args) => smartshift::run(args).await,

--- a/crates/openlogi-cli/src/cmd/diag/hosts.rs
+++ b/crates/openlogi-cli/src/cmd/diag/hosts.rs
@@ -1,0 +1,92 @@
+//! `openlogi diag hosts` — read the Easy-Switch host table.
+
+use std::fmt;
+
+use anyhow::Result;
+use clap::Args;
+use openlogi_hid::{DiagnosticHostBus, DiagnosticHostSlotStatus};
+
+use super::select_device;
+
+#[derive(Debug, Args)]
+pub struct HostsArgs {
+    /// Device name (or a unique substring) to inspect.
+    #[arg(long)]
+    device: Option<String>,
+}
+
+pub async fn run(args: HostsArgs) -> Result<()> {
+    let (route, name) = select_device(args.device.as_deref(), &[0x1815]).await?;
+    let hosts = openlogi_hid::dump_hosts(&route).await?;
+
+    println!("device: {name} ({route})");
+    match hosts.current_host {
+        Some(slot) => println!("current host: {}", slot + 1),
+        None => println!("current host: unknown"),
+    }
+    for slot in &hosts.slots {
+        let current = if hosts.current_host == Some(slot.index) {
+            " [current]"
+        } else {
+            ""
+        };
+        println!(
+            "  host {}: {}, {}{}",
+            slot.index + 1,
+            StatusDisplay(slot.status),
+            BusDisplay(slot.bus),
+            current
+        );
+    }
+    Ok(())
+}
+
+struct StatusDisplay(DiagnosticHostSlotStatus);
+
+impl fmt::Display for StatusDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self.0 {
+            DiagnosticHostSlotStatus::Empty => "empty",
+            DiagnosticHostSlotStatus::Paired => "paired",
+        })
+    }
+}
+
+struct BusDisplay(DiagnosticHostBus);
+
+impl fmt::Display for BusDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self.0 {
+            DiagnosticHostBus::Undefined => "unknown transport",
+            DiagnosticHostBus::Equad => "eQuad",
+            DiagnosticHostBus::Usb => "USB",
+            DiagnosticHostBus::Bluetooth => "Bluetooth",
+            DiagnosticHostBus::BluetoothLowEnergy => "Bluetooth LE",
+            DiagnosticHostBus::Bolt => "Logi Bolt",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openlogi_hid::{DiagnosticHostBus, DiagnosticHostSlotStatus};
+
+    use super::{BusDisplay, StatusDisplay};
+
+    #[test]
+    fn statuses_are_plain_language() {
+        assert_eq!(
+            StatusDisplay(DiagnosticHostSlotStatus::Paired).to_string(),
+            "paired"
+        );
+        assert_eq!(
+            StatusDisplay(DiagnosticHostSlotStatus::Empty).to_string(),
+            "empty"
+        );
+    }
+
+    #[test]
+    fn bolt_is_named_for_the_user() {
+        assert_eq!(BusDisplay(DiagnosticHostBus::Bolt).to_string(), "Logi Bolt");
+    }
+}

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -56,11 +56,12 @@ pub use session::keyboard::{
     KEYBOARD_KEY_CIDS, run_keyboard_capture_session, run_keyboard_capture_session_with_registry,
 };
 pub use write::{
-    Dpi, DpiCapabilities, DpiInfo, FeatureEntry, FirmwareEntity, FirmwareEntityInfo,
-    HapticWaveform, HidppFeatureErrorKind, HidppOperation, LITRA_BEAM_PRODUCT_ID,
-    LITRA_GLOW_PRODUCT_ID, LightCommand, LightingMethod, LitraDescriptor, LitraModel,
-    ReprogControlEntry, ScrollReportingTarget, ScrollResolution, ScrollWheelMode, WriteError,
-    apply_litra, commands_for_light_settings, dump_features, dump_firmware_entities,
+    DiagnosticHostBus, DiagnosticHostSlot, DiagnosticHostSlotStatus, DiagnosticHosts, Dpi,
+    DpiCapabilities, DpiInfo, FeatureEntry, FirmwareEntity, FirmwareEntityInfo, HapticWaveform,
+    HidppFeatureErrorKind, HidppOperation, LITRA_BEAM_PRODUCT_ID, LITRA_GLOW_PRODUCT_ID,
+    LightCommand, LightingMethod, LitraDescriptor, LitraModel, ReprogControlEntry,
+    ScrollReportingTarget, ScrollResolution, ScrollWheelMode, WriteError, apply_litra,
+    commands_for_light_settings, dump_features, dump_firmware_entities, dump_hosts,
     dump_reprog_controls, encode_litra_command, ensure_haptics_armed_on, find_litra, get_backlight,
     get_dpi, get_dpi_info, get_dpi_info_on, get_scroll_wheel_mode, get_scroll_wheel_mode_on,
     get_smartshift_status, get_smartshift_status_on, litra_model_for_route, matches_litra,

--- a/crates/openlogi-device/src/write.rs
+++ b/crates/openlogi-device/src/write.rs
@@ -28,8 +28,9 @@ mod smartshift;
 
 pub use backlight::{get_backlight, set_backlight_enabled};
 pub use diagnostics::{
-    FeatureEntry, FirmwareEntity, FirmwareEntityInfo, ReprogControlEntry, dump_features,
-    dump_firmware_entities, dump_reprog_controls, read_battery_raw,
+    DiagnosticHostBus, DiagnosticHostSlot, DiagnosticHostSlotStatus, DiagnosticHosts, FeatureEntry,
+    FirmwareEntity, FirmwareEntityInfo, ReprogControlEntry, dump_features, dump_firmware_entities,
+    dump_hosts, dump_reprog_controls, read_battery_raw,
 };
 pub use dpi::{
     Dpi, DpiCapabilities, DpiInfo, get_dpi, get_dpi_info, get_dpi_info_on, set_dpi, set_dpi_on,

--- a/crates/openlogi-device/src/write/diagnostics.rs
+++ b/crates/openlogi-device/src/write/diagnostics.rs
@@ -10,6 +10,7 @@ use hidpp::{
         DeviceEntityFirmwareInfo, DeviceEntityType, DeviceInformationFeature,
     },
     feature::feature_set::FeatureSetFeature,
+    feature::hosts_info::{HostBusType, HostIndex, HostSlotStatus, HostsInfoFeature},
     feature::unified_battery::UnifiedBatteryFeature,
     protocol::v20::Hidpp20Error,
 };
@@ -43,6 +44,95 @@ pub struct ReprogControlEntry {
     pub task_id: u16,
     /// Capability and classification flags for the control.
     pub flags: CidFlags,
+}
+
+/// Pairing state of one Easy-Switch host slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticHostSlotStatus {
+    /// No host is paired in this slot.
+    Empty,
+    /// A host is paired in this slot.
+    Paired,
+}
+
+/// Wireless transport recorded for one Easy-Switch host slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticHostBus {
+    /// The device did not identify the transport.
+    Undefined,
+    /// Logitech eQuad / Unifying transport.
+    Equad,
+    /// Wired USB transport.
+    Usb,
+    /// Bluetooth Classic transport.
+    Bluetooth,
+    /// Bluetooth Low Energy transport.
+    BluetoothLowEnergy,
+    /// Bluetooth Low Energy Pro / Logi Bolt transport.
+    Bolt,
+}
+
+/// Read-only snapshot of one Easy-Switch host slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticHostSlot {
+    /// Zero-based slot index used by HID++ `ChangeHost`.
+    pub index: u8,
+    /// Whether a host is paired in the slot.
+    pub status: DiagnosticHostSlotStatus,
+    /// Transport associated with the pairing.
+    pub bus: DiagnosticHostBus,
+}
+
+/// Read-only snapshot of a device's Easy-Switch host table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticHosts {
+    /// Zero-based active host slot, when the device returned a concrete slot.
+    pub current_host: Option<u8>,
+    /// Every slot reported by the device.
+    pub slots: Vec<DiagnosticHostSlot>,
+}
+
+impl TryFrom<HostSlotStatus> for DiagnosticHostSlotStatus {
+    type Error = WriteError;
+
+    fn try_from(status: HostSlotStatus) -> Result<Self, Self::Error> {
+        match status {
+            HostSlotStatus::Empty => Ok(Self::Empty),
+            HostSlotStatus::Paired => Ok(Self::Paired),
+            _ => Err(unsupported_hosts_response()),
+        }
+    }
+}
+
+impl TryFrom<HostBusType> for DiagnosticHostBus {
+    type Error = WriteError;
+
+    fn try_from(bus: HostBusType) -> Result<Self, Self::Error> {
+        match bus {
+            HostBusType::Undefined => Ok(Self::Undefined),
+            HostBusType::Equad => Ok(Self::Equad),
+            HostBusType::Usb => Ok(Self::Usb),
+            HostBusType::Bt => Ok(Self::Bluetooth),
+            HostBusType::Ble => Ok(Self::BluetoothLowEnergy),
+            HostBusType::BlePro => Ok(Self::Bolt),
+            _ => Err(unsupported_hosts_response()),
+        }
+    }
+}
+
+fn current_host_slot(host: HostIndex) -> Result<Option<u8>, WriteError> {
+    match host {
+        HostIndex::Current => Ok(None),
+        HostIndex::Slot(slot) => Ok(Some(slot)),
+        _ => Err(unsupported_hosts_response()),
+    }
+}
+
+fn unsupported_hosts_response() -> WriteError {
+    WriteError::UnsupportedResponse {
+        operation: HidppOperation::DumpFeatures,
+        feature_hex: HostsInfoFeature::ID,
+    }
 }
 
 impl From<CidInfo> for ReprogControlEntry {
@@ -138,6 +228,43 @@ pub async fn dump_reprog_controls(
             entries.push(control.into());
         }
         Ok(entries)
+    })
+    .await
+}
+
+/// Read the Easy-Switch host table without changing the active host.
+pub async fn dump_hosts(
+    backend: &dyn HidBackend,
+    route: &DeviceRoute,
+) -> Result<DiagnosticHosts, WriteError> {
+    let index = route.device_index();
+    with_route(backend, route, move |channel| async move {
+        let mut device = Device::new(Arc::clone(&channel), index)
+            .await
+            .map_err(|_| WriteError::DeviceUnreachable { index })?;
+        let hosts = open_feature::<HostsInfoFeature>(&mut device).await?;
+        let feature_info = hosts.get_feature_info().await.map_err(|error| {
+            classify_hidpp_error(error, HidppOperation::DumpFeatures, HostsInfoFeature::ID)
+        })?;
+        let current_host = current_host_slot(feature_info.current_host)?;
+        let mut slots = Vec::with_capacity(usize::from(feature_info.host_count));
+        for slot in 0..feature_info.host_count {
+            let info = hosts
+                .get_host_info(HostIndex::Slot(slot))
+                .await
+                .map_err(|error| {
+                    classify_hidpp_error(error, HidppOperation::DumpFeatures, HostsInfoFeature::ID)
+                })?;
+            slots.push(DiagnosticHostSlot {
+                index: slot,
+                status: info.status.try_into()?,
+                bus: info.bus_type.try_into()?,
+            });
+        }
+        Ok(DiagnosticHosts {
+            current_host,
+            slots,
+        })
     })
     .await
 }

--- a/crates/openlogi-device/src/write/tests.rs
+++ b/crates/openlogi-device/src/write/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use hidpp::feature::extended_dpi::{DpiRange, Lod};
+use hidpp::feature::hosts_info::{HostBusType, HostSlotStatus};
 use hidpp::feature::per_key_lighting::FramePersistence;
 use hidpp::feature::smartshift::WheelMode;
 
@@ -26,6 +27,34 @@ const TEST_TORQUE: TunableTorque = match TunableTorque::try_new(33) {
     Ok(value) => value,
     Err(_) => panic!("valid test SmartShift torque"),
 };
+
+#[test]
+fn host_diagnostics_preserve_known_protocol_values() {
+    assert_eq!(
+        DiagnosticHostSlotStatus::try_from(HostSlotStatus::Empty)
+            .expect("empty is a supported host-slot status"),
+        DiagnosticHostSlotStatus::Empty
+    );
+    assert_eq!(
+        DiagnosticHostSlotStatus::try_from(HostSlotStatus::Paired)
+            .expect("paired is a supported host-slot status"),
+        DiagnosticHostSlotStatus::Paired
+    );
+
+    for (wire, diagnostic) in [
+        (HostBusType::Undefined, DiagnosticHostBus::Undefined),
+        (HostBusType::Equad, DiagnosticHostBus::Equad),
+        (HostBusType::Usb, DiagnosticHostBus::Usb),
+        (HostBusType::Bt, DiagnosticHostBus::Bluetooth),
+        (HostBusType::Ble, DiagnosticHostBus::BluetoothLowEnergy),
+        (HostBusType::BlePro, DiagnosticHostBus::Bolt),
+    ] {
+        assert_eq!(
+            DiagnosticHostBus::try_from(wire).expect("known host bus must remain supported"),
+            diagnostic
+        );
+    }
+}
 
 #[test]
 fn smartshift_and_wheel_mode_byte_encodings_match() {

--- a/crates/openlogi-hid/src/host.rs
+++ b/crates/openlogi-hid/src/host.rs
@@ -24,8 +24,8 @@ use openlogi_device::backlight::BacklightState;
 use openlogi_device::inventory::{Enumerator, InventoryError};
 use openlogi_device::pairing::PairingReceiver;
 use openlogi_device::write::{
-    self as device, Dpi, DpiInfo, FeatureEntry, FirmwareEntity, HapticWaveform, LightingMethod,
-    LitraModel, ReprogControlEntry, ScrollResolution, ScrollWheelMode,
+    self as device, DiagnosticHosts, Dpi, DpiInfo, FeatureEntry, FirmwareEntity, HapticWaveform,
+    LightingMethod, LitraModel, ReprogControlEntry, ScrollResolution, ScrollWheelMode,
 };
 
 /// This host's HID stack.
@@ -162,6 +162,11 @@ pub async fn apply_litra(
 /// Walk the HID++ feature table of the device `route` reaches.
 pub async fn dump_features(route: &DeviceRoute) -> Result<Vec<FeatureEntry>, WriteError> {
     device::dump_features(&*native_backend(), route).await
+}
+
+/// Read the Easy-Switch host table without changing the active host.
+pub async fn dump_hosts(route: &DeviceRoute) -> Result<DiagnosticHosts, WriteError> {
+    device::dump_hosts(&*native_backend(), route).await
 }
 
 /// Walk the firmware entities of the device `route` reaches.

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -29,11 +29,11 @@ pub use openlogi_device::{backend, inventory, pairing, session, write};
 pub use hidpp::feature::FeatureType;
 pub use hidpp::feature::device_information::DeviceEntityType;
 pub use host::{
-    apply_litra, channel_pool, dump_features, dump_firmware_entities, dump_reprog_controls,
-    enumerate, enumerate_standalone, get_backlight, get_dpi, get_dpi_info, get_scroll_wheel_mode,
-    get_smartshift_status, list_pairing_receivers, play_haptic, read_battery_raw,
-    set_backlight_enabled, set_dpi, set_fn_lock, set_keyboard_color, set_keyboard_color_with,
-    set_scroll_inversion, set_scroll_resolution, set_scroll_wheel_mode, set_smartshift,
-    set_smartshift_sensitivity, toggle_smartshift, watch_hotplug,
+    apply_litra, channel_pool, dump_features, dump_firmware_entities, dump_hosts,
+    dump_reprog_controls, enumerate, enumerate_standalone, get_backlight, get_dpi, get_dpi_info,
+    get_scroll_wheel_mode, get_smartshift_status, list_pairing_receivers, play_haptic,
+    read_battery_raw, set_backlight_enabled, set_dpi, set_fn_lock, set_keyboard_color,
+    set_keyboard_color_with, set_scroll_inversion, set_scroll_resolution, set_scroll_wheel_mode,
+    set_smartshift, set_smartshift_sensitivity, toggle_smartshift, watch_hotplug,
 };
 pub use probe_cache::FileProbeCacheStore;

--- a/crates/openlogi-permissions/src/lib.rs
+++ b/crates/openlogi-permissions/src/lib.rs
@@ -36,7 +36,12 @@ mod macos;
 mod tests;
 
 /// Tri-state result of a permission query.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+///
+/// Declared on every platform, like [`Permission::Accessibility`] beside it,
+/// rather than only on the two that can answer one. Windows has no permission
+/// to report, but the module docs above still name this type, and a `cfg` that
+/// deletes it there turns those docs into a broken intra-doc link that fails
+/// the whole crate's rustdoc build on Windows alone.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PermissionStatus {
     /// The app may use the capability.

--- a/xtask/src/commands/ci/jobs/tests.rs
+++ b/xtask/src/commands/ci/jobs/tests.rs
@@ -26,12 +26,39 @@ fn workflow() -> Option<String> {
 /// The workflow with its line continuations joined back up and every run of
 /// whitespace collapsed, so a command it wraps for readability is one line
 /// again.
+///
+/// Line endings are normalized first. Git hands Windows checkouts CRLF unless
+/// a `.gitattributes` overrides it, and a continuation is then a backslash
+/// followed by CRLF, which the join below does not match — leaving a stray
+/// backslash mid-command and failing every wrapped command in
+/// [`ci_yml_runs_what_this_runner_runs`] on exactly one platform.
 fn workflow_commands(workflow: &str) -> String {
     workflow
+        .replace("\r\n", "\n")
         .replace("\\\n", " ")
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// The parser must not care how git checked the workflow out. A CRLF tree
+/// wraps continuations as a backslash followed by CRLF; missing that leaves a
+/// stray backslash mid-command and fails every wrapped command on Windows
+/// alone — invisible to CI, which is Linux and macOS.
+#[test]
+fn line_continuations_join_under_either_line_ending() {
+    let lf = "run: cargo doc --workspace \\\n  --no-deps --document-private-items";
+    let crlf = lf.replace('\n', "\r\n");
+
+    assert_eq!(
+        workflow_commands(lf),
+        "run: cargo doc --workspace --no-deps --document-private-items"
+    );
+    assert_eq!(
+        workflow_commands(&crlf),
+        workflow_commands(lf),
+        "a CRLF checkout must parse to the same commands as an LF one"
+    );
 }
 
 /// `ci.yml` is the pipeline's source of truth and this runner is a copy of it.


### PR DESCRIPTION
> **Dependency:** This draft depends on #970. Until that PR merges, this
> branch includes its four commits so the documented Windows local gate can
> pass. The Easy-Switch change is the final commit in this PR.

## Summary

- Add a read-only command for inspecting Easy-Switch host slots.
- Report the current slot, paired/empty state, and recorded transport without
  changing device state.

## Changes

- **openlogi-device / openlogi-hid** — expose a fallible read-only HostsInfo
  diagnostic snapshot; unsupported protocol values remain errors rather than
  silent fallbacks.
- **openlogi-cli / openlogi** — add `openlogi diag hosts --device <query>` with
  one-based labels for users and explicit current-slot marking.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `RUSTFLAGS="-D warnings" cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown`
- `typos` was not run locally because `typos-cli` is unavailable.
- Not runtime-tested on physical hardware after the rebase. The command is
  read-only; a fresh keyboard/mouse output capture is still welcome before
  marking the PR ready for merge.

Related to #650

Depends on #970

Code and PR drafted with Codex
