### PR TITLE
fix(agent): stabilize Easy-Switch forwarding

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -59,7 +59,7 @@ warning that host clippy `-D warnings` does not surface still fails CI.
 | `tests (linux)` | `cargo test --workspace --exclude openlogi-desktop` | Linux |
 | `tests (macos, <arch>)` | `cargo test --workspace --all-targets` | macOS. CI matrix is arm64 (`macos-latest`) and x86_64 (`macos-15-intel`) |
 | `cargo-deny` | `cargo deny --config .cargo/deny.toml --all-features --manifest-path crates/openlogi/Cargo.toml check` | any (needs `cargo-deny`; `nix run nixpkgs#cargo-deny -- …` also works) |
-| `clippy (windows)` | `cargo clippy --workspace --all-targets -- -D warnings` | **Windows**. Elsewhere: `devenv tasks run openlogi:check-windows` (ring-free subset, not the full workspace) |
+| `clippy (windows)` | `cargo clippy --workspace --all-targets -- -D warnings`, then the `rustdoc` job's `cargo doc` line | **Windows**. Also carries the Windows rustdoc gate: a `cfg`-gated doc target missing only on Windows resolves fine in the Linux `rustdoc` job. Elsewhere: `devenv tasks run openlogi:check-windows` (ring-free subset, not the full workspace) |
 | `wasm (portable crates)` | `cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown` then `cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown` | any (needs the `wasm32-unknown-unknown` std; devenv installs it) |
 
 CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, and
@@ -68,7 +68,8 @@ CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, and
 job deliberately skips sccache setup. `rust-cache` stores only Cargo registry/git
 inputs (`cache-targets: false`); sccache owns compiler outputs. PRs read the
 default branch's sccache objects but do not write their isolated merge-ref cache.
-There is no Windows test job — only `clippy (windows)`.
+There is no Windows test job — only `clippy (windows)`, which runs clippy and
+rustdoc but no tests.
 
 ### MSRV trap
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,10 @@ jobs:
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D warnings"
+        # This job's default shell is pwsh, where a trailing backslash is not a
+        # line continuation and `--exclude` parses as a unary operator. bash keeps
+        # this command byte-identical to the Linux rustdoc job it mirrors.
+        shell: bash
         run: |
           cargo doc --workspace --no-deps --document-private-items \
             --exclude openlogi-ui \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,22 @@ jobs:
       # and the agent's HKCU-Run autostart) that the Linux/macOS clippy jobs
       # never compile.
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # The same docs the Linux `rustdoc` job builds, built again here because
+      # a `cfg`-gated doc target can exist on Linux and macOS yet be missing on
+      # Windows — an intra-doc link that then resolves everywhere CI looked.
+      # That is neither a compile error nor a clippy lint, so without this step
+      # nothing stands between such a break and a Windows contributor finding
+      # it by hand, which is how `PermissionStatus::Unknown` (fixed in this PR)
+      # reached master.
+      - name: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          cargo doc --workspace --no-deps --document-private-items \
+            --exclude openlogi-ui \
+            --exclude openlogi-desktop \
+            --exclude openlogi-overlay \
+            --exclude openlogi-agent
 
   wasm:
     name: wasm (portable crates)

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -39,7 +39,7 @@ use crate::observable::ObservableState;
 use crate::receiver_access::ReceiverAccess;
 use crate::runtime::hook::{HookMaps, SharedHookMaps};
 use crate::runtime::scroll::ScrollPreferences;
-use crate::watchers::host_switch::{HostSwitchLink, HostSwitchLinks};
+use crate::watchers::host_switch::{HostSwitchInventory, HostSwitchLink, HostSwitchLinks};
 use crate::watchers::keyboard::{KeyboardSpec, SharedKeyboardSpec};
 use crate::{DpiCycleState, DpiCycles};
 
@@ -106,8 +106,10 @@ pub struct SharedRuntime {
     /// Receiver access shared by HID++ sessions and pairing. Pairing/host
     /// transitions are exclusive; capture sessions share under read leases.
     pub receiver_access: ReceiverAccess,
-    /// Keyboard → pointing-device routes resolved from `config.toml`.
+    /// Keyboard → linked-device routes resolved from `config.toml`.
     pub host_switch_links: HostSwitchLinks,
+    /// Online physical routes, independent of host-switch configuration.
+    pub host_switch_inventory: HostSwitchInventory,
 }
 
 impl SharedRuntime {
@@ -181,6 +183,7 @@ pub struct Orchestrator {
     capture_plans_tx: watch::Sender<Arc<Vec<DeviceCapturePlan>>>,
     keyboard_spec_tx: watch::Sender<Option<Arc<KeyboardSpec>>>,
     host_switch_links_tx: watch::Sender<Arc<Vec<HostSwitchLink>>>,
+    host_switch_inventory_tx: watch::Sender<Arc<Vec<DeviceRoute>>>,
     shared: SharedRuntime,
     /// The state the GUI observes. Every mutator below that changes one of its
     /// facts republishes here, so the cell cannot go stale behind a new code
@@ -214,6 +217,8 @@ impl Orchestrator {
         let (capture_plans_tx, capture_plans) = watch::channel(Arc::new(Vec::new()));
         let (keyboard_spec_tx, keyboard_spec) = watch::channel(None);
         let (host_switch_links_tx, host_switch_links) = watch::channel(Arc::new(Vec::new()));
+        let (host_switch_inventory_tx, host_switch_inventory) =
+            watch::channel(Arc::new(Vec::new()));
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(config.keyboard.bindings.clone())),
@@ -232,6 +237,7 @@ impl Orchestrator {
             capture_rearm_generation: Arc::new(AtomicU64::new(0)),
             receiver_access: ReceiverAccess::default(),
             host_switch_links,
+            host_switch_inventory,
         };
         let orch = Self {
             config,
@@ -248,6 +254,7 @@ impl Orchestrator {
             capture_plans_tx,
             keyboard_spec_tx,
             host_switch_links_tx,
+            host_switch_inventory_tx,
             shared,
             observable,
         };
@@ -383,6 +390,10 @@ impl Orchestrator {
             self.config.keyboard.bindings.clone(),
             "keyboard_bindings",
         );
+        // Publish physical presence before configured links. A newly online
+        // keyboard must never arm a session before departure confirmation can
+        // see that it is still present.
+        publish_arc_if_changed(&self.host_switch_inventory_tx, online_routes(&self.devices));
         publish_arc_if_changed(
             &self.host_switch_links_tx,
             host_switch_links(&self.config, &self.devices),
@@ -1042,8 +1053,20 @@ fn host_switch_links(config: &Config, devices: &[AgentDevice]) -> Vec<HostSwitch
                         .and_then(|device| device.route.clone())
                 })
                 .collect::<Vec<_>>();
-            (!targets.is_empty()).then_some(HostSwitchLink { keyboard, targets })
+            (!targets.is_empty()).then_some(HostSwitchLink {
+                keyboard_key: keyboard_key.clone(),
+                keyboard,
+                targets,
+            })
         })
+        .collect()
+}
+
+fn online_routes(devices: &[AgentDevice]) -> Vec<DeviceRoute> {
+    devices
+        .iter()
+        .filter(|device| device.online)
+        .filter_map(|device| device.route.clone())
         .collect()
 }
 

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -3,7 +3,7 @@
 use super::{
     AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES,
     any_device_needs_capture_rearm, build_devices, configured_wheel_mode, host_switch_links,
-    pick_current, plan_reapply, reapply_targets, stable_id,
+    online_routes, pick_current, plan_reapply, reapply_targets, stable_id,
 };
 use openlogi_core::app::ForegroundApp;
 use openlogi_core::binding::{Action, Binding, ButtonId};
@@ -384,15 +384,14 @@ fn host_switch_links_keep_sleeping_targets_but_require_online_keyboard() {
         .entry("keyboard".into())
         .or_default()
         .host_switch_targets = vec!["mouse".into(), "offline".into(), "missing".into()];
-    let devices = [
-        dev("keyboard", 1, true),
-        dev("mouse", 2, true),
-        dev("offline", 3, false),
-    ];
+    let mut keyboard = dev("keyboard", 1, true);
+    keyboard.kind = DeviceKind::Keyboard;
+    let devices = [keyboard, dev("mouse", 2, true), dev("offline", 3, false)];
 
     let links = host_switch_links(&config, &devices);
 
     assert_eq!(links.len(), 1);
+    assert_eq!(links[0].keyboard_key, "keyboard");
     assert_eq!(
         links[0].keyboard,
         DeviceRoute::Bolt {
@@ -412,6 +411,10 @@ fn host_switch_links_keep_sleeping_targets_but_require_online_keyboard() {
                 slot: 3,
             }
         ]
+    );
+    assert_eq!(
+        online_routes(&devices),
+        vec![links[0].keyboard.clone(), links[0].targets[0].clone()]
     );
 }
 

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -1,10 +1,11 @@
-//! Keep configured keyboard → pointing-device host-switch links armed.
+//! Keep configured keyboard → linked-device host-switch relationships armed.
 
 use std::thread;
 use std::time::Duration;
 
 use openlogi_hid::{
-    ChannelPool, DeviceIoGate, DeviceRoute, HostSwitchStopReason, run_host_switch_session,
+    ChannelPool, DeviceIoGate, DeviceRoute, HostSwitchCaptureMode, HostSwitchError,
+    HostSwitchRequest, HostSwitchStopReason, KeyboardHostTransition, run_host_switch_session,
     switch_linked_hosts,
 };
 use tokio::sync::{mpsc, oneshot, watch};
@@ -16,27 +17,44 @@ use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess, ReceiverRequ
 const DEPARTURE_TIMEOUT: Duration = Duration::from_secs(10);
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
+#[derive(Clone, Copy)]
+struct TransitionTimeouts {
+    commanded_departure: Duration,
+}
+
+const TRANSITION_TIMEOUTS: TransitionTimeouts = TransitionTimeouts {
+    commanded_departure: DEPARTURE_TIMEOUT,
+};
+
 /// One resolved link. Config keys are converted to live routes by the
 /// orchestrator so the transport watcher never needs to understand inventory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostSwitchLink {
+    /// Stable physical configuration identity of the initiating keyboard.
+    pub keyboard_key: String,
     /// Keyboard whose host switch keys initiate the transition.
     pub keyboard: DeviceRoute,
-    /// Pointing devices that follow the keyboard.
+    /// Devices that follow the keyboard.
     pub targets: Vec<DeviceRoute>,
 }
 
 /// Read-only, lossless, coalescing view of resolved links.
 pub type HostSwitchLinks = watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>;
+/// Read-only physical routes from the latest successful inventory snapshot.
+/// This stays independent of host-switch configuration so editing a link
+/// cannot masquerade as a keyboard departure.
+pub type HostSwitchInventory = watch::Receiver<std::sync::Arc<Vec<DeviceRoute>>>;
 
 /// Spawn the host switch session manager.
 pub fn spawn(
     links: &HostSwitchLinks,
+    inventory: &HostSwitchInventory,
     channel_pool: ChannelPool,
     receiver_access: ReceiverAccess,
     device_io: DeviceIoGate,
 ) {
     let links = links.clone();
+    let inventory = inventory.clone();
     let receiver_requests = receiver_access.subscribe_requests();
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
@@ -51,6 +69,7 @@ pub fn spawn(
         };
         runtime.block_on(manage(
             links,
+            inventory,
             channel_pool,
             receiver_access,
             receiver_requests,
@@ -63,6 +82,7 @@ struct HostSwitchManagerState {
     sessions: Vec<RunningSession>,
     next_generation: u64,
     restart_after: Vec<(HostSwitchLink, Instant)>,
+    announcement_keyboards: Vec<String>,
 }
 
 impl HostSwitchManagerState {
@@ -71,6 +91,7 @@ impl HostSwitchManagerState {
             sessions: Vec::new(),
             next_generation: 0,
             restart_after: Vec::new(),
+            announcement_keyboards: Vec::new(),
         }
     }
 
@@ -123,11 +144,13 @@ impl HostSwitchManagerState {
                 break;
             };
             self.next_generation = self.next_generation.wrapping_add(1);
+            let capture_mode = capture_mode_for(&self.announcement_keyboards, &link.keyboard_key);
             self.sessions.push(spawn_session(
                 link.clone(),
                 self.next_generation,
                 receiver_lease,
                 channel_pool.clone(),
+                capture_mode,
                 done.clone(),
                 device_io.clone(),
             ));
@@ -136,7 +159,8 @@ impl HostSwitchManagerState {
 }
 
 async fn manage(
-    mut links: watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
+    mut links: HostSwitchLinks,
+    mut inventory: HostSwitchInventory,
     channel_pool: ChannelPool,
     receiver_access: ReceiverAccess,
     mut receiver_requests: watch::Receiver<ReceiverRequestState>,
@@ -175,27 +199,39 @@ async fn manage(
 
         tokio::select! {
             Some(completion) = done_rx.recv() => {
-                if let Some(index) = state.sessions
-                    .iter()
-                    .position(|session| session.generation == completion.generation)
-                {
-                    let completed = state.sessions.remove(index);
+                if let Some(accepted) = accept_completion(&mut state.sessions, completion) {
+                    let AcceptedCompletion { completed, request } = accepted;
                     let _ = completed.task.await;
-                    if let Some((link, host)) = completion.request {
+                    if let Some((link, request)) = request {
+                        if request.keyboard_transition.announcement_observed() {
+                            remember_announcement_keyboard(
+                                &mut state.announcement_keyboards,
+                                link.keyboard_key.clone(),
+                            );
+                        }
+                        debug!(
+                            generation = completed.generation,
+                            route = %link.keyboard,
+                            host = request.host,
+                            targets = link.targets.len(),
+                            "starting linked transition"
+                        );
                         if !device_io.wait_until_allowed().await {
                             return;
                         }
                         stop_all(&mut state.sessions, HostSwitchStopReason::Graceful).await;
                         run_transition(
-                            &mut links,
+                            &mut inventory,
                             &channel_pool,
                             &receiver_access,
                             link,
-                            host,
+                            request,
                         )
                         .await;
                     } else if device_io.allows_io() {
-                        state.restart_after.push((completed.link, Instant::now() + RETRY_DELAY));
+                        state
+                            .restart_after
+                            .push((completed.link, Instant::now() + RETRY_DELAY));
                     }
                     reconcile = true;
                 }
@@ -237,6 +273,7 @@ fn spawn_session(
     generation: u64,
     receiver_lease: crate::receiver_access::SessionReceiverLease,
     pool: ChannelPool,
+    capture_mode: HostSwitchCaptureMode,
     done: mpsc::UnboundedSender<SessionCompletion>,
     device_io: DeviceIoGate,
 ) -> RunningSession {
@@ -245,16 +282,21 @@ fn spawn_session(
     let task = tokio::spawn(async move {
         let _receiver_lease = receiver_lease;
         let keyboard = session_link.keyboard.clone();
-        let request =
-            match run_host_switch_session(session_link.keyboard.clone(), stop_rx, pool, device_io)
-                .await
-            {
-                Ok(host) => host.map(|host| (session_link, host)),
-                Err(error) => {
-                    debug!(%error, route = %keyboard, "host switch session ended");
-                    None
-                }
-            };
+        let request = match run_host_switch_session(
+            session_link.keyboard.clone(),
+            stop_rx,
+            pool,
+            capture_mode,
+            device_io,
+        )
+        .await
+        {
+            Ok(request) => request.map(|request| (session_link, request)),
+            Err(error) => {
+                debug!(%error, route = %keyboard, "host switch session ended");
+                None
+            }
+        };
         let _ = done.send(SessionCompletion {
             generation,
             request,
@@ -277,7 +319,30 @@ struct RunningSession {
 
 struct SessionCompletion {
     generation: u64,
-    request: Option<(HostSwitchLink, u8)>,
+    request: Option<(HostSwitchLink, HostSwitchRequest)>,
+}
+
+struct AcceptedCompletion {
+    completed: RunningSession,
+    request: Option<(HostSwitchLink, HostSwitchRequest)>,
+}
+
+/// Accept a completion only while its exact session generation is still live.
+///
+/// A stopped session can finish after a replacement is armed. Discarding that
+/// obsolete request here prevents its host selection from moving the current
+/// session's linked devices.
+fn accept_completion(
+    sessions: &mut Vec<RunningSession>,
+    completion: SessionCompletion,
+) -> Option<AcceptedCompletion> {
+    let index = sessions
+        .iter()
+        .position(|session| session.generation == completion.generation)?;
+    Some(AcceptedCompletion {
+        completed: sessions.remove(index),
+        request: completion.request,
+    })
 }
 
 async fn stop_all(sessions: &mut Vec<RunningSession>, reason: HostSwitchStopReason) {
@@ -306,108 +371,136 @@ async fn stop_unwanted(sessions: &mut Vec<RunningSession>, wanted: &[HostSwitchL
 }
 
 async fn run_transition(
-    links: &mut watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
+    inventory: &mut HostSwitchInventory,
     channel_pool: &ChannelPool,
     receiver_access: &ReceiverAccess,
     link: HostSwitchLink,
-    host: u8,
+    request: HostSwitchRequest,
+) {
+    run_transition_with(
+        inventory,
+        channel_pool,
+        receiver_access,
+        link,
+        request,
+        &DeviceTransitionExecutor,
+        TRANSITION_TIMEOUTS,
+    )
+    .await;
+}
+
+trait HostTransitionExecutor {
+    async fn switch(
+        &self,
+        keyboard: &DeviceRoute,
+        targets: &[DeviceRoute],
+        host: u8,
+        keyboard_transition: KeyboardHostTransition,
+        channel_pool: &ChannelPool,
+    ) -> Result<bool, HostSwitchError>;
+}
+
+struct DeviceTransitionExecutor;
+
+impl HostTransitionExecutor for DeviceTransitionExecutor {
+    async fn switch(
+        &self,
+        keyboard: &DeviceRoute,
+        targets: &[DeviceRoute],
+        host: u8,
+        keyboard_transition: KeyboardHostTransition,
+        channel_pool: &ChannelPool,
+    ) -> Result<bool, HostSwitchError> {
+        switch_linked_hosts(keyboard, targets, host, keyboard_transition, channel_pool).await
+    }
+}
+
+async fn run_transition_with(
+    inventory: &mut HostSwitchInventory,
+    channel_pool: &ChannelPool,
+    receiver_access: &ReceiverAccess,
+    link: HostSwitchLink,
+    request: HostSwitchRequest,
+    executor: &impl HostTransitionExecutor,
+    timeouts: TransitionTimeouts,
 ) {
     let _lease = receiver_access
         .acquire_exclusive(ExclusiveAccessReason::HostTransition)
         .await;
-    match switch_linked_hosts(&link.keyboard, &link.targets, host, channel_pool).await {
-        Ok(true) => wait_for_departure(links, &link.keyboard).await,
+    match executor
+        .switch(
+            &link.keyboard,
+            &link.targets,
+            request.host,
+            request.keyboard_transition,
+            channel_pool,
+        )
+        .await
+    {
+        Ok(true) => {
+            if !wait_for_departure(inventory, &link.keyboard, timeouts.commanded_departure).await {
+                warn!(route = %link.keyboard, "host transition departure was not observed");
+            }
+        }
         Ok(false) => {}
+        Err(HostSwitchError::HostSlotUnverified { .. }) => {
+            warn!(
+                route = %link.keyboard,
+                host = request.host,
+                "host destination could not be revalidated; followers remain"
+            );
+        }
         Err(error) => {
-            debug!(%error, route = %link.keyboard, host, "keyboard host switch failed");
+            debug!(%error, route = %link.keyboard, host = request.host, "keyboard host switch failed");
         }
     }
 }
 
+fn capture_mode_for(
+    announcement_keyboards: &[String],
+    keyboard_key: &str,
+) -> HostSwitchCaptureMode {
+    if announcement_keyboards
+        .iter()
+        .any(|known_key| known_key == keyboard_key)
+    {
+        HostSwitchCaptureMode::ChangeHostAnnouncement
+    } else {
+        HostSwitchCaptureMode::Full
+    }
+}
+
+fn remember_announcement_keyboard(announcement_keyboards: &mut Vec<String>, keyboard_key: String) {
+    if !announcement_keyboards.contains(&keyboard_key) {
+        announcement_keyboards.push(keyboard_key);
+    }
+}
+
+fn keyboard_departed(inventory: &mut HostSwitchInventory, keyboard: &DeviceRoute) -> bool {
+    !inventory.borrow_and_update().contains(keyboard)
+}
+
 async fn wait_for_departure(
-    links: &mut watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
+    inventory: &mut HostSwitchInventory,
     keyboard: &DeviceRoute,
-) {
-    let deadline = tokio::time::sleep(DEPARTURE_TIMEOUT);
+    timeout: Duration,
+) -> bool {
+    let deadline = tokio::time::sleep(timeout);
     tokio::pin!(deadline);
     loop {
-        let departed = !links
-            .borrow_and_update()
-            .iter()
-            .any(|link| link.keyboard == *keyboard);
-        if departed {
-            return;
+        if keyboard_departed(inventory, keyboard) {
+            return true;
         }
         tokio::select! {
-            result = links.changed() => {
+            result = inventory.changed() => {
                 if result.is_err() {
-                    return;
+                    return false;
                 }
             }
-            () = &mut deadline => {
-                warn!(route = %keyboard, "host transition departure was not observed");
-                return;
-            }
+            () = &mut deadline => return false,
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn route(slot: u8) -> DeviceRoute {
-        DeviceRoute::Bolt {
-            receiver_uid: "cafe".to_owned(),
-            slot,
-        }
-    }
-
-    #[test]
-    fn suspended_device_io_disables_retry_deadlines() {
-        let retry_at = Instant::now() + RETRY_DELAY;
-        let mut state = HostSwitchManagerState::new();
-        state.restart_after.push((
-            HostSwitchLink {
-                keyboard: route(1),
-                targets: vec![route(2)],
-            },
-            retry_at,
-        ));
-
-        assert_eq!(
-            state.deadline(ReceiverRequestState::default(), true),
-            Some(retry_at),
-        );
-        assert_eq!(
-            state.deadline(ReceiverRequestState::default(), false),
-            None,
-            "host-switch retries must stay dormant until visible resume",
-        );
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn departure_publication_finishes_wait_without_advancing_time() {
-        let keyboard = route(1);
-        let link = HostSwitchLink {
-            keyboard: keyboard.clone(),
-            targets: vec![route(2)],
-        };
-        let (links, mut published) = watch::channel(std::sync::Arc::new(vec![link]));
-        let started = Instant::now();
-        let waiting = tokio::spawn(async move {
-            wait_for_departure(&mut published, &keyboard).await;
-            Instant::now()
-        });
-        tokio::task::yield_now().await;
-
-        links.send_replace(std::sync::Arc::new(Vec::new()));
-        tokio::task::yield_now().await;
-
-        assert_eq!(
-            waiting.await.expect("departure waiter should finish"),
-            started,
-            "the link publication should reconcile departure immediately"
-        );
-    }
-}
+mod tests;

--- a/crates/openlogi-agent-core/src/watchers/host_switch/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch/tests.rs
@@ -1,0 +1,306 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use openlogi_hid::{
+    DeviceRoute, HostSwitchCaptureMode, HostSwitchError, HostSwitchRequest, KeyboardHostTransition,
+    ReportedHostSlot,
+};
+use tokio::sync::{oneshot, watch};
+
+use super::{
+    HostSwitchInventory, HostSwitchLink, HostSwitchLinks, HostSwitchManagerState,
+    HostTransitionExecutor, RETRY_DELAY, RunningSession, SessionCompletion, TransitionTimeouts,
+    accept_completion, capture_mode_for, keyboard_departed, remember_announcement_keyboard,
+    run_transition_with, wait_for_departure,
+};
+use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess, ReceiverRequestState};
+
+#[derive(Default)]
+struct DepartureExecutor {
+    calls: AtomicUsize,
+    target_writes: AtomicUsize,
+}
+
+impl HostTransitionExecutor for DepartureExecutor {
+    async fn switch(
+        &self,
+        _keyboard: &DeviceRoute,
+        targets: &[DeviceRoute],
+        host: u8,
+        keyboard_transition: KeyboardHostTransition,
+        _channel_pool: &openlogi_hid::ChannelPool,
+    ) -> Result<bool, HostSwitchError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        let outcome = match keyboard_transition {
+            KeyboardHostTransition::AlreadyDeparting {
+                host_slot: ReportedHostSlot::Empty,
+            } => Err(HostSwitchError::HostSlotEmpty { host }),
+            KeyboardHostTransition::AlreadyDeparting { .. } => {
+                self.target_writes
+                    .fetch_add(targets.len(), Ordering::Relaxed);
+                Ok(true)
+            }
+            transition @ (KeyboardHostTransition::AnalyticsEvent { .. }
+            | KeyboardHostTransition::CommandRequired) => {
+                panic!("unexpected scripted transition: {transition:?}")
+            }
+        };
+        std::future::ready(outcome).await
+    }
+}
+
+async fn wait_for_host_transition_request(receiver_access: &ReceiverAccess) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !receiver_access.requested(ExclusiveAccessReason::HostTransition) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("host transition never requested exclusive access");
+}
+
+fn test_link() -> HostSwitchLink {
+    HostSwitchLink {
+        keyboard_key: "keyboard-a".into(),
+        keyboard: DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb37c,
+        },
+        targets: Vec::new(),
+    }
+}
+
+#[test]
+fn suspended_device_io_disables_retry_deadlines() {
+    let retry_at = tokio::time::Instant::now() + RETRY_DELAY;
+    let mut state = HostSwitchManagerState::new();
+    state.restart_after.push((test_link(), retry_at));
+
+    assert_eq!(
+        state.deadline(ReceiverRequestState::default(), true),
+        Some(retry_at),
+    );
+    assert_eq!(
+        state.deadline(ReceiverRequestState::default(), false),
+        None,
+        "host-switch retries must stay dormant until visible resume",
+    );
+}
+
+#[test]
+fn observed_announcement_enables_lightweight_reconnect_capture() {
+    let mut keyboards = Vec::new();
+
+    assert_eq!(
+        capture_mode_for(&keyboards, "keyboard-a"),
+        HostSwitchCaptureMode::Full
+    );
+    remember_announcement_keyboard(&mut keyboards, "keyboard-a".into());
+    assert_eq!(
+        capture_mode_for(&keyboards, "keyboard-a"),
+        HostSwitchCaptureMode::ChangeHostAnnouncement
+    );
+    assert_eq!(
+        capture_mode_for(&keyboards, "replacement-keyboard"),
+        HostSwitchCaptureMode::Full,
+        "a device reusing the same route must not inherit another keyboard's capture mode"
+    );
+}
+
+#[test]
+fn config_link_removal_does_not_confirm_a_departure() {
+    let link = test_link();
+    let keyboard = link.keyboard.clone();
+    let (links_tx, _links): (_, HostSwitchLinks) = watch::channel(Arc::new(vec![link]));
+    let (inventory_tx, mut inventory): (_, HostSwitchInventory) =
+        watch::channel(Arc::new(vec![keyboard.clone()]));
+
+    assert!(!keyboard_departed(&mut inventory, &keyboard));
+    links_tx.send_replace(Arc::new(Vec::new()));
+    assert!(
+        !keyboard_departed(&mut inventory, &keyboard),
+        "configuration state must not stand in for physical inventory"
+    );
+    inventory_tx.send_replace(Arc::new(Vec::new()));
+    assert!(keyboard_departed(&mut inventory, &keyboard));
+}
+
+#[tokio::test(start_paused = true)]
+async fn departure_publication_finishes_wait_without_advancing_time() {
+    let keyboard = test_link().keyboard;
+    let (inventory_tx, mut inventory): (_, HostSwitchInventory) =
+        watch::channel(Arc::new(vec![keyboard.clone()]));
+    let started = tokio::time::Instant::now();
+    let waiting = tokio::spawn(async move {
+        assert!(
+            wait_for_departure(&mut inventory, &keyboard, Duration::from_secs(10)).await,
+            "published physical departure should complete the wait"
+        );
+        tokio::time::Instant::now()
+    });
+    tokio::task::yield_now().await;
+
+    inventory_tx.send_replace(Arc::new(Vec::new()));
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        waiting.await.expect("departure waiter should finish"),
+        started,
+        "inventory publication should reconcile departure immediately"
+    );
+}
+
+#[tokio::test]
+async fn paired_announcement_moves_targets_after_exclusive_wait() {
+    let mut link = test_link();
+    let keyboard = link.keyboard.clone();
+    link.targets.push(DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xb025,
+    });
+    let (_inventory_tx, inventory): (_, HostSwitchInventory) =
+        watch::channel(Arc::new(vec![keyboard]));
+    let channel_pool = openlogi_hid::host::channel_pool();
+    let receiver_access = ReceiverAccess::default();
+    let session_lease = receiver_access
+        .try_acquire_for_session()
+        .expect("the test session should hold shared receiver access");
+    let executor = Arc::new(DepartureExecutor::default());
+    let request = HostSwitchRequest {
+        host: 2,
+        keyboard_transition: KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Paired,
+        },
+    };
+    let no_wait = TransitionTimeouts {
+        commanded_departure: Duration::ZERO,
+    };
+    let transition = tokio::spawn({
+        let mut inventory = inventory.clone();
+        let channel_pool = channel_pool.clone();
+        let receiver_access = receiver_access.clone();
+        let executor = Arc::clone(&executor);
+        async move {
+            run_transition_with(
+                &mut inventory,
+                &channel_pool,
+                &receiver_access,
+                link,
+                request,
+                executor.as_ref(),
+                no_wait,
+            )
+            .await;
+        }
+    });
+
+    wait_for_host_transition_request(&receiver_access).await;
+    drop(session_lease);
+    transition.await.expect("host transition task panicked");
+
+    assert_eq!(executor.calls.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        executor.target_writes.load(Ordering::Relaxed),
+        1,
+        "the firmware departure announcement should move the target after access is acquired"
+    );
+}
+
+#[tokio::test]
+async fn physical_departure_completes_one_target_switch_without_a_retry() {
+    let mut link = test_link();
+    let keyboard = link.keyboard.clone();
+    link.targets.push(DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xb025,
+    });
+    let (inventory_tx, inventory): (_, HostSwitchInventory) =
+        watch::channel(Arc::new(vec![keyboard]));
+    let channel_pool = openlogi_hid::host::channel_pool();
+    let receiver_access = ReceiverAccess::default();
+    let session_lease = receiver_access
+        .try_acquire_for_session()
+        .expect("the test session should hold shared receiver access");
+    let executor = Arc::new(DepartureExecutor::default());
+    let request = HostSwitchRequest {
+        host: 2,
+        keyboard_transition: KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Unknown,
+        },
+    };
+    let no_wait = TransitionTimeouts {
+        commanded_departure: Duration::ZERO,
+    };
+    let transition = tokio::spawn({
+        let mut inventory = inventory.clone();
+        let channel_pool = channel_pool.clone();
+        let receiver_access = receiver_access.clone();
+        let executor = Arc::clone(&executor);
+        async move {
+            run_transition_with(
+                &mut inventory,
+                &channel_pool,
+                &receiver_access,
+                link,
+                request,
+                executor.as_ref(),
+                no_wait,
+            )
+            .await;
+        }
+    });
+
+    wait_for_host_transition_request(&receiver_access).await;
+    inventory_tx.send_replace(Arc::new(Vec::new()));
+    drop(session_lease);
+    transition.await.expect("host transition task panicked");
+
+    assert_eq!(
+        executor.calls.load(Ordering::Relaxed),
+        1,
+        "physical absence must not trigger a second target switch"
+    );
+    assert_eq!(
+        executor.target_writes.load(Ordering::Relaxed),
+        1,
+        "the announced departure should switch the target exactly once"
+    );
+}
+
+#[tokio::test]
+async fn stale_completion_cannot_remove_or_command_the_current_session() {
+    let (stop, _stop_rx) = oneshot::channel();
+    let task = tokio::spawn(async {});
+    let mut sessions = vec![RunningSession {
+        link: test_link(),
+        generation: 2,
+        stop,
+        task,
+    }];
+    let stale = SessionCompletion {
+        generation: 1,
+        request: Some((
+            test_link(),
+            HostSwitchRequest {
+                host: 2,
+                keyboard_transition: KeyboardHostTransition::AlreadyDeparting {
+                    host_slot: ReportedHostSlot::Paired,
+                },
+            },
+        )),
+    };
+
+    assert!(accept_completion(&mut sessions, stale).is_none());
+    assert_eq!(sessions.len(), 1, "the replacement session must stay armed");
+
+    let current = sessions.pop().expect("replacement session remains live");
+    current
+        .task
+        .await
+        .expect("test session should finish cleanly");
+}

--- a/crates/openlogi-agent/src/pairing/tests.rs
+++ b/crates/openlogi-agent/src/pairing/tests.rs
@@ -13,6 +13,7 @@ fn shared_runtime() -> SharedRuntime {
     let (_, capture_plans) = tokio::sync::watch::channel(Arc::new(Vec::new()));
     let (_, keyboard_spec) = tokio::sync::watch::channel(None);
     let (_, host_switch_links) = tokio::sync::watch::channel(Arc::new(Vec::new()));
+    let (_, host_switch_inventory) = tokio::sync::watch::channel(Arc::new(Vec::new()));
     SharedRuntime {
         hook_maps: Arc::new(RwLock::new(HookMaps::default())),
         keyboard_bindings: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
@@ -31,6 +32,7 @@ fn shared_runtime() -> SharedRuntime {
         capture_rearm_generation: Arc::new(0.into()),
         receiver_access: ReceiverAccess::default(),
         host_switch_links,
+        host_switch_inventory,
     }
 }
 

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -184,6 +184,7 @@ pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputService
     );
     watchers::host_switch::spawn(
         &shared.host_switch_links,
+        &shared.host_switch_inventory,
         shared.channel_pool.clone(),
         shared.receiver_access.clone(),
         shared.device_io.clone(),

--- a/crates/openlogi-device/src/channel/scripted.rs
+++ b/crates/openlogi-device/src/channel/scripted.rs
@@ -18,6 +18,7 @@ use crate::backend::{BackendError, HidBackend, HotplugStream, NodeId, NodeInfo, 
 #[derive(Clone)]
 pub(crate) struct ScriptedRawHidHandle {
     written: Arc<Mutex<Vec<Vec<u8>>>>,
+    incoming_tx: mpsc::UnboundedSender<Vec<u8>>,
 }
 
 impl ScriptedRawHidHandle {
@@ -26,6 +27,13 @@ impl ScriptedRawHidHandle {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .clone()
+    }
+
+    /// Inject an unsolicited HID++ event from the scripted device.
+    pub(crate) fn emit_report(&self, report: Vec<u8>) {
+        self.incoming_tx
+            .send(report)
+            .expect("scripted HID channel should still be open");
     }
 }
 
@@ -77,13 +85,16 @@ impl ScriptedRawHidChannel {
         let written = Arc::new(Mutex::new(Vec::new()));
         (
             Self {
-                incoming_tx,
+                incoming_tx: incoming_tx.clone(),
                 incoming_rx: tokio::sync::Mutex::new(incoming_rx),
                 written: Arc::clone(&written),
                 responder: Arc::new(responder),
                 fails,
             },
-            ScriptedRawHidHandle { written },
+            ScriptedRawHidHandle {
+                written,
+                incoming_tx,
+            },
         )
     }
 }
@@ -173,6 +184,8 @@ pub(crate) enum ScriptedNode {
     OpenFails,
     /// The node opens but carries no HID++ collection.
     NotHidpp,
+    /// The node opens into the supplied live scripted HID++ channel.
+    Live(Arc<HidppChannel>),
 }
 
 /// A [`HidBackend`] over scripted nodes.
@@ -212,6 +225,7 @@ impl HidBackend for ScriptedBackend {
         match self.node(&node.id) {
             None | Some(ScriptedNode::OpenFails) => Err(BackendError::Disconnected),
             Some(ScriptedNode::NotHidpp) => Ok(None),
+            Some(ScriptedNode::Live(channel)) => Ok(Some(Arc::clone(channel))),
         }
     }
 

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -55,7 +55,8 @@ pub use session::gesture::{
     PendingCaptureRestore, run_capture_session, run_capture_session_with_registry_spec,
 };
 pub use session::host_switch::{
-    HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
+    HostSwitchCaptureMode, HostSwitchError, HostSwitchRequest, HostSwitchStopReason,
+    KeyboardHostTransition, ReportedHostSlot, run_host_switch_session, switch_linked_hosts,
 };
 pub use session::keyboard::{
     KEYBOARD_KEY_CIDS, run_keyboard_capture_session, run_keyboard_capture_session_with_registry,

--- a/crates/openlogi-device/src/reprog_controls.rs
+++ b/crates/openlogi-device/src/reprog_controls.rs
@@ -136,6 +136,30 @@ impl CtrlIdInfo {
     }
 }
 
+/// Resolve one Easy-Switch control to its zero-based host channel.
+///
+/// Firmware is inconsistent about whether the stable control ID or the
+/// current task ID carries the channel identity, so both are authoritative.
+#[must_use]
+pub(crate) fn host_switch_channel(info: CtrlIdInfo) -> Option<u8> {
+    [
+        (control_ids::HOST_SWITCH_CHANNEL_1.0, 0),
+        (control_ids::HOST_SWITCH_CHANNEL_2.0, 1),
+        (control_ids::HOST_SWITCH_CHANNEL_3.0, 2),
+    ]
+    .into_iter()
+    .find_map(|(cid, host)| (info.cid == cid).then_some(host))
+    .or_else(|| {
+        [
+            (task_ids::HOST_SWITCH_CHANNEL_1.0, 0),
+            (task_ids::HOST_SWITCH_CHANNEL_2.0, 1),
+            (task_ids::HOST_SWITCH_CHANNEL_3.0, 2),
+        ]
+        .into_iter()
+        .find_map(|(task, host)| (info.task_id == task).then_some(host))
+    })
+}
+
 impl From<CidInfo> for CtrlIdInfo {
     fn from(info: CidInfo) -> Self {
         Self {

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -1,7 +1,7 @@
 //! Keyboard-initiated host-switch synchronization.
 //!
 //! A session temporarily diverts the keyboard's three host controls, observes
-//! which channel was pressed, switches the linked pointing devices, and then
+//! which channel was pressed, switches the linked devices, and then
 //! switches the keyboard itself. Ordering matters: once the keyboard leaves
 //! this host its HID++ channel can no longer command a mouse sharing the same
 //! receiver.
@@ -10,12 +10,8 @@ use std::{future::Future, sync::Arc, time::Duration};
 
 use hidpp::{
     channel::HidppChannel,
-    device::Device,
-    feature::{
-        CreatableFeature,
-        change_host::ChangeHostFeature,
-        hosts_info::{HostIndex, HostSlotStatus, HostsInfoFeature},
-    },
+    device::{Device, DeviceError},
+    feature::{CreatableFeature, change_host::ChangeHostFeature},
     protocol::v20,
 };
 use thiserror::Error;
@@ -31,6 +27,15 @@ use crate::{
     reprog_controls::{self, ReprogControlsV4},
 };
 
+mod slots;
+mod transition;
+
+pub use slots::ReportedHostSlot;
+use slots::ReportedHostSlotReader;
+pub use transition::switch_linked_hosts;
+#[cfg(test)]
+use transition::{host_change_required, prepare_host_change_on, shares_channel};
+
 /// Why an armed host-switch session is being stopped externally.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostSwitchStopReason {
@@ -40,17 +45,64 @@ pub enum HostSwitchStopReason {
     DeviceLost,
 }
 
-const HOST_CONTROL_IDS: [(reprog_controls::ControlId, u8); 3] = [
-    (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_1, 0),
-    (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_2, 1),
-    (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_3, 2),
-];
-const HOST_TASK_IDS: [(reprog_controls::TaskId, u8); 3] = [
-    (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_1, 0),
-    (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_2, 1),
-    (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_3, 2),
-];
+/// Whether OpenLogi must command the keyboard or its firmware already began
+/// the requested transition after reporting a physical Easy-Switch press.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyboardHostTransition {
+    /// Move linked devices first, then command the keyboard last.
+    CommandRequired,
+    /// An undiverted analytics event was observed. Revalidate and command the
+    /// keyboard while it remains reachable. If the destination cannot be
+    /// revalidated, linked devices remain on the current host.
+    AnalyticsEvent {
+        /// Pairing status sampled at the analytics event boundary.
+        host_slot: ReportedHostSlot,
+    },
+    /// The keyboard firmware reported its own departure. An explicitly empty
+    /// destination fails closed; otherwise followers move through their own
+    /// channels without reopening the departing keyboard.
+    AlreadyDeparting {
+        /// Pairing status sampled at the departure announcement boundary.
+        host_slot: ReportedHostSlot,
+    },
+}
+
+impl KeyboardHostTransition {
+    /// Whether a ChangeHost announcement proved that the keyboard firmware
+    /// already began the transition.
+    #[must_use]
+    pub const fn announcement_observed(self) -> bool {
+        matches!(self, Self::AlreadyDeparting { .. })
+    }
+}
+
+/// How a host-switch session should observe the keyboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostSwitchCaptureMode {
+    /// Discover and arm the keyboard's reportable host controls.
+    Full,
+    /// Resolve ChangeHost and listen only for its departure announcement.
+    ChangeHostAnnouncement,
+}
+
+/// A host-switch request captured from the keyboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostSwitchRequest {
+    /// Zero-based destination host slot.
+    pub host: u8,
+    /// How the keyboard itself will reach the destination.
+    pub keyboard_transition: KeyboardHostTransition,
+}
+const EASY_SWITCH_HOST_COUNT: u8 = 3;
 const HIDPP_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
+/// A host event can be the keyboard's last message on this host. Bound the
+/// event-boundary slot read so follower switching never waits behind the
+/// general multi-second HID++ timeout.
+const EVENT_SLOT_VALIDATION_TIMEOUT: Duration = Duration::from_millis(250);
+/// Analytics-only keyboards can begin leaving as soon as their host key is
+/// pressed. Give a reachable keyboard a brief chance to accept cleanup without
+/// putting linked-device forwarding behind a multi-second HID++ timeout.
+const ANALYTICS_CLEANUP_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Clone, Copy)]
 enum ReportingMode {
@@ -64,6 +116,86 @@ struct ArmedControl {
     host: u8,
     mode: ReportingMode,
     original: reprog_controls::CidReporting,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ControlCleanup {
+    /// The keyboard is expected to remain reachable, so retry every restore.
+    Full,
+    /// The keyboard may already be leaving, so make one bounded restore pass.
+    Prompt,
+}
+
+#[derive(Clone, Copy)]
+struct CapturedHostSwitch {
+    request: HostSwitchRequest,
+    cleanup: ControlCleanup,
+}
+
+enum CapturedSessionEvent {
+    Control(CapturedHostSwitch),
+    DepartureAnnouncement { host: u8 },
+}
+
+#[derive(Clone)]
+struct ChangeHostCapture {
+    feature_index: u8,
+    slot_reader: ReportedHostSlotReader,
+}
+
+impl ChangeHostCapture {
+    async fn resolve(feature_index: u8, device: &mut Device) -> Self {
+        let slot_reader = ReportedHostSlotReader::resolve(device).await;
+        Self {
+            feature_index,
+            slot_reader,
+        }
+    }
+
+    async fn reported_host_slot(&self, host: u8) -> ReportedHostSlot {
+        if self.slot_reader.is_supported() {
+            match timeout(
+                EVENT_SLOT_VALIDATION_TIMEOUT,
+                self.slot_reader.read_one(host),
+            )
+            .await
+            {
+                Ok(ReportedHostSlot::Empty) => ReportedHostSlot::Empty,
+                Ok(ReportedHostSlot::Paired) => ReportedHostSlot::Paired,
+                Ok(ReportedHostSlot::Unknown) => {
+                    debug!(host, "host-slot validation was inconclusive");
+                    ReportedHostSlot::Unknown
+                }
+                Err(_) => {
+                    debug!(
+                        host,
+                        "keyboard did not answer host-slot validation before departure"
+                    );
+                    ReportedHostSlot::Unknown
+                }
+            }
+        } else {
+            ReportedHostSlot::Unknown
+        }
+    }
+
+    async fn departure_request(&self, host: u8) -> Result<HostSwitchRequest, HostSwitchError> {
+        let host_slot = self.reported_host_slot(host).await;
+        Ok(HostSwitchRequest {
+            host,
+            keyboard_transition: KeyboardHostTransition::AlreadyDeparting { host_slot },
+        })
+    }
+}
+
+struct HostSwitchFeatures {
+    controls: ReprogControlsV4,
+    change_host: Option<ChangeHostCapture>,
+}
+
+enum SessionOutcome {
+    Captured(CapturedSessionEvent),
+    Stopped(HostSwitchStopReason),
 }
 
 /// Failure while arming or running a host-switch link.
@@ -81,6 +213,9 @@ pub enum HostSwitchError {
     /// A required HID++ operation failed.
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
+    /// Opening the addressed HID++ device failed.
+    #[error("HID++ device error: {0}")]
+    Device(#[from] DeviceError),
     /// A required HID++ operation did not complete within its budget.
     #[error("HID++ operation timed out while {operation}")]
     TimedOut {
@@ -97,16 +232,40 @@ pub enum HostSwitchError {
         /// The zero-based host slot that has no pairing.
         host: u8,
     },
+    /// A host event was captured, but its destination slot could not be
+    /// verified while the keyboard remained reachable.
+    #[error("host {host} pairing could not be verified")]
+    HostSlotUnverified {
+        /// The zero-based host slot whose pairing could not be verified.
+        host: u8,
+    },
+}
+
+impl HostSwitchError {
+    /// Whether the error means the keyboard may already have departed after
+    /// reporting an analytics-only host key. Validation failures are not
+    /// departure signals: switching targets after one would strand them.
+    fn is_device_unreachable(&self) -> bool {
+        matches!(
+            self,
+            Self::Hid(BackendError::Disconnected)
+                | Self::KeyboardNotFound
+                | Self::Device(DeviceError::DeviceNotFound)
+        )
+    }
 }
 
 /// Capture host switch keys on `keyboard` until one is pressed or `shutdown`
-/// resolves. Controls are restored before a requested host is returned.
+/// resolves. Reachable controls are restored before a requested host is
+/// returned; analytics-only capture uses a short cleanup budget because the
+/// keyboard may already be leaving.
 pub async fn run_host_switch_session(
     keyboard: DeviceRoute,
     shutdown: oneshot::Receiver<HostSwitchStopReason>,
     channel_pool: ChannelPool,
+    capture_mode: HostSwitchCaptureMode,
     mut device_io: DeviceIoGate,
-) -> Result<Option<u8>, HostSwitchError> {
+) -> Result<Option<HostSwitchRequest>, HostSwitchError> {
     if !device_io.allows_io() {
         return Err(HostSwitchError::Hid(BackendError::Backend(
             "host device I/O is suspended".into(),
@@ -116,18 +275,22 @@ pub async fn run_host_switch_session(
         .await?
         .ok_or(HostSwitchError::KeyboardNotFound)?;
     let keyboard_index = keyboard.device_index();
-    let device = timed_hidpp(
-        "opening keyboard device",
-        Device::new(Arc::clone(&channel), keyboard_index),
-    )
-    .await?;
-    let feature = timed_hidpp(
-        "locating host controls",
-        device.root().get_feature(reprog_controls::FEATURE_ID),
-    )
-    .await?
-    .ok_or(HostSwitchError::UnsupportedKeyboard)?;
-    let controls = ReprogControlsV4::new(Arc::clone(&channel), keyboard_index, feature.index);
+    if capture_mode == HostSwitchCaptureMode::ChangeHostAnnouncement {
+        let change_host = resolve_change_host_capture(&channel, keyboard_index).await?;
+        return run_change_host_announcement_session(
+            keyboard,
+            keyboard_index,
+            change_host,
+            shutdown,
+            channel,
+            device_io,
+        )
+        .await;
+    }
+    let HostSwitchFeatures {
+        controls,
+        change_host,
+    } = discover_host_switch_features(&channel, keyboard_index).await?;
 
     let armed = arm_host_controls(&controls).await?;
     if armed.is_empty() {
@@ -137,18 +300,35 @@ pub async fn run_host_switch_session(
     let (press_tx, mut press_rx) = mpsc::unbounded_channel();
     let feature_index = controls.feature_index();
     let event_controls = armed.clone();
+    let announcement_feature_index = change_host.as_ref().map(|capture| capture.feature_index);
     let listener = channel.add_msg_listener_guarded(move |raw, matched| {
         if matched {
             return;
         }
         let message = v20::Message::from(raw);
-        let Some(event) =
+        if let Some(event) =
             reprog_controls::decode_full_event(&message, keyboard_index, feature_index)
-        else {
+        {
+            debug!(
+                ?event,
+                keyboard_index, feature_index, "decoded keyboard control event"
+            );
+            if let Some(captured) = host_control_request(&event_controls, event) {
+                debug!(host = captured.request.host, "matched host control event");
+                let _ = press_tx.send(CapturedSessionEvent::Control(captured));
+            }
             return;
-        };
-        if let Some(host) = event_host(&event_controls, event) {
-            let _ = press_tx.send(host);
+        }
+        if let Some(host) = announcement_feature_index.and_then(|feature_index| {
+            change_host_announcement(
+                &message,
+                keyboard_index,
+                feature_index,
+                EASY_SWITCH_HOST_COUNT,
+            )
+        }) {
+            debug!(host, "matched change-host announcement");
+            let _ = press_tx.send(CapturedSessionEvent::DepartureAnnouncement { host });
         }
     });
 
@@ -158,56 +338,169 @@ pub async fn run_host_switch_session(
         "host switch link active"
     );
     let outcome = tokio::select! {
-        reason = shutdown => {
-            let reason = reason.unwrap_or(HostSwitchStopReason::DeviceLost);
-            (None, reason == HostSwitchStopReason::Graceful)
-        },
-        Some(host) = press_rx.recv() => (Some(host), true),
+        reason = shutdown => SessionOutcome::Stopped(
+            reason.unwrap_or(HostSwitchStopReason::DeviceLost)
+        ),
+        Some(captured) = press_rx.recv() => SessionOutcome::Captured(captured),
     };
 
     drop(listener);
-    if outcome.1 && device_io.wait_until_allowed().await {
-        restore_host_controls(&controls, armed).await;
-    }
-    Ok(outcome.0)
+    finish_captured_session(
+        outcome,
+        &controls,
+        armed,
+        change_host.as_ref(),
+        &mut device_io,
+    )
+    .await
 }
 
-/// Move reachable targets to `host`, then move the keyboard last.
-///
-/// Returns whether the keyboard actually changed hosts.
-pub async fn switch_linked_hosts(
-    keyboard: &DeviceRoute,
-    targets: &[DeviceRoute],
-    host: u8,
-    channel_pool: &ChannelPool,
-) -> Result<bool, HostSwitchError> {
-    let channel = open_channel(channel_pool, keyboard, "opening keyboard channel")
-        .await?
-        .ok_or(HostSwitchError::KeyboardNotFound)?;
-    // Validate the keyboard's own move before touching anything: preparation is
-    // read-only, but it is the step that rejects an unpaired host slot, and
-    // discovering that *after* the mice have moved would strand them on a host
-    // the keyboard never reaches. Applying it still happens last, because once
-    // the keyboard leaves this host its channel can no longer command a mouse
-    // sharing the same receiver.
-    let keyboard_change = prepare_host_change_on(&channel, keyboard.device_index(), host).await?;
-    for target in targets {
-        match prepare_host_change(target, host, keyboard, &channel, channel_pool).await {
-            Ok(change) => {
-                if let Err(error) = apply_host_change(change).await {
-                    debug!(%error, route = %target, host, "linked device host switch failed");
-                }
+async fn finish_captured_session(
+    outcome: SessionOutcome,
+    controls: &ReprogControlsV4,
+    armed: Vec<ArmedControl>,
+    change_host: Option<&ChangeHostCapture>,
+    device_io: &mut DeviceIoGate,
+) -> Result<Option<HostSwitchRequest>, HostSwitchError> {
+    let request = match outcome {
+        SessionOutcome::Captured(CapturedSessionEvent::Control(captured)) => {
+            if !device_io.wait_until_allowed().await {
+                return Ok(None);
             }
-            Err(error) => {
-                debug!(%error, route = %target, host, "linked device host switch preparation failed");
-            }
+            Some(finish_captured_control(captured, controls, armed, change_host).await)
         }
+        SessionOutcome::Captured(CapturedSessionEvent::DepartureAnnouncement { host }) => {
+            if !device_io.wait_until_allowed().await {
+                return Ok(None);
+            }
+            let capture = change_host.ok_or(HostSwitchError::UnsupportedKeyboard)?;
+            Some(capture.departure_request(host).await?)
+        }
+        SessionOutcome::Stopped(HostSwitchStopReason::Graceful) => {
+            if device_io.wait_until_allowed().await {
+                restore_host_controls(controls, armed).await;
+            }
+            None
+        }
+        SessionOutcome::Stopped(HostSwitchStopReason::DeviceLost) => None,
+    };
+    Ok(request)
+}
+
+async fn finish_captured_control(
+    captured: CapturedHostSwitch,
+    controls: &ReprogControlsV4,
+    armed: Vec<ArmedControl>,
+    change_host: Option<&ChangeHostCapture>,
+) -> HostSwitchRequest {
+    let mut request = captured.request;
+    if matches!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AnalyticsEvent { .. }
+    ) {
+        let host_slot = match change_host {
+            Some(capture) => capture.reported_host_slot(request.host).await,
+            None => ReportedHostSlot::Unknown,
+        };
+        request.keyboard_transition = KeyboardHostTransition::AnalyticsEvent { host_slot };
     }
-    let changed = apply_host_change(keyboard_change).await?;
-    if changed {
-        debug!(host, route = %keyboard, "keyboard host switched");
+    match captured.cleanup {
+        ControlCleanup::Full => restore_host_controls(controls, armed).await,
+        ControlCleanup::Prompt => restore_host_controls_promptly(controls, armed).await,
     }
-    Ok(changed)
+    request
+}
+
+async fn resolve_change_host_capture(
+    channel: &Arc<HidppChannel>,
+    keyboard_index: u8,
+) -> Result<ChangeHostCapture, HostSwitchError> {
+    let mut device = timed_device(
+        "opening keyboard device",
+        Device::new(Arc::clone(channel), keyboard_index),
+    )
+    .await?;
+    let feature_index = timed_hidpp(
+        "locating change-host announcements",
+        device.root().get_feature(ChangeHostFeature::ID),
+    )
+    .await?
+    .map(|feature| feature.index)
+    .ok_or(HostSwitchError::UnsupportedKeyboard)?;
+    Ok(ChangeHostCapture::resolve(feature_index, &mut device).await)
+}
+
+async fn discover_host_switch_features(
+    channel: &Arc<HidppChannel>,
+    keyboard_index: u8,
+) -> Result<HostSwitchFeatures, HostSwitchError> {
+    let mut device = timed_device(
+        "opening keyboard device",
+        Device::new(Arc::clone(channel), keyboard_index),
+    )
+    .await?;
+    let feature = timed_hidpp(
+        "locating host controls",
+        device.root().get_feature(reprog_controls::FEATURE_ID),
+    )
+    .await?
+    .ok_or(HostSwitchError::UnsupportedKeyboard)?;
+    let controls = ReprogControlsV4::new(Arc::clone(channel), keyboard_index, feature.index);
+    let change_host = match timed_hidpp(
+        "locating change-host announcements",
+        device.root().get_feature(ChangeHostFeature::ID),
+    )
+    .await
+    {
+        Ok(Some(info)) => Some(ChangeHostCapture::resolve(info.index, &mut device).await),
+        Ok(None) => None,
+        Err(error) => {
+            debug!(%error, "change-host announcement lookup failed");
+            None
+        }
+    };
+    Ok(HostSwitchFeatures {
+        controls,
+        change_host,
+    })
+}
+
+async fn run_change_host_announcement_session(
+    keyboard: DeviceRoute,
+    keyboard_index: u8,
+    change_host: ChangeHostCapture,
+    shutdown: oneshot::Receiver<HostSwitchStopReason>,
+    channel: Arc<HidppChannel>,
+    mut device_io: DeviceIoGate,
+) -> Result<Option<HostSwitchRequest>, HostSwitchError> {
+    let (press_tx, mut press_rx) = mpsc::unbounded_channel();
+    let announcement_feature_index = change_host.feature_index;
+    let listener = channel.add_msg_listener_guarded(move |raw, matched| {
+        if matched {
+            return;
+        }
+        let message = v20::Message::from(raw);
+        if let Some(host) = change_host_announcement(
+            &message,
+            keyboard_index,
+            announcement_feature_index,
+            EASY_SWITCH_HOST_COUNT,
+        ) {
+            let _ = press_tx.send(host);
+        }
+    });
+    info!(route = %keyboard, "host switch announcement link active");
+    let host = tokio::select! {
+        _ = shutdown => None,
+        host = press_rx.recv() => host,
+    };
+    drop(listener);
+    match host {
+        Some(host) if device_io.wait_until_allowed().await => {
+            Ok(Some(change_host.departure_request(host).await?))
+        }
+        Some(_) | None => Ok(None),
+    }
 }
 
 async fn arm_host_controls(
@@ -232,7 +525,7 @@ async fn arm_host_controls_inner(
             controls.get_ctrl_id_info(index),
         )
         .await?;
-        let Some(host) = host_channel(info) else {
+        let Some(host) = reprog_controls::host_switch_channel(info) else {
             continue;
         };
         debug!(
@@ -270,7 +563,7 @@ async fn arm_host_controls_inner(
                     timed_hidpp("diverting host control", controls.divert_cid(info.cid)).await?;
                 }
                 ReportingMode::Analytics => {
-                    timed_hidpp(
+                    let echo = timed_hidpp(
                         "enabling host control analytics",
                         controls.set_cid_reporting_full(
                             info.cid,
@@ -281,6 +574,11 @@ async fn arm_host_controls_inner(
                         ),
                     )
                     .await?;
+                    debug!(
+                        cid = format_args!("{:#06x}", info.cid),
+                        ?echo,
+                        "analytics reporting enabled"
+                    );
                 }
             }
         }
@@ -301,6 +599,27 @@ async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedCont
                 "could not restore host switch control"
             );
         }
+    }
+}
+
+async fn restore_host_controls_promptly(controls: &ReprogControlsV4, armed: Vec<ArmedControl>) {
+    let restore_count = armed.len();
+    let restore = async {
+        for control in armed {
+            if let Err(error) = restore_host_control(controls, control).await {
+                debug!(
+                    ?error,
+                    cid = control.cid,
+                    "could not promptly restore host switch control"
+                );
+            }
+        }
+    };
+    if timeout(ANALYTICS_CLEANUP_TIMEOUT, restore).await.is_err() {
+        debug!(
+            controls = restore_count,
+            "prompt host switch cleanup exceeded its budget"
+        );
     }
 }
 
@@ -330,76 +649,6 @@ fn restoration_change(control: ArmedControl) -> reprog_controls::CidReportingCha
     }
 }
 
-struct PreparedHostChange {
-    feature: Arc<ChangeHostFeature>,
-    device_index: u8,
-    host: u8,
-    required: bool,
-}
-
-async fn prepare_host_change(
-    target: &DeviceRoute,
-    host: u8,
-    keyboard: &DeviceRoute,
-    keyboard_channel: &Arc<HidppChannel>,
-    channel_pool: &ChannelPool,
-) -> Result<PreparedHostChange, HostSwitchError> {
-    if shares_channel(target, keyboard) {
-        prepare_host_change_on(keyboard_channel, target.device_index(), host).await
-    } else {
-        let channel = open_channel(channel_pool, target, "opening linked device channel")
-            .await?
-            .ok_or(HostSwitchError::TargetNotFound)?;
-        prepare_host_change_on(&channel, target.device_index(), host).await
-    }
-}
-
-async fn prepare_host_change_on(
-    channel: &Arc<HidppChannel>,
-    device_index: u8,
-    host: u8,
-) -> Result<PreparedHostChange, HostSwitchError> {
-    let mut device = timed_hidpp(
-        "opening host-change device",
-        Device::new(Arc::clone(channel), device_index),
-    )
-    .await?;
-    let info = timed_hidpp(
-        "locating host-change feature",
-        device.root().get_feature(ChangeHostFeature::ID),
-    )
-    .await?
-    .ok_or_else(|| HostSwitchError::Hidpp("ChangeHost is unsupported".into()))?;
-    let change_host = device.add_feature::<ChangeHostFeature>(info.index);
-    let state = timed_hidpp("reading current host", change_host.get_host_info()).await?;
-    let required = host_change_required(state.current_host, state.host_count, host)?;
-    if required && host_slot_is_empty(&mut device, host).await {
-        return Err(HostSwitchError::HostSlotEmpty { host });
-    }
-    Ok(PreparedHostChange {
-        feature: change_host,
-        device_index,
-        host,
-        required,
-    })
-}
-
-async fn apply_host_change(change: PreparedHostChange) -> Result<bool, HostSwitchError> {
-    if !change.required {
-        let PreparedHostChange {
-            device_index, host, ..
-        } = change;
-        debug!(device_index, host, "device already uses requested host");
-        return Ok(false);
-    }
-    timed_hidpp(
-        "writing current host",
-        change.feature.set_current_host(change.host),
-    )
-    .await?;
-    Ok(true)
-}
-
 async fn open_channel(
     channel_pool: &ChannelPool,
     route: &DeviceRoute,
@@ -424,409 +673,85 @@ where
         .map_err(|error| hidpp_error(operation, error))
 }
 
-/// Whether the device explicitly reports `host` as an empty slot.
-///
-/// `ChangeHost`'s `host_count` counts the device's RF channels, not the ones
-/// that have a pairing. Switching to an empty slot is not refused by the
-/// device: `setCurrentHost` is fire-and-forget and a successful switch usually
-/// resets the device, so it simply drops off this host and does not come back
-/// until the user pairs that slot or presses the device's own host button. A
-/// keyboard with three host keys paired to two machines is enough to hit this.
-///
-/// `HostsInfo` (`0x1815`) is the only feature that reports per-slot pairing
-/// status, and asking is advisory: a device that does not implement it, times
-/// out, returns a feature error, or answers with a status byte outside the
-/// spec has not said the slot is empty, and must still be allowed to switch.
-/// Only an explicit `Empty` refuses, so this returns a plain `bool` — an
-/// unreadable status can never abort the transition it was meant to protect.
-async fn host_slot_is_empty(device: &mut Device, host: u8) -> bool {
-    let feature = timed_hidpp(
-        "locating hosts-info feature",
-        device.root().get_feature(HostsInfoFeature::ID),
-    )
-    .await;
-    let index = match feature {
-        Ok(Some(info)) => info.index,
-        Ok(None) => return false,
-        Err(error) => {
-            debug!(host, %error, "hosts-info lookup failed; treating the slot as usable");
-            return false;
-        }
-    };
-    let hosts_info = device.add_feature::<HostsInfoFeature>(index);
-    match timed_hidpp(
-        "reading host slot status",
-        hosts_info.get_host_info(HostIndex::Slot(host)),
-    )
-    .await
-    {
-        Ok(slot) => slot.status == HostSlotStatus::Empty,
-        Err(error) => {
-            debug!(host, %error, "host slot status is unreadable; treating the slot as usable");
-            false
-        }
-    }
-}
-
-fn host_change_required(
-    current_host: u8,
-    host_count: u8,
-    requested_host: u8,
-) -> Result<bool, HostSwitchError> {
-    if requested_host >= host_count {
-        return Err(HostSwitchError::Hidpp(format!(
-            "host {requested_host} is outside device host count {host_count}"
-        )));
-    }
-    Ok(current_host != requested_host)
-}
-
-fn shares_channel(left: &DeviceRoute, right: &DeviceRoute) -> bool {
-    left.shares_transport(right)
+async fn timed_device<T>(
+    operation: &'static str,
+    future: impl Future<Output = Result<T, DeviceError>>,
+) -> Result<T, HostSwitchError> {
+    timeout(HIDPP_OPERATION_TIMEOUT, future)
+        .await
+        .map_err(|_| HostSwitchError::TimedOut { operation })?
+        .map_err(HostSwitchError::Device)
 }
 
 fn hidpp_error(operation: &'static str, error: impl std::fmt::Debug) -> HostSwitchError {
     HostSwitchError::Hidpp(format!("{operation}: {error:?}"))
 }
 
-fn host_channel(info: reprog_controls::CtrlIdInfo) -> Option<u8> {
-    HOST_CONTROL_IDS
-        .iter()
-        .find_map(|(cid, host)| (info.cid == cid.0).then_some(*host))
-        .or_else(|| {
-            HOST_TASK_IDS
-                .iter()
-                .find_map(|(task, host)| (info.task_id == task.0).then_some(*host))
-        })
-}
-
-fn event_host(
+fn event_control(
     controls: &[ArmedControl],
-    event: reprog_controls::ReprogControlsEvent,
-) -> Option<u8> {
+    event: &reprog_controls::ReprogControlsEvent,
+) -> Option<ArmedControl> {
     match event {
         reprog_controls::ReprogControlsEvent::DivertedButtons(cids) => controls
             .iter()
-            .find_map(|control| cids.contains(&control.cid.into()).then_some(control.host)),
-        reprog_controls::ReprogControlsEvent::AnalyticsKeyEvents(events) => {
-            controls.iter().find_map(|control| {
-                events
-                    .iter()
-                    .any(|event| event.cid.0 == control.cid)
-                    .then_some(control.host)
-            })
-        }
+            .find(|control| cids.contains(&control.cid.into()))
+            .copied(),
+        reprog_controls::ReprogControlsEvent::AnalyticsKeyEvents(events) => controls
+            .iter()
+            .find(|control| events.iter().any(|event| event.cid.0 == control.cid))
+            .copied(),
         reprog_controls::ReprogControlsEvent::DivertedRawMouseXy { .. }
         | reprog_controls::ReprogControlsEvent::DivertedRawWheel { .. } => None,
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use hidpp::channel::HidppChannel;
-
-    use super::{
-        ArmedControl, HostSwitchError, ReportingMode, event_host, host_change_required,
-        host_channel, prepare_host_change_on, restoration_change, shares_channel,
-    };
-    use crate::DeviceRoute;
-    use crate::channel::scripted::{ScriptedRawHidChannel, feature_error};
-    use crate::reprog_controls::{
-        AnalyticsKeyEvent, CidReporting, ControlId, CtrlIdInfo, ReprogControlsEvent,
-    };
-
-    /// Feature index the scripted keyboard reports for `0x1814 ChangeHost`.
-    const CHANGE_HOST_INDEX: u8 = 0x04;
-    /// Feature index the scripted keyboard reports for `0x1815 HostsInfo`.
-    const HOSTS_INFO_INDEX: u8 = 0x05;
-
-    /// `ErrorType::Busy`, the failure a scripted device answers with.
-    const BUSY: u8 = 0x08;
-
-    /// What the scripted keyboard's firmware does when asked about `0x1815`.
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    enum SlotStatus {
-        /// Answers the query: hosts 0 and 1 paired, host 2 empty.
-        Reported,
-        /// Reports the feature as unimplemented, the usual index-0 lookup miss.
-        Unimplemented,
-        /// Errors on the lookup itself, as firmware that refuses unknown
-        /// feature ids rather than reporting index 0 does.
-        LookupErrors,
-        /// Implements the feature but errors on the status read.
-        ReadErrors,
-    }
-
-    /// A three-channel keyboard currently on host 0, paired on hosts 0 and 1
-    /// but **not** on host 2 — a keyboard with three host keys and only two
-    /// machines paired, which is the shape that used to strand devices.
-    fn keyboard_with_an_empty_third_slot(request: &[u8]) -> Option<Vec<u8>> {
-        scripted_keyboard(request, SlotStatus::Reported)
-    }
-
-    /// The same keyboard without `0x1815`, so its slot pairing is unknowable.
-    fn keyboard_without_hosts_info(request: &[u8]) -> Option<Vec<u8>> {
-        scripted_keyboard(request, SlotStatus::Unimplemented)
-    }
-
-    /// The same keyboard, whose firmware errors when asked for `0x1815`.
-    fn keyboard_erroring_on_hosts_info_lookup(request: &[u8]) -> Option<Vec<u8>> {
-        scripted_keyboard(request, SlotStatus::LookupErrors)
-    }
-
-    /// The same keyboard, whose `0x1815` reads come back an error.
-    fn keyboard_erroring_on_slot_status(request: &[u8]) -> Option<Vec<u8>> {
-        scripted_keyboard(request, SlotStatus::ReadErrors)
-    }
-
-    fn scripted_keyboard(request: &[u8], slot_status: SlotStatus) -> Option<Vec<u8>> {
-        if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
-            return None;
-        }
-        let mut payload = [0u8; 16];
-        match (request[2], request[3] >> 4) {
-            // Root ping used by Device::new.
-            (0x00, 0x01) => payload[0] = 4,
-            // Root feature lookup.
-            (0x00, 0x00) => {
-                payload[0] = match u16::from_be_bytes([request[4], request[5]]) {
-                    0x1814 => CHANGE_HOST_INDEX,
-                    0x1815 => match slot_status {
-                        SlotStatus::Unimplemented => 0x00,
-                        SlotStatus::LookupErrors => return Some(feature_error(request, BUSY)),
-                        SlotStatus::Reported | SlotStatus::ReadErrors => HOSTS_INFO_INDEX,
-                    },
-                    _ => 0x00,
-                };
-            }
-            // ChangeHost getHostInfo: three RF channels, currently on host 0.
-            (CHANGE_HOST_INDEX, 0x00) => payload[..2].copy_from_slice(&[3, 0]),
-            // HostsInfo getHostInfo: echo the slot, then its pairing status.
-            (HOSTS_INFO_INDEX, 0x01) => {
-                if slot_status == SlotStatus::ReadErrors {
-                    return Some(feature_error(request, BUSY));
-                }
-                payload[0] = request[4];
-                payload[1] = u8::from(request[4] < 2);
-            }
-            _ => return None,
-        }
-
-        let mut response = vec![0u8; 7];
-        response[0] = 0x10;
-        response[1..4].copy_from_slice(&request[1..4]);
-        response[4..].copy_from_slice(&payload[..3]);
-        Some(response)
-    }
-
-    async fn scripted_channel(responder: crate::channel::scripted::Responder) -> Arc<HidppChannel> {
-        let (raw, _handle) = ScriptedRawHidChannel::with_responder(responder);
-        crate::channel::scripted::scripted_channel(raw).await
-    }
-
-    #[tokio::test]
-    async fn switching_to_an_unpaired_slot_is_refused() {
-        // ChangeHost would allow it: host 2 is within the device's channel
-        // count. But nothing is paired there, and `setCurrentHost` is
-        // fire-and-forget — the device would simply leave and not come back.
-        let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
-
-        let Err(error) = prepare_host_change_on(&channel, 1, 2).await else {
-            panic!("an unpaired slot must not be switched to");
-        };
-
-        assert!(
-            matches!(error, HostSwitchError::HostSlotEmpty { host: 2 }),
-            "got {error:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn switching_to_a_paired_slot_proceeds() {
-        let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
-
-        let change = prepare_host_change_on(&channel, 1, 1)
-            .await
-            .expect("a paired slot must be switchable");
-
-        assert!(change.required, "host 1 differs from the current host 0");
-    }
-
-    #[tokio::test]
-    async fn a_device_without_hosts_info_is_still_switched() {
-        // 0x1815 is the only source of per-slot pairing status. Without it the
-        // guard must not block, or this change would regress every device that
-        // does not implement it.
-        let channel = scripted_channel(keyboard_without_hosts_info).await;
-
-        let change = prepare_host_change_on(&channel, 1, 2)
-            .await
-            .expect("a device that cannot report slot status must still switch");
-
-        assert!(change.required);
-    }
-
-    #[tokio::test]
-    async fn a_failed_hosts_info_lookup_does_not_block_the_switch() {
-        // Firmware that answers an unknown feature id with an error rather than
-        // index 0 must read the same as not implementing 0x1815 at all: the
-        // pairing status is unknowable, which is not a reason to refuse.
-        let channel = scripted_channel(keyboard_erroring_on_hosts_info_lookup).await;
-
-        let change = prepare_host_change_on(&channel, 1, 2)
-            .await
-            .expect("an errored feature lookup must not abort the switch");
-
-        assert!(change.required);
-    }
-
-    #[tokio::test]
-    async fn an_unreadable_slot_status_does_not_block_the_switch() {
-        // The guard is advisory. A device that has 0x1815 but cannot answer for
-        // it right now has not said the slot is empty, so refusing here would
-        // turn a transient read failure into a dead host key.
-        let channel = scripted_channel(keyboard_erroring_on_slot_status).await;
-
-        let change = prepare_host_change_on(&channel, 1, 2)
-            .await
-            .expect("an errored status read must not abort the switch");
-
-        assert!(change.required);
-    }
-
-    #[tokio::test]
-    async fn a_switch_to_the_current_host_never_consults_slot_status() {
-        // Already-there is decided before the pairing check, so a device on an
-        // unpaired-looking slot is not blocked from staying put.
-        let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
-
-        let change = prepare_host_change_on(&channel, 1, 0)
-            .await
-            .expect("staying on the current host is always fine");
-
-        assert!(!change.required);
-    }
-
-    /// A reporting snapshot with unrelated bits deliberately set, so the
-    /// cleanup tests prove that only the bits they vary are restored.
-    fn noisy_reporting() -> CidReporting {
-        CidReporting {
-            cid: ControlId(0x00d3),
-            diverted: false,
-            persistently_diverted: true,
-            force_raw_xy: true,
-            raw_xy: false,
-            remap: Some(ControlId(0x1234)),
-            analytics_key_events: false,
-            raw_wheel: true,
-        }
-    }
-
-    #[test]
-    fn receiver_slots_share_one_channel() {
-        let keyboard = DeviceRoute::Bolt {
-            receiver_uid: "AABB".into(),
-            slot: 1,
-        };
-        let mouse = DeviceRoute::Bolt {
-            receiver_uid: "aabb".into(),
-            slot: 2,
-        };
-        assert!(shares_channel(&keyboard, &mouse));
-    }
-
-    #[test]
-    fn direct_devices_do_not_share_channels() {
-        let route = DeviceRoute::Direct {
-            vendor_id: 0x046d,
-            product_id: 0xb025,
-        };
-        assert!(!shares_channel(&route, &route));
-    }
-
-    #[test]
-    fn host_controls_are_recognized_by_task_when_cid_varies() {
-        let info = CtrlIdInfo {
-            cid: 0x1234,
-            task_id: 0x00af,
-            flags: 0,
-        };
-        assert_eq!(host_channel(info), Some(1));
-    }
-
-    #[test]
-    fn analytics_event_selects_the_matching_host() {
-        let controls = [ArmedControl {
-            cid: 0x00d3,
-            host: 2,
-            mode: ReportingMode::Analytics,
-            original: noisy_reporting(),
-        }];
-        let mut events = [AnalyticsKeyEvent::default(); 5];
-        events[0] = AnalyticsKeyEvent {
-            cid: ControlId(0x00d3),
-            event: 1,
-        };
-        assert_eq!(
-            event_host(&controls, ReprogControlsEvent::AnalyticsKeyEvents(events)),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn current_host_does_not_require_a_change() {
-        assert!(matches!(host_change_required(1, 3, 1), Ok(false)));
-    }
-
-    #[test]
-    fn different_valid_host_requires_a_change() {
-        assert!(matches!(host_change_required(0, 3, 2), Ok(true)));
-    }
-
-    #[test]
-    fn host_outside_device_range_is_rejected() {
-        assert!(
-            host_change_required(0, 2, 2).is_err(),
-            "host 2 is outside a device that reports 2 hosts and must be rejected"
-        );
-    }
-
-    #[test]
-    fn diverted_cleanup_restores_only_the_original_temporary_bits() {
-        let change = restoration_change(ArmedControl {
-            cid: 0x00d3,
-            host: 2,
-            mode: ReportingMode::Diverted,
-            original: CidReporting {
-                diverted: true,
-                raw_xy: true,
-                ..noisy_reporting()
+fn host_control_request(
+    controls: &[ArmedControl],
+    event: reprog_controls::ReprogControlsEvent,
+) -> Option<CapturedHostSwitch> {
+    let control = event_control(controls, &event)?;
+    let (keyboard_transition, cleanup) = match control.mode {
+        ReportingMode::Diverted => (
+            KeyboardHostTransition::CommandRequired,
+            ControlCleanup::Full,
+        ),
+        ReportingMode::Analytics => (
+            KeyboardHostTransition::AnalyticsEvent {
+                host_slot: ReportedHostSlot::Unknown,
             },
-        });
-
-        assert_eq!(change.diverted, Some(true));
-        assert_eq!(change.raw_xy, Some(true));
-        assert_eq!(change.analytics_key_events, None);
-        assert_eq!(change.persistently_diverted, None);
-        assert_eq!(change.remap, None);
-    }
-
-    #[test]
-    fn analytics_cleanup_restores_the_original_analytics_bit() {
-        let change = restoration_change(ArmedControl {
-            cid: 0x00d3,
-            host: 2,
-            mode: ReportingMode::Analytics,
-            original: CidReporting {
-                analytics_key_events: true,
-                ..noisy_reporting()
-            },
-        });
-
-        assert_eq!(change.analytics_key_events, Some(true));
-        assert_eq!(change.diverted, None);
-        assert_eq!(change.raw_xy, None);
-    }
+            ControlCleanup::Prompt,
+        ),
+    };
+    Some(CapturedHostSwitch {
+        request: HostSwitchRequest {
+            host: control.host,
+            keyboard_transition,
+        },
+        cleanup,
+    })
 }
+
+/// Decode a keyboard's `0x1814` host-change announcement.
+///
+/// Some analytics-only keyboards announce the physical Easy-Switch press on
+/// ChangeHost function 0 instead of emitting a ReprogControls analytics event.
+fn change_host_announcement(
+    message: &v20::Message,
+    device_index: u8,
+    feature_index: u8,
+    host_count: u8,
+) -> Option<u8> {
+    let header = message.header();
+    if header.device_index != device_index
+        || header.feature_index != feature_index
+        || header.function_id.to_lo() != 0
+        || header.software_id.to_lo() != 0
+    {
+        return None;
+    }
+    let target_host = message.extend_payload()[1];
+    (target_host < host_count).then_some(target_host)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-device/src/session/host_switch/slots.rs
+++ b/crates/openlogi-device/src/session/host_switch/slots.rs
@@ -1,0 +1,105 @@
+//! Best-effort pairing status for Easy-Switch host slots.
+
+use std::sync::Arc;
+
+use hidpp::{
+    device::Device,
+    feature::{
+        CreatableFeature,
+        hosts_info::{HostIndex, HostSlotStatus, HostsInfoFeature},
+    },
+};
+use tracing::debug;
+
+use super::timed_hidpp;
+
+/// Pairing status explicitly reported for one Easy-Switch host slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportedHostSlot {
+    /// The device reports that nothing is paired in this slot.
+    Empty,
+    /// The device reports that this slot is paired.
+    Paired,
+    /// The device cannot report a trustworthy pairing status for this slot.
+    Unknown,
+}
+
+/// Resolved access to a keyboard's reportable host-slot state.
+#[derive(Clone)]
+pub(super) enum ReportedHostSlotReader {
+    /// The keyboard explicitly does not expose `HostsInfo`.
+    Unsupported,
+    /// Feature discovery failed, so support could not be determined safely.
+    Unavailable,
+    /// The keyboard exposes `HostsInfo` at this runtime feature index.
+    Supported(Arc<HostsInfoFeature>),
+}
+
+impl ReportedHostSlotReader {
+    pub(super) async fn resolve(device: &mut Device) -> Self {
+        let feature = timed_hidpp(
+            "locating hosts-info feature",
+            device.root().get_feature(HostsInfoFeature::ID),
+        )
+        .await;
+        match feature {
+            Ok(Some(info)) => Self::Supported(device.add_feature::<HostsInfoFeature>(info.index)),
+            Ok(None) => Self::Unsupported,
+            Err(error) => {
+                debug!(%error, "hosts-info lookup failed; slot validation is unavailable");
+                Self::Unavailable
+            }
+        }
+    }
+
+    pub(super) fn is_supported(&self) -> bool {
+        matches!(self, Self::Supported(_))
+    }
+
+    /// Read one physical host key while the keyboard is reachable.
+    ///
+    /// `ChangeHost`'s host count includes empty RF channels, and both a
+    /// physical host key and `setCurrentHost` can therefore leave for an
+    /// unpaired slot. `HostsInfo` is the only source of per-slot pairing
+    /// status. Unsupported, timed-out, malformed, or errored reads remain
+    /// [`ReportedHostSlot::Unknown`]. A commanded transition treats that as
+    /// advisory; an announced transition requires a fresh paired result while
+    /// reachable. Physical departure cannot validate the destination slot.
+    pub(super) async fn read_one(&self, host: u8) -> ReportedHostSlot {
+        match self {
+            Self::Supported(feature) => read_host_slot(feature, host).await,
+            Self::Unsupported | Self::Unavailable => ReportedHostSlot::Unknown,
+        }
+    }
+}
+
+/// Read one slot while preparing a commanded transition.
+pub(super) async fn reported_host_slot(device: &mut Device, host: u8) -> ReportedHostSlot {
+    ReportedHostSlotReader::resolve(device)
+        .await
+        .read_one(host)
+        .await
+}
+
+async fn read_host_slot(feature: &HostsInfoFeature, host: u8) -> ReportedHostSlot {
+    match timed_hidpp(
+        "reading host slot status",
+        feature.get_host_info(HostIndex::Slot(host)),
+    )
+    .await
+    {
+        Ok(slot) if slot.host_index != HostIndex::Slot(host) => {
+            debug!(host, returned = ?slot.host_index, "host slot response identified a different slot");
+            ReportedHostSlot::Unknown
+        }
+        Ok(slot) => match slot.status {
+            HostSlotStatus::Empty => ReportedHostSlot::Empty,
+            HostSlotStatus::Paired => ReportedHostSlot::Paired,
+            _ => ReportedHostSlot::Unknown,
+        },
+        Err(error) => {
+            debug!(host, %error, "host slot status is unreadable; treating the slot as unknown");
+            ReportedHostSlot::Unknown
+        }
+    }
+}

--- a/crates/openlogi-device/src/session/host_switch/tests.rs
+++ b/crates/openlogi-device/src/session/host_switch/tests.rs
@@ -1,0 +1,176 @@
+//! Host-switch capture and transition regressions.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use hidpp::{channel::HidppChannel, device::DeviceError, nibble::U4, protocol::v20};
+
+use super::{
+    ANALYTICS_CLEANUP_TIMEOUT, ArmedControl, ControlCleanup, HostSwitchError, HostSwitchRequest,
+    KeyboardHostTransition, ReportedHostSlot, ReportingMode, change_host_announcement,
+    finish_captured_control, host_change_required, host_control_request, prepare_host_change_on,
+    resolve_change_host_capture, restoration_change, restore_host_controls_promptly,
+    run_change_host_announcement_session, shares_channel, switch_linked_hosts,
+};
+use crate::channel::scripted::{
+    ScriptedBackend, ScriptedNode, ScriptedRawHidChannel, ScriptedRawHidHandle, feature_error,
+    scripted_node_info,
+};
+use crate::reprog_controls::{
+    self, AnalyticsKeyEvent, CidReporting, ControlId, CtrlIdInfo, ReprogControlsEvent,
+    ReprogControlsV4,
+};
+use crate::{ChannelPool, DeviceRoute, backend::BackendError};
+
+mod capture;
+mod controls;
+mod slots;
+mod transition;
+
+use controls::analytics_request;
+
+/// Feature index the scripted keyboard reports for `0x1814 ChangeHost`.
+const CHANGE_HOST_INDEX: u8 = 0x04;
+/// Feature index the scripted keyboard reports for `0x1815 HostsInfo`.
+const HOSTS_INFO_INDEX: u8 = 0x05;
+
+/// `ErrorType::Busy`, the failure a scripted device answers with.
+const BUSY: u8 = 0x08;
+
+/// What the scripted keyboard's firmware does when asked about `0x1815`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SlotStatus {
+    /// Answers the query: hosts 0 and 1 paired, host 2 empty.
+    Reported,
+    /// Answers the query with all three hosts paired.
+    AllPaired,
+    /// Reports the feature as unimplemented, the usual index-0 lookup miss.
+    Unimplemented,
+    /// Errors on the lookup itself, as firmware that refuses unknown
+    /// feature ids rather than reporting index 0 does.
+    LookupErrors,
+    /// Implements the feature but errors on the status read.
+    ReadErrors,
+    /// Implements the feature but never answers the status read.
+    ReadTimesOut,
+    /// Implements the feature but returns an unknown pairing-status value.
+    Unrecognized,
+}
+
+/// A three-channel keyboard currently on host 0, paired on hosts 0 and 1
+/// but **not** on host 2 - a keyboard with three host keys and only two
+/// machines paired, which is the shape that used to strand devices.
+fn keyboard_with_an_empty_third_slot(request: &[u8]) -> Option<Vec<u8>> {
+    scripted_keyboard(request, SlotStatus::Reported)
+}
+
+/// The same keyboard with every reported host slot paired.
+fn keyboard_with_all_slots_paired(request: &[u8]) -> Option<Vec<u8>> {
+    scripted_keyboard(request, SlotStatus::AllPaired)
+}
+
+/// The same keyboard without `0x1815`, so its slot pairing is unknowable.
+fn keyboard_without_hosts_info(request: &[u8]) -> Option<Vec<u8>> {
+    scripted_keyboard(request, SlotStatus::Unimplemented)
+}
+
+/// The same keyboard, whose firmware errors when asked for `0x1815`.
+fn keyboard_erroring_on_hosts_info_lookup(request: &[u8]) -> Option<Vec<u8>> {
+    scripted_keyboard(request, SlotStatus::LookupErrors)
+}
+
+/// The same keyboard, whose `0x1815` reads come back an error.
+fn keyboard_erroring_on_slot_status(request: &[u8]) -> Option<Vec<u8>> {
+    scripted_keyboard(request, SlotStatus::ReadErrors)
+}
+
+/// The same keyboard, whose `0x1815` status reads never answer.
+fn keyboard_timing_out_on_slot_status(request: &[u8]) -> Option<Vec<u8>> {
+    scripted_keyboard(request, SlotStatus::ReadTimesOut)
+}
+
+/// The same keyboard, whose `0x1815` status value is not recognized.
+fn keyboard_with_unrecognized_slot_status(request: &[u8]) -> Option<Vec<u8>> {
+    scripted_keyboard(request, SlotStatus::Unrecognized)
+}
+
+fn scripted_keyboard(request: &[u8], slot_status: SlotStatus) -> Option<Vec<u8>> {
+    if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
+        return None;
+    }
+    let mut payload = [0u8; 16];
+    match (request[2], request[3] >> 4) {
+        // Root ping used by Device::new.
+        (0x00, 0x01) => payload[0] = 4,
+        // Root feature lookup.
+        (0x00, 0x00) => {
+            payload[0] = match u16::from_be_bytes([request[4], request[5]]) {
+                0x1814 => CHANGE_HOST_INDEX,
+                0x1815 => match slot_status {
+                    SlotStatus::Unimplemented => 0x00,
+                    SlotStatus::LookupErrors => return Some(feature_error(request, BUSY)),
+                    SlotStatus::Reported
+                    | SlotStatus::AllPaired
+                    | SlotStatus::ReadErrors
+                    | SlotStatus::ReadTimesOut
+                    | SlotStatus::Unrecognized => HOSTS_INFO_INDEX,
+                },
+                _ => 0x00,
+            };
+        }
+        // ChangeHost getHostInfo: three RF channels, currently on host 0.
+        (CHANGE_HOST_INDEX, 0x00) => payload[..2].copy_from_slice(&[3, 0]),
+        // HostsInfo getHostInfo: echo the slot, then its pairing status.
+        (HOSTS_INFO_INDEX, 0x01) => {
+            if slot_status == SlotStatus::ReadTimesOut {
+                return None;
+            }
+            if slot_status == SlotStatus::ReadErrors {
+                return Some(feature_error(request, BUSY));
+            }
+            payload[0] = request[4];
+            payload[1] = if slot_status == SlotStatus::Unrecognized {
+                0xff
+            } else {
+                u8::from(slot_status == SlotStatus::AllPaired || request[4] < 2)
+            };
+        }
+        _ => return None,
+    }
+
+    let mut response = vec![0u8; 7];
+    response[0] = 0x10;
+    response[1..4].copy_from_slice(&request[1..4]);
+    response[4..].copy_from_slice(&payload[..3]);
+    Some(response)
+}
+
+async fn scripted_channel(responder: crate::channel::scripted::Responder) -> Arc<HidppChannel> {
+    let (raw, _handle) = ScriptedRawHidChannel::with_responder(responder);
+    crate::channel::scripted::scripted_channel(raw).await
+}
+
+async fn scripted_live_node(
+    id: &str,
+    product_id: u16,
+    responder: crate::channel::scripted::Responder,
+) -> (crate::backend::NodeInfo, ScriptedNode, ScriptedRawHidHandle) {
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(responder);
+    let channel = crate::channel::scripted::scripted_channel(raw).await;
+    let mut node = scripted_node_info(id);
+    node.product_id = product_id;
+    (node, ScriptedNode::Live(channel), handle)
+}
+
+fn sent_host_change(handle: &ScriptedRawHidHandle, host: u8) -> bool {
+    handle.written_reports().iter().any(|report| {
+        report.get(2) == Some(&CHANGE_HOST_INDEX)
+            && report.get(3).is_some_and(|function| function >> 4 == 1)
+            && report.get(4) == Some(&host)
+    })
+}

--- a/crates/openlogi-device/src/session/host_switch/tests/capture.rs
+++ b/crates/openlogi-device/src/session/host_switch/tests/capture.rs
@@ -1,0 +1,283 @@
+use super::*;
+
+#[tokio::test]
+async fn announcement_capture_resolves_the_current_runtime_feature_index() {
+    let channel = scripted_channel(keyboard_without_hosts_info).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+
+    assert_eq!(capture.feature_index, CHANGE_HOST_INDEX);
+    let request = capture
+        .departure_request(2)
+        .await
+        .expect("missing HostsInfo must remain compatible");
+    assert_eq!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Unknown,
+        }
+    );
+}
+
+#[tokio::test]
+async fn announcement_capture_validates_pairing_status_at_the_event_boundary() {
+    let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+
+    assert_eq!(
+        capture
+            .departure_request(1)
+            .await
+            .expect("paired host should be reportable")
+            .keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Paired,
+        }
+    );
+    assert_eq!(
+        capture
+            .departure_request(2)
+            .await
+            .expect("empty host should be reportable")
+            .keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Empty,
+        }
+    );
+}
+
+#[tokio::test]
+async fn announcement_session_reads_pairing_changes_at_the_event_boundary() {
+    let all_paired = Arc::new(AtomicBool::new(false));
+    let responder_state = Arc::clone(&all_paired);
+    let (raw, handle) = ScriptedRawHidChannel::with_dynamic_responder(move |request| {
+        let status = if responder_state.load(Ordering::Relaxed) {
+            SlotStatus::AllPaired
+        } else {
+            SlotStatus::Reported
+        };
+        scripted_keyboard(request, status)
+    });
+    let channel = crate::channel::scripted::scripted_channel(raw).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+    assert_eq!(
+        capture.slot_reader.read_one(2).await,
+        ReportedHostSlot::Empty
+    );
+
+    let (_stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+    let session = tokio::spawn(run_change_host_announcement_session(
+        DeviceRoute::Direct {
+            vendor_id: crate::LOGITECH_VENDOR_ID,
+            product_id: 0xb369,
+        },
+        1,
+        capture,
+        stop_rx,
+        Arc::clone(&channel),
+        crate::device_io_channel().1,
+    ));
+    tokio::task::yield_now().await;
+    all_paired.store(true, Ordering::Relaxed);
+    let mut announcement = vec![0_u8; 20];
+    announcement[0] = 0x11;
+    announcement[1] = 1;
+    announcement[2] = CHANGE_HOST_INDEX;
+    announcement[5] = 2;
+    handle.emit_report(announcement);
+
+    let request = tokio::time::timeout(Duration::from_secs(1), session)
+        .await
+        .expect("announcement session should finish")
+        .expect("announcement session should not panic")
+        .expect("announcement session should remain valid")
+        .expect("announcement should produce a host-switch request");
+    assert_eq!(request.host, 2);
+    assert_eq!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Paired,
+        }
+    );
+}
+
+#[tokio::test]
+async fn announcement_slot_read_error_is_reported_as_unknown() {
+    let reads_fail = Arc::new(AtomicBool::new(false));
+    let responder_state = Arc::clone(&reads_fail);
+    let (raw, _handle) = ScriptedRawHidChannel::with_dynamic_responder(move |request| {
+        let status = if responder_state.load(Ordering::Relaxed) {
+            SlotStatus::ReadErrors
+        } else {
+            SlotStatus::Reported
+        };
+        scripted_keyboard(request, status)
+    });
+    let channel = crate::channel::scripted::scripted_channel(raw).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+    assert_eq!(
+        capture.slot_reader.read_one(2).await,
+        ReportedHostSlot::Empty
+    );
+
+    reads_fail.store(true, Ordering::Relaxed);
+    let request = capture
+        .departure_request(2)
+        .await
+        .expect("ambiguous status should remain unverified");
+    assert_eq!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Unknown,
+        }
+    );
+}
+
+#[tokio::test]
+async fn announcement_lookup_error_is_reported_as_unknown() {
+    let channel = scripted_channel(keyboard_erroring_on_hosts_info_lookup).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+
+    let request = capture
+        .departure_request(2)
+        .await
+        .expect("indeterminate support should remain unverified");
+
+    assert_eq!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Unknown,
+        }
+    );
+}
+
+#[tokio::test]
+async fn announcement_validation_timeout_is_bounded_and_preserves_the_departure() {
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(keyboard_timing_out_on_slot_status);
+    let channel = crate::channel::scripted::scripted_channel(raw).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+    let (_stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+    let session = tokio::spawn(run_change_host_announcement_session(
+        DeviceRoute::Direct {
+            vendor_id: crate::LOGITECH_VENDOR_ID,
+            product_id: 0xb369,
+        },
+        1,
+        capture,
+        stop_rx,
+        Arc::clone(&channel),
+        crate::device_io_channel().1,
+    ));
+    tokio::task::yield_now().await;
+    let mut announcement = vec![0_u8; 20];
+    announcement[0] = 0x11;
+    announcement[1] = 1;
+    announcement[2] = CHANGE_HOST_INDEX;
+    announcement[5] = 2;
+    handle.emit_report(announcement);
+
+    let request = tokio::time::timeout(Duration::from_millis(500), session)
+        .await
+        .expect("announcement validation exceeded its bounded latency")
+        .expect("announcement session should not panic")
+        .expect("announcement session should remain valid")
+        .expect("the departure must survive when the keyboard leaves before replying");
+
+    assert_eq!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Unknown,
+        }
+    );
+}
+
+#[tokio::test]
+async fn announcement_validation_observes_a_pairing_removed_after_capture_started() {
+    let all_paired = Arc::new(AtomicBool::new(true));
+    let responder_state = Arc::clone(&all_paired);
+    let (raw, _handle) = ScriptedRawHidChannel::with_dynamic_responder(move |request| {
+        let status = if responder_state.load(Ordering::Relaxed) {
+            SlotStatus::AllPaired
+        } else {
+            SlotStatus::Reported
+        };
+        scripted_keyboard(request, status)
+    });
+    let channel = crate::channel::scripted::scripted_channel(raw).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+    assert_eq!(
+        capture.slot_reader.read_one(2).await,
+        ReportedHostSlot::Paired
+    );
+
+    all_paired.store(false, Ordering::Relaxed);
+    let request = capture
+        .departure_request(2)
+        .await
+        .expect("empty status should be reported at the event boundary");
+
+    assert_eq!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Empty,
+        }
+    );
+}
+
+#[test]
+fn change_host_announcement_selects_the_reported_destination() {
+    let mut payload = [0; 16];
+    payload[0] = 0;
+    payload[1] = 1;
+    let announcement = v20::Message::Long(
+        v20::MessageHeader {
+            device_index: 1,
+            feature_index: 9,
+            function_id: U4::from_lo(0),
+            software_id: U4::from_lo(0),
+        },
+        payload,
+    );
+
+    assert_eq!(change_host_announcement(&announcement, 1, 9, 3), Some(1));
+}
+
+#[test]
+fn change_host_announcement_rejects_foreign_or_malformed_messages() {
+    let announcement = |device_index, feature_index, function_id, software_id, target_host| {
+        let mut payload = [0; 16];
+        payload[1] = target_host;
+        v20::Message::Long(
+            v20::MessageHeader {
+                device_index,
+                feature_index,
+                function_id: U4::from_lo(function_id),
+                software_id: U4::from_lo(software_id),
+            },
+            payload,
+        )
+    };
+
+    for message in [
+        announcement(2, 9, 0, 0, 1),
+        announcement(1, 8, 0, 0, 1),
+        announcement(1, 9, 1, 0, 1),
+        announcement(1, 9, 0, 1, 1),
+        announcement(1, 9, 0, 0, 3),
+    ] {
+        assert_eq!(change_host_announcement(&message, 1, 9, 3), None);
+    }
+}

--- a/crates/openlogi-device/src/session/host_switch/tests/controls.rs
+++ b/crates/openlogi-device/src/session/host_switch/tests/controls.rs
@@ -1,0 +1,246 @@
+use super::*;
+
+/// A reporting snapshot with unrelated bits deliberately set, so the
+/// cleanup tests prove that only the bits they vary are restored.
+fn noisy_reporting() -> CidReporting {
+    CidReporting {
+        cid: ControlId(0x00d3),
+        diverted: false,
+        persistently_diverted: true,
+        force_raw_xy: true,
+        raw_xy: false,
+        remap: Some(ControlId(0x1234)),
+        analytics_key_events: false,
+        raw_wheel: true,
+    }
+}
+
+pub(super) fn analytics_request(host: u8) -> HostSwitchRequest {
+    let cid = 0x00d1 + u16::from(host);
+    let controls = [ArmedControl {
+        cid,
+        host,
+        mode: ReportingMode::Analytics,
+        original: noisy_reporting(),
+    }];
+    let mut events = [AnalyticsKeyEvent::default(); 5];
+    events[0] = AnalyticsKeyEvent {
+        cid: ControlId(cid),
+        event: 1,
+    };
+    host_control_request(&controls, ReprogControlsEvent::AnalyticsKeyEvents(events))
+        .expect("analytics host press")
+        .request
+}
+
+async fn scripted_reprog_controls(
+    responder: crate::channel::scripted::Responder,
+) -> (ReprogControlsV4, ScriptedRawHidHandle) {
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(responder);
+    let channel = crate::channel::scripted::scripted_channel(raw).await;
+    (ReprogControlsV4::new(channel, 1, 0x09), handle)
+}
+
+fn echo_reprog_reporting_write(request: &[u8]) -> Option<Vec<u8>> {
+    (request.len() >= 20 && request[2] == 0x09 && request[3] >> 4 == 3).then(|| request.to_vec())
+}
+
+fn ignore_reprog_reporting_write(_request: &[u8]) -> Option<Vec<u8>> {
+    None
+}
+
+#[test]
+fn receiver_slots_share_one_channel() {
+    let keyboard = DeviceRoute::Bolt {
+        receiver_uid: "AABB".into(),
+        slot: 1,
+    };
+    let mouse = DeviceRoute::Bolt {
+        receiver_uid: "aabb".into(),
+        slot: 2,
+    };
+    assert!(shares_channel(&keyboard, &mouse));
+}
+
+#[test]
+fn direct_devices_do_not_share_channels() {
+    let route = DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xb025,
+    };
+    assert!(!shares_channel(&route, &route));
+}
+
+#[test]
+fn host_controls_are_recognized_by_task_when_cid_varies() {
+    let info = CtrlIdInfo {
+        cid: 0x1234,
+        task_id: 0x00af,
+        flags: 0,
+    };
+    assert_eq!(reprog_controls::host_switch_channel(info), Some(1));
+}
+
+#[test]
+fn analytics_event_marks_a_native_keyboard_transition() {
+    let controls = [ArmedControl {
+        cid: 0x00d3,
+        host: 2,
+        mode: ReportingMode::Analytics,
+        original: noisy_reporting(),
+    }];
+    let mut events = [AnalyticsKeyEvent::default(); 5];
+    events[0] = AnalyticsKeyEvent {
+        cid: ControlId(0x00d3),
+        event: 1,
+    };
+    let captured = host_control_request(&controls, ReprogControlsEvent::AnalyticsKeyEvents(events))
+        .expect("analytics host press");
+
+    assert_eq!(captured.request.host, 2);
+    assert_eq!(
+        captured.request.keyboard_transition,
+        KeyboardHostTransition::AnalyticsEvent {
+            host_slot: ReportedHostSlot::Unknown,
+        },
+        "an undiverted analytics control may begin its native transition immediately"
+    );
+    assert_eq!(captured.cleanup, ControlCleanup::Prompt);
+}
+
+#[tokio::test]
+async fn analytics_event_samples_pairing_at_the_event_boundary() {
+    let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+    let capture = resolve_change_host_capture(&channel, 1)
+        .await
+        .expect("ChangeHost feature");
+    let (controls, _handle) = scripted_reprog_controls(echo_reprog_reporting_write).await;
+    let armed = ArmedControl {
+        cid: 0x00d3,
+        host: 2,
+        mode: ReportingMode::Analytics,
+        original: noisy_reporting(),
+    };
+    let mut events = [AnalyticsKeyEvent::default(); 5];
+    events[0] = AnalyticsKeyEvent {
+        cid: ControlId(armed.cid),
+        event: 1,
+    };
+    let captured = host_control_request(&[armed], ReprogControlsEvent::AnalyticsKeyEvents(events))
+        .expect("analytics host press");
+
+    let request = finish_captured_control(captured, &controls, vec![armed], Some(&capture)).await;
+
+    assert_eq!(
+        request.keyboard_transition,
+        KeyboardHostTransition::AnalyticsEvent {
+            host_slot: ReportedHostSlot::Empty,
+        }
+    );
+}
+
+#[test]
+fn diverted_event_requires_a_commanded_transition() {
+    let controls = [ArmedControl {
+        cid: 0x00d3,
+        host: 2,
+        mode: ReportingMode::Diverted,
+        original: noisy_reporting(),
+    }];
+    let mut cids = [ControlId::default(); 4];
+    cids[0] = ControlId(0x00d3);
+    let captured = host_control_request(&controls, ReprogControlsEvent::DivertedButtons(cids))
+        .expect("diverted host press");
+
+    assert_eq!(captured.request.host, 2);
+    assert_eq!(
+        captured.request.keyboard_transition,
+        KeyboardHostTransition::CommandRequired,
+    );
+    assert_eq!(captured.cleanup, ControlCleanup::Full);
+}
+
+#[tokio::test]
+async fn prompt_analytics_cleanup_restores_an_answering_keyboard() {
+    let (controls, handle) = scripted_reprog_controls(echo_reprog_reporting_write).await;
+    let armed = ArmedControl {
+        cid: 0x00d3,
+        host: 2,
+        mode: ReportingMode::Analytics,
+        original: noisy_reporting(),
+    };
+
+    restore_host_controls_promptly(&controls, vec![armed]).await;
+
+    let reports = handle.written_reports();
+    let restore = reports
+        .iter()
+        .find(|report| report.len() >= 20 && report[2] == 0x09 && report[3] >> 4 == 3)
+        .expect("analytics cleanup must write the original reporting state");
+    assert_eq!(&restore[4..6], &armed.cid.to_be_bytes());
+    assert_eq!(
+        restore[9] & 0b11,
+        0b10,
+        "analytics reporting must be explicitly restored to its original false value"
+    );
+}
+
+#[tokio::test]
+async fn prompt_analytics_cleanup_does_not_wait_for_a_departing_keyboard() {
+    let (controls, handle) = scripted_reprog_controls(ignore_reprog_reporting_write).await;
+    let armed = ArmedControl {
+        cid: 0x00d3,
+        host: 2,
+        mode: ReportingMode::Analytics,
+        original: noisy_reporting(),
+    };
+
+    tokio::time::timeout(
+        ANALYTICS_CLEANUP_TIMEOUT + Duration::from_millis(250),
+        restore_host_controls_promptly(&controls, vec![armed]),
+    )
+    .await
+    .expect("prompt cleanup exceeded its bounded latency");
+    assert_eq!(
+        handle.written_reports().len(),
+        1,
+        "prompt cleanup must not retry a keyboard that is already departing"
+    );
+}
+
+#[test]
+fn diverted_cleanup_restores_only_the_original_temporary_bits() {
+    let change = restoration_change(ArmedControl {
+        cid: 0x00d3,
+        host: 2,
+        mode: ReportingMode::Diverted,
+        original: CidReporting {
+            diverted: true,
+            raw_xy: true,
+            ..noisy_reporting()
+        },
+    });
+
+    assert_eq!(change.diverted, Some(true));
+    assert_eq!(change.raw_xy, Some(true));
+    assert_eq!(change.analytics_key_events, None);
+    assert_eq!(change.persistently_diverted, None);
+    assert_eq!(change.remap, None);
+}
+
+#[test]
+fn analytics_cleanup_restores_the_original_analytics_bit() {
+    let change = restoration_change(ArmedControl {
+        cid: 0x00d3,
+        host: 2,
+        mode: ReportingMode::Analytics,
+        original: CidReporting {
+            analytics_key_events: true,
+            ..noisy_reporting()
+        },
+    });
+
+    assert_eq!(change.analytics_key_events, Some(true));
+    assert_eq!(change.diverted, None);
+    assert_eq!(change.raw_xy, None);
+}

--- a/crates/openlogi-device/src/session/host_switch/tests/slots.rs
+++ b/crates/openlogi-device/src/session/host_switch/tests/slots.rs
@@ -1,0 +1,128 @@
+use super::*;
+
+#[tokio::test]
+async fn switching_to_an_unpaired_slot_is_refused() {
+    // ChangeHost would allow it: host 2 is within the device's channel
+    // count. But nothing is paired there, and `setCurrentHost` is
+    // fire-and-forget - the device would simply leave and not come back.
+    let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+
+    let Err(error) = prepare_host_change_on(&channel, 1, 2).await else {
+        panic!("an unpaired slot must not be switched to");
+    };
+
+    assert!(
+        matches!(error, HostSwitchError::HostSlotEmpty { host: 2 }),
+        "got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn switching_to_a_paired_slot_proceeds() {
+    let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+
+    let change = prepare_host_change_on(&channel, 1, 1)
+        .await
+        .expect("a paired slot must be switchable");
+
+    assert!(change.required, "host 1 differs from the current host 0");
+}
+
+#[tokio::test]
+async fn a_device_without_hosts_info_is_still_switched() {
+    // 0x1815 is the only source of per-slot pairing status. Without it the
+    // guard must not block, or this change would regress every device that
+    // does not implement it.
+    let channel = scripted_channel(keyboard_without_hosts_info).await;
+
+    let change = prepare_host_change_on(&channel, 1, 2)
+        .await
+        .expect("a device that cannot report slot status must still switch");
+
+    assert!(change.required);
+}
+
+#[tokio::test]
+async fn a_failed_hosts_info_lookup_does_not_block_the_switch() {
+    // Firmware that answers an unknown feature id with an error rather than
+    // index 0 must read the same as not implementing 0x1815 at all: the
+    // pairing status is unknowable, which is not a reason to refuse.
+    let channel = scripted_channel(keyboard_erroring_on_hosts_info_lookup).await;
+
+    let change = prepare_host_change_on(&channel, 1, 2)
+        .await
+        .expect("an errored feature lookup must not abort the switch");
+
+    assert!(change.required);
+}
+
+#[tokio::test]
+async fn an_unreadable_slot_status_does_not_block_the_switch() {
+    // The guard is advisory. A device that has 0x1815 but cannot answer for
+    // it right now has not said the slot is empty, so refusing here would
+    // turn a transient read failure into a dead host key.
+    let channel = scripted_channel(keyboard_erroring_on_slot_status).await;
+
+    let change = prepare_host_change_on(&channel, 1, 2)
+        .await
+        .expect("an errored status read must not abort the switch");
+
+    assert!(change.required);
+}
+
+#[tokio::test]
+async fn a_switch_to_the_current_host_never_consults_slot_status() {
+    // Already-there is decided before the pairing check, so a device on an
+    // unpaired-looking slot is not blocked from staying put.
+    let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+
+    let change = prepare_host_change_on(&channel, 1, 0)
+        .await
+        .expect("staying on the current host is always fine");
+
+    assert!(!change.required);
+}
+
+#[test]
+fn current_host_does_not_require_a_change() {
+    assert!(matches!(host_change_required(1, 3, 1), Ok(false)));
+}
+
+#[test]
+fn different_valid_host_requires_a_change() {
+    assert!(matches!(host_change_required(0, 3, 2), Ok(true)));
+}
+
+#[test]
+fn host_outside_device_range_is_rejected() {
+    assert!(
+        host_change_required(0, 2, 2).is_err(),
+        "host 2 is outside a device that reports 2 hosts and must be rejected"
+    );
+}
+
+#[test]
+fn only_departure_errors_mark_a_device_unreachable() {
+    assert!(HostSwitchError::KeyboardNotFound.is_device_unreachable());
+    assert!(HostSwitchError::Hid(BackendError::Disconnected).is_device_unreachable());
+    assert!(HostSwitchError::Device(DeviceError::DeviceNotFound).is_device_unreachable());
+    assert!(
+        !HostSwitchError::Hidpp("DeviceNotFound".into()).is_device_unreachable(),
+        "formatted debug text must not classify a departure"
+    );
+
+    assert!(
+        !HostSwitchError::HostSlotEmpty { host: 2 }.is_device_unreachable(),
+        "an unpaired slot must never be classified as a departure"
+    );
+    assert!(
+        !HostSwitchError::TimedOut {
+            operation: "probing"
+        }
+        .is_device_unreachable()
+    );
+    assert!(
+        !HostSwitchError::Hid(BackendError::Backend("permission denied".into()))
+            .is_device_unreachable()
+    );
+}

--- a/crates/openlogi-device/src/session/host_switch/tests/transition.rs
+++ b/crates/openlogi-device/src/session/host_switch/tests/transition.rs
@@ -1,0 +1,526 @@
+use super::*;
+
+#[tokio::test]
+async fn a_paired_event_sample_does_not_authorize_an_unreachable_destination() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let mut keyboard_node = scripted_node_info("departed-keyboard");
+    keyboard_node.product_id = KEYBOARD_PID;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, ScriptedNode::OpenFails),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    let error = switch_linked_hosts(
+        &keyboard,
+        std::slice::from_ref(&target),
+        1,
+        KeyboardHostTransition::AnalyticsEvent {
+            host_slot: ReportedHostSlot::Paired,
+        },
+        &pool,
+    )
+    .await
+    .expect_err("an event-time pairing sample must not prove a later departure");
+    assert!(matches!(
+        error,
+        HostSwitchError::HostSlotUnverified { host: 1 }
+    ));
+    assert!(
+        !sent_host_change(&target_handle, 1),
+        "physical absence must not substitute for destination validation"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_departure_announcement_moves_the_target_without_reopening_the_keyboard() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let mut keyboard_node = scripted_node_info("departed-keyboard");
+    keyboard_node.product_id = KEYBOARD_PID;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, ScriptedNode::OpenFails),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    assert!(
+        switch_linked_hosts(
+            &keyboard,
+            &[target],
+            1,
+            KeyboardHostTransition::AlreadyDeparting {
+                host_slot: ReportedHostSlot::Unknown,
+            },
+            &pool,
+        )
+        .await
+        .expect("the firmware departure announcement must authorize target-only forwarding")
+    );
+    assert!(
+        sent_host_change(&target_handle, 1),
+        "the target was delayed behind an impossible keyboard reopen"
+    );
+}
+
+#[tokio::test]
+async fn an_unreachable_commanded_keyboard_never_moves_a_target() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let mut keyboard_node = scripted_node_info("departed-keyboard");
+    keyboard_node.product_id = KEYBOARD_PID;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, ScriptedNode::OpenFails),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    switch_linked_hosts(
+        &keyboard,
+        &[target],
+        1,
+        KeyboardHostTransition::CommandRequired,
+        &pool,
+    )
+    .await
+    .expect_err("a commanded transition must fail closed when its keyboard is unreachable");
+    assert!(
+        !sent_host_change(&target_handle, 1),
+        "the target moved without validating the commanded keyboard transition"
+    );
+}
+
+#[tokio::test]
+async fn an_unverified_analytics_destination_never_moves_a_target() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let mut keyboard_node = scripted_node_info("departed-keyboard");
+    keyboard_node.product_id = KEYBOARD_PID;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, ScriptedNode::OpenFails),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    let error = switch_linked_hosts(
+        &keyboard,
+        &[target],
+        1,
+        KeyboardHostTransition::AnalyticsEvent {
+            host_slot: ReportedHostSlot::Unknown,
+        },
+        &pool,
+    )
+    .await
+    .expect_err("unknown analytics destinations must fail closed");
+    assert!(matches!(
+        error,
+        HostSwitchError::HostSlotUnverified { host: 1 }
+    ));
+    assert!(
+        !sent_host_change(&target_handle, 1),
+        "the target moved without fresh destination validation"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_keyboard_slot_never_moves_a_target() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let (keyboard_node, keyboard, _keyboard_handle) = scripted_live_node(
+        "keyboard-with-empty-slot",
+        KEYBOARD_PID,
+        keyboard_with_an_empty_third_slot,
+    )
+    .await;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, keyboard),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    let analytics_request = analytics_request(2);
+    let error = switch_linked_hosts(
+        &keyboard,
+        &[target],
+        2,
+        analytics_request.keyboard_transition,
+        &pool,
+    )
+    .await
+    .expect_err("the keyboard has no pairing in host slot 2");
+    assert!(matches!(error, HostSwitchError::HostSlotEmpty { host: 2 }));
+    assert!(
+        !sent_host_change(&target_handle, 2),
+        "the target moved even though the keyboard rejected the host slot"
+    );
+}
+
+#[tokio::test]
+async fn a_paired_departure_announcement_does_not_use_later_slot_status() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let (keyboard_node, keyboard, _keyboard_handle) = scripted_live_node(
+        "keyboard-with-changed-slot",
+        KEYBOARD_PID,
+        keyboard_with_an_empty_third_slot,
+    )
+    .await;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, keyboard),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    assert!(
+        switch_linked_hosts(
+            &keyboard,
+            &[target],
+            2,
+            KeyboardHostTransition::AlreadyDeparting {
+                host_slot: ReportedHostSlot::Paired,
+            },
+            &pool,
+        )
+        .await
+        .expect("the firmware departure announcement is authoritative")
+    );
+    assert!(
+        sent_host_change(&target_handle, 2),
+        "the target was blocked by a later, stale slot sample"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_departure_announcement_does_not_command_the_keyboard_again() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let (keyboard_node, keyboard, keyboard_handle) = scripted_live_node(
+        "keyboard-with-fresh-paired-slot",
+        KEYBOARD_PID,
+        keyboard_with_all_slots_paired,
+    )
+    .await;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, keyboard),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    assert!(
+        switch_linked_hosts(
+            &keyboard,
+            &[target],
+            2,
+            KeyboardHostTransition::AlreadyDeparting {
+                host_slot: ReportedHostSlot::Unknown,
+            },
+            &pool,
+        )
+        .await
+        .expect("the firmware departure announcement should move the target directly")
+    );
+    assert!(sent_host_change(&target_handle, 2));
+    assert!(
+        !sent_host_change(&keyboard_handle, 2),
+        "an already-departing keyboard was commanded a second time"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_departure_announcement_is_not_overridden_by_later_pairing() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let (keyboard_node, keyboard, keyboard_handle) = scripted_live_node(
+        "keyboard-with-newly-paired-slot",
+        KEYBOARD_PID,
+        keyboard_with_all_slots_paired,
+    )
+    .await;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, keyboard),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    let error = switch_linked_hosts(
+        &keyboard,
+        &[target],
+        2,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Empty,
+        },
+        &pool,
+    )
+    .await
+    .expect_err("an explicitly empty announced slot must fail closed");
+    assert!(matches!(error, HostSwitchError::HostSlotEmpty { host: 2 }));
+    assert!(!sent_host_change(&target_handle, 2));
+    assert!(!sent_host_change(&keyboard_handle, 2));
+}
+
+#[tokio::test]
+async fn an_unknown_departure_announcement_does_not_use_later_slot_status() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let (keyboard_node, keyboard, keyboard_handle) = scripted_live_node(
+        "keyboard-with-fresh-empty-slot",
+        KEYBOARD_PID,
+        keyboard_with_an_empty_third_slot,
+    )
+    .await;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, keyboard),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    assert!(
+        switch_linked_hosts(
+            &keyboard,
+            &[target],
+            2,
+            KeyboardHostTransition::AlreadyDeparting {
+                host_slot: ReportedHostSlot::Unknown,
+            },
+            &pool,
+        )
+        .await
+        .expect("the firmware departure announcement should move the target directly")
+    );
+    assert!(sent_host_change(&target_handle, 2));
+    assert!(
+        !sent_host_change(&keyboard_handle, 2),
+        "an already-departing keyboard was reopened for a stale slot sample"
+    );
+}
+
+#[tokio::test]
+async fn an_event_transition_requires_a_fresh_paired_slot() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let responders: [(&str, crate::channel::scripted::Responder); 5] = [
+        ("missing-hosts-info", keyboard_without_hosts_info),
+        (
+            "hosts-info-lookup-error",
+            keyboard_erroring_on_hosts_info_lookup,
+        ),
+        ("slot-status-error", keyboard_erroring_on_slot_status),
+        ("slot-status-timeout", keyboard_timing_out_on_slot_status),
+        (
+            "unrecognized-slot-status",
+            keyboard_with_unrecognized_slot_status,
+        ),
+    ];
+    let transition = KeyboardHostTransition::AnalyticsEvent {
+        host_slot: ReportedHostSlot::Paired,
+    };
+
+    for (case, responder) in responders {
+        let (keyboard_node, keyboard, keyboard_handle) =
+            scripted_live_node(case, KEYBOARD_PID, responder).await;
+        let (target_node, target, target_handle) =
+            scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+        let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+            (keyboard_node, keyboard),
+            (target_node, target),
+        ]));
+        let keyboard = DeviceRoute::Direct {
+            vendor_id: crate::LOGITECH_VENDOR_ID,
+            product_id: KEYBOARD_PID,
+        };
+        let target = DeviceRoute::Direct {
+            vendor_id: crate::LOGITECH_VENDOR_ID,
+            product_id: TARGET_PID,
+        };
+
+        let error = switch_linked_hosts(&keyboard, &[target], 2, transition, &pool)
+            .await
+            .expect_err("inconclusive fresh status must fail closed");
+        assert!(
+            matches!(error, HostSwitchError::HostSlotUnverified { host: 2 }),
+            "{case} returned {error:?}"
+        );
+        assert!(
+            !sent_host_change(&target_handle, 2),
+            "{case} moved the target"
+        );
+        assert!(
+            !sent_host_change(&keyboard_handle, 2),
+            "{case} moved the keyboard"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_commanded_transition_keeps_unknown_slot_status_compatible() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let (keyboard_node, keyboard, keyboard_handle) = scripted_live_node(
+        "keyboard-without-hosts-info",
+        KEYBOARD_PID,
+        keyboard_without_hosts_info,
+    )
+    .await;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, keyboard),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    assert!(
+        switch_linked_hosts(
+            &keyboard,
+            &[target],
+            2,
+            KeyboardHostTransition::CommandRequired,
+            &pool,
+        )
+        .await
+        .expect("manual switching must remain compatible without HostsInfo")
+    );
+    assert!(sent_host_change(&target_handle, 2));
+    assert!(sent_host_change(&keyboard_handle, 2));
+}
+
+#[tokio::test]
+async fn a_departure_announcement_for_an_empty_slot_never_moves_a_target() {
+    const KEYBOARD_PID: u16 = 0xb369;
+    const TARGET_PID: u16 = 0xb042;
+
+    let mut keyboard_node = scripted_node_info("departing-keyboard");
+    keyboard_node.product_id = KEYBOARD_PID;
+    let (target_node, target, target_handle) =
+        scripted_live_node("reachable-target", TARGET_PID, keyboard_without_hosts_info).await;
+    let pool = ChannelPool::with_backend(ScriptedBackend::new(vec![
+        (keyboard_node, ScriptedNode::OpenFails),
+        (target_node, target),
+    ]));
+    let keyboard = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: KEYBOARD_PID,
+    };
+    let target = DeviceRoute::Direct {
+        vendor_id: crate::LOGITECH_VENDOR_ID,
+        product_id: TARGET_PID,
+    };
+
+    let error = switch_linked_hosts(
+        &keyboard,
+        &[target],
+        2,
+        KeyboardHostTransition::AlreadyDeparting {
+            host_slot: ReportedHostSlot::Empty,
+        },
+        &pool,
+    )
+    .await
+    .expect_err("an announcement does not prove that its destination is paired");
+    assert!(matches!(error, HostSwitchError::HostSlotEmpty { host: 2 }));
+    assert!(
+        !sent_host_change(&target_handle, 2),
+        "the target moved even though the keyboard reported an empty slot"
+    );
+}

--- a/crates/openlogi-device/src/session/host_switch/transition.rs
+++ b/crates/openlogi-device/src/session/host_switch/transition.rs
@@ -1,0 +1,274 @@
+//! Validation and application of linked host transitions.
+
+use std::sync::Arc;
+
+use hidpp::{
+    channel::HidppChannel,
+    device::Device,
+    feature::{CreatableFeature, change_host::ChangeHostFeature},
+};
+use tracing::debug;
+
+use crate::{ChannelPool, DeviceRoute};
+
+use super::slots::{ReportedHostSlot, reported_host_slot};
+use super::{HostSwitchError, KeyboardHostTransition, open_channel, timed_device, timed_hidpp};
+/// Move reachable targets to `host`, then move the keyboard last.
+///
+/// Returns whether the keyboard actually changed hosts, or firmware announced
+/// that it had already begun departing. A ChangeHost announcement carries the
+/// destination selected by the keyboard itself, so followers use their own
+/// channels immediately instead of waiting for an impossible keyboard reopen.
+/// Analytics-only events still require destination revalidation.
+pub async fn switch_linked_hosts(
+    keyboard: &DeviceRoute,
+    targets: &[DeviceRoute],
+    host: u8,
+    keyboard_transition: KeyboardHostTransition,
+    channel_pool: &ChannelPool,
+) -> Result<bool, HostSwitchError> {
+    let analytics_host_slot = match keyboard_transition {
+        KeyboardHostTransition::AlreadyDeparting { host_slot } => {
+            if host_slot == ReportedHostSlot::Empty {
+                return Err(HostSwitchError::HostSlotEmpty { host });
+            }
+            debug!(
+                route = %keyboard,
+                host,
+                ?host_slot,
+                "keyboard departure announced; switching targets immediately"
+            );
+            switch_targets_directly(targets, host, channel_pool).await;
+            return Ok(true);
+        }
+        KeyboardHostTransition::AnalyticsEvent { host_slot } => Some(host_slot),
+        KeyboardHostTransition::CommandRequired => None,
+    };
+    let channel = match open_channel(channel_pool, keyboard, "opening keyboard channel").await {
+        Ok(Some(channel)) => channel,
+        Ok(None) => {
+            return unreachable_transition_error(
+                analytics_host_slot,
+                host,
+                HostSwitchError::KeyboardNotFound,
+            );
+        }
+        Err(error) if error.is_device_unreachable() => {
+            return unreachable_transition_error(analytics_host_slot, host, error);
+        }
+        Err(error) => return Err(error),
+    };
+    // Validate the keyboard's own move before touching anything: preparation is
+    // read-only, but it is the step that rejects an unpaired host slot, and
+    // discovering that *after* the mice have moved would strand them on a host
+    // the keyboard never reaches. Applying it still happens last, because once
+    // the keyboard leaves this host its channel can no longer command a mouse
+    // sharing the same receiver.
+    let keyboard_change = if analytics_host_slot.is_some() {
+        prepare_announced_host_change_on(&channel, keyboard.device_index(), host).await
+    } else {
+        prepare_host_change_on(&channel, keyboard.device_index(), host).await
+    };
+    let keyboard_change = match keyboard_change {
+        Ok(change) => change,
+        Err(error) if error.is_device_unreachable() => {
+            return unreachable_transition_error(analytics_host_slot, host, error);
+        }
+        Err(error) => return Err(error),
+    };
+    for target in targets {
+        match prepare_host_change(target, host, keyboard, &channel, channel_pool).await {
+            Ok(change) => {
+                if let Err(error) = apply_host_change(change).await {
+                    debug!(%error, route = %target, host, "linked device host switch failed");
+                }
+            }
+            Err(error) => {
+                debug!(%error, route = %target, host, "linked device host switch preparation failed");
+            }
+        }
+    }
+    let changed = apply_host_change(keyboard_change).await?;
+    if changed {
+        debug!(host, route = %keyboard, "keyboard host switched");
+    }
+    Ok(changed)
+}
+
+/// Switch targets through their own channels after the initiating keyboard
+/// has announced that its firmware is already leaving this host.
+async fn switch_targets_directly(targets: &[DeviceRoute], host: u8, channel_pool: &ChannelPool) {
+    for target in targets {
+        let channel = match open_channel(channel_pool, target, "opening target channel").await {
+            Ok(Some(channel)) => channel,
+            Ok(None) => {
+                debug!(route = %target, host, "target not reachable for direct switch");
+                continue;
+            }
+            Err(error) => {
+                debug!(%error, route = %target, host, "target channel open failed");
+                continue;
+            }
+        };
+        match prepare_host_change_on(&channel, target.device_index(), host).await {
+            Ok(change) => {
+                if let Err(error) = apply_host_change(change).await {
+                    debug!(%error, route = %target, host, "direct target host switch failed");
+                }
+            }
+            Err(error) => {
+                debug!(%error, route = %target, host, "direct target host switch preparation failed");
+            }
+        }
+    }
+}
+
+fn unreachable_transition_error(
+    host_slot: Option<ReportedHostSlot>,
+    host: u8,
+    unreachable: HostSwitchError,
+) -> Result<bool, HostSwitchError> {
+    match host_slot {
+        None => Err(unreachable),
+        Some(ReportedHostSlot::Empty) => Err(HostSwitchError::HostSlotEmpty { host }),
+        Some(ReportedHostSlot::Unknown | ReportedHostSlot::Paired) => {
+            Err(HostSwitchError::HostSlotUnverified { host })
+        }
+    }
+}
+
+pub(super) struct PreparedHostChange {
+    feature: Arc<ChangeHostFeature>,
+    device_index: u8,
+    host: u8,
+    pub(super) required: bool,
+}
+
+enum HostSlotRequirement {
+    Advisory,
+    Paired,
+}
+
+async fn prepare_announced_host_change_on(
+    channel: &Arc<HidppChannel>,
+    device_index: u8,
+    host: u8,
+) -> Result<PreparedHostChange, HostSwitchError> {
+    prepare_host_change_on_with_requirement(
+        channel,
+        device_index,
+        host,
+        HostSlotRequirement::Paired,
+    )
+    .await
+}
+
+async fn prepare_host_change(
+    target: &DeviceRoute,
+    host: u8,
+    keyboard: &DeviceRoute,
+    keyboard_channel: &Arc<HidppChannel>,
+    channel_pool: &ChannelPool,
+) -> Result<PreparedHostChange, HostSwitchError> {
+    if shares_channel(target, keyboard) {
+        prepare_host_change_on(keyboard_channel, target.device_index(), host).await
+    } else {
+        let channel = open_channel(channel_pool, target, "opening linked device channel")
+            .await?
+            .ok_or(HostSwitchError::TargetNotFound)?;
+        prepare_host_change_on(&channel, target.device_index(), host).await
+    }
+}
+
+pub(super) async fn prepare_host_change_on(
+    channel: &Arc<HidppChannel>,
+    device_index: u8,
+    host: u8,
+) -> Result<PreparedHostChange, HostSwitchError> {
+    prepare_host_change_on_with_requirement(
+        channel,
+        device_index,
+        host,
+        HostSlotRequirement::Advisory,
+    )
+    .await
+}
+
+async fn prepare_host_change_on_with_requirement(
+    channel: &Arc<HidppChannel>,
+    device_index: u8,
+    host: u8,
+    slot_requirement: HostSlotRequirement,
+) -> Result<PreparedHostChange, HostSwitchError> {
+    let mut device = timed_device(
+        "opening host-change device",
+        Device::new(Arc::clone(channel), device_index),
+    )
+    .await?;
+    let info = timed_hidpp(
+        "locating host-change feature",
+        device.root().get_feature(ChangeHostFeature::ID),
+    )
+    .await?
+    .ok_or_else(|| HostSwitchError::Hidpp("ChangeHost is unsupported".into()))?;
+    let change_host = device.add_feature::<ChangeHostFeature>(info.index);
+    let state = timed_hidpp("reading current host", change_host.get_host_info()).await?;
+    let required = host_change_required(state.current_host, state.host_count, host)?;
+    if required {
+        match (
+            slot_requirement,
+            reported_host_slot(&mut device, host).await,
+        ) {
+            (_, ReportedHostSlot::Empty) => {
+                return Err(HostSwitchError::HostSlotEmpty { host });
+            }
+            (HostSlotRequirement::Paired, ReportedHostSlot::Unknown) => {
+                return Err(HostSwitchError::HostSlotUnverified { host });
+            }
+            (
+                HostSlotRequirement::Advisory,
+                ReportedHostSlot::Unknown | ReportedHostSlot::Paired,
+            )
+            | (HostSlotRequirement::Paired, ReportedHostSlot::Paired) => {}
+        }
+    }
+    Ok(PreparedHostChange {
+        feature: change_host,
+        device_index,
+        host,
+        required,
+    })
+}
+
+async fn apply_host_change(change: PreparedHostChange) -> Result<bool, HostSwitchError> {
+    if !change.required {
+        let PreparedHostChange {
+            device_index, host, ..
+        } = change;
+        debug!(device_index, host, "device already uses requested host");
+        return Ok(false);
+    }
+    timed_hidpp(
+        "writing current host",
+        change.feature.set_current_host(change.host),
+    )
+    .await?;
+    Ok(true)
+}
+
+pub(super) fn host_change_required(
+    current_host: u8,
+    host_count: u8,
+    requested_host: u8,
+) -> Result<bool, HostSwitchError> {
+    if requested_host >= host_count {
+        return Err(HostSwitchError::Hidpp(format!(
+            "host {requested_host} is outside device host count {host_count}"
+        )));
+    }
+    Ok(current_host != requested_host)
+}
+
+pub(super) fn shares_channel(left: &DeviceRoute, right: &DeviceRoute) -> bool {
+    left.shares_transport(right)
+}

--- a/crates/openlogi-permissions/src/lib.rs
+++ b/crates/openlogi-permissions/src/lib.rs
@@ -36,7 +36,12 @@ mod macos;
 mod tests;
 
 /// Tri-state result of a permission query.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+///
+/// Declared on every platform, like [`Permission::Accessibility`] beside it,
+/// rather than only on the two that can answer one. Windows has no permission
+/// to report, but the module docs above still name this type, and a `cfg` that
+/// deletes it there turns those docs into a broken intra-doc link that fails
+/// the whole crate's rustdoc build on Windows alone.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PermissionStatus {
     /// The app may use the capability.

--- a/xtask/src/commands/ci/jobs/steps.rs
+++ b/xtask/src/commands/ci/jobs/steps.rs
@@ -273,21 +273,22 @@ fn msrv(job: Job, sh: &Shell, host: Host) -> Result<Plan> {
 }
 
 fn rustdoc(job: Job) -> Plan {
+    Plan::run(job, [rustdoc_step()])
+}
+
+fn rustdoc_step() -> Step {
     let excludes = RUSTDOC_EXCLUDES
         .iter()
         .flat_map(|crate_name| ["--exclude", crate_name]);
-    Plan::run(
-        job,
-        [Step::new("cargo")
-            .args([
-                "doc",
-                "--workspace",
-                "--no-deps",
-                "--document-private-items",
-            ])
-            .args(excludes)
-            .env("RUSTDOCFLAGS", "-D warnings")],
-    )
+    Step::new("cargo")
+        .args([
+            "doc",
+            "--workspace",
+            "--no-deps",
+            "--document-private-items",
+        ])
+        .args(excludes)
+        .env("RUSTDOCFLAGS", "-D warnings")
 }
 
 fn tests_macos(job: Job) -> Plan {
@@ -379,7 +380,10 @@ fn wasm(job: Job, sh: &Shell) -> Result<Plan> {
 
 fn clippy_windows(job: Job, sh: &Shell, host: Host) -> Result<Plan> {
     if host == Host::Windows {
-        return Ok(Plan::run(job, [Step::new("cargo").args(CLIPPY_ARGS)]));
+        return Ok(Plan::run(
+            job,
+            [Step::new("cargo").args(CLIPPY_ARGS), rustdoc_step()],
+        ));
     }
 
     let sysroot = cmd!(sh, "rustc --print sysroot").quiet().read()?;

--- a/xtask/src/commands/ci/jobs/tests.rs
+++ b/xtask/src/commands/ci/jobs/tests.rs
@@ -26,12 +26,39 @@ fn workflow() -> Option<String> {
 /// The workflow with its line continuations joined back up and every run of
 /// whitespace collapsed, so a command it wraps for readability is one line
 /// again.
+///
+/// Line endings are normalized first. Git hands Windows checkouts CRLF unless
+/// a `.gitattributes` overrides it, and a continuation is then a backslash
+/// followed by CRLF, which the join below does not match — leaving a stray
+/// backslash mid-command and failing every wrapped command in
+/// [`ci_yml_runs_what_this_runner_runs`] on exactly one platform.
 fn workflow_commands(workflow: &str) -> String {
     workflow
+        .replace("\r\n", "\n")
         .replace("\\\n", " ")
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// The parser must not care how git checked the workflow out. A CRLF tree
+/// wraps continuations as a backslash followed by CRLF; missing that leaves a
+/// stray backslash mid-command and fails every wrapped command on Windows
+/// alone — invisible to CI, which is Linux and macOS.
+#[test]
+fn line_continuations_join_under_either_line_ending() {
+    let lf = "run: cargo doc --workspace \\\n  --no-deps --document-private-items";
+    let crlf = lf.replace('\n', "\r\n");
+
+    assert_eq!(
+        workflow_commands(lf),
+        "run: cargo doc --workspace --no-deps --document-private-items"
+    );
+    assert_eq!(
+        workflow_commands(&crlf),
+        workflow_commands(lf),
+        "a CRLF checkout must parse to the same commands as an LF one"
+    );
 }
 
 /// `ci.yml` is the pipeline's source of truth and this runner is a copy of it.

--- a/xtask/src/commands/ci/jobs/tests.rs
+++ b/xtask/src/commands/ci/jobs/tests.rs
@@ -104,6 +104,27 @@ fn ci_yml_runs_what_this_runner_runs() {
     }
 }
 
+#[test]
+fn native_windows_clippy_plan_also_builds_rustdoc() {
+    let sh = Shell::new().expect("a shell");
+    let plan = Job::ClippyWindows
+        .plan(&sh, Host::Windows)
+        .expect("native Windows plan");
+    let Action::Run(steps) = plan.action else {
+        panic!("native Windows clippy must run");
+    };
+
+    assert_eq!(steps.len(), 2);
+    assert_eq!(
+        steps[0].argv_line(),
+        "cargo clippy --workspace --all-targets -- -D warnings"
+    );
+    assert_eq!(
+        steps[1].argv_line(),
+        "cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent"
+    );
+}
+
 /// The wasm job skips itself on a machine without the wasm32 std, so its plan
 /// cannot be compared against `ci.yml` the way the others are. What must not
 /// drift is the crate list: a crate declared portable here but absent from the


### PR DESCRIPTION
## Summary

Re-home the analytics-only keyboard work from #718 onto the current host-switch
architecture while preserving Samuel Phinizy's authorship.

Make keyboard-initiated linked switching distinguish three transition sources. A
genuine HID++ ChangeHost departure announcement is authoritative: an Unknown or
Paired destination moves followers through their own channels without reopening
the already-departing keyboard. An explicitly Empty destination still fails
closed. Analytics-only control events remain non-authoritative and require a
fresh Paired result after exclusive access is acquired.

This PR forwards the keyboard's numeric host index unchanged. Linked devices must
therefore use the same Easy-Switch slot number for the same computer. It does not
detect or remap mismatched follower associations.

A sleeping or powered-off destination can cause Logitech firmware to fall back to
another paired host after a software ChangeHost command. This device behavior is
not solved by this PR.

This branch is stacked on #970. Until that PR merges, its four commits appear
before the Easy-Switch reliability commit. It also carries one local-runner
compatibility follow-up so the native Windows CI plan mirrors #970's rustdoc step.

## Changes

- **openlogi-device** - model commanded, analytics, and already-departing
  transitions explicitly; treat genuine ChangeHost announcements as
  authoritative unless the event-boundary slot is explicitly Empty; switch
  followers directly without reopening an already-departing keyboard; require a
  fresh Paired destination for analytics-only control events; and preserve
  commanded compatibility without HostsInfo.
- **openlogi-agent-core** - acquire exclusive receiver access before transition
  writes, keep a configuration-independent physical route inventory, remember
  keyboards that support ChangeHost announcements, wait for commanded departures
  before rearming, and reject obsolete session completions.
- **xtask** - keep the native Windows local CI plan in lockstep with #970's
  Clippy-plus-rustdoc workflow job.
- **tests** - cover authoritative Unknown and Paired departure announcements,
  explicit Empty rejection, fresh analytics validation, commanded compatibility,
  unavailable keyboards, target-only forwarding without reopening the keyboard,
  physical inventory departure, stale completions, suspended device-I/O retry
  suppression, and the Windows local CI plan.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo test -p xtask native_windows_clippy_plan_also_builds_rustdoc`
- `cargo test -p xtask ci_yml_runs_what_this_runner_runs`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p xtask --no-deps --document-private-items`
- `cargo xtask ci wasm`
- `cargo test -p openlogi-device host_switch --no-fail-fast`
- `cargo test -p openlogi-agent-core host_switch --no-fail-fast`
- `cargo test -p openlogi-device an_unknown_departure_announcement_moves_the_target_without_reopening_the_keyboard -- --nocapture`
- `cargo test -p openlogi-ipc --test wire_format`
- `typos` was not run locally because `typos-cli` is unavailable.
- Hardware tested before the final upstream rebase on Windows with MX Keys Mini
  and MX Master 4. The restored announcement path moved the mouse on reachable
  destinations after the previous head failed to move it. The final rebased head
  has not been runtime-tested on hardware.
- For final hardware verification, map each numbered slot to the same computer on
  keyboard and mouse, then test 1 -> 2 -> 1 and 1 -> 3 -> 1, including rapid
  switching. The mouse should follow genuine keyboard departure announcements
  without the keyboard being commanded again. Treat sleeping or powered-off
  destination fallback separately as the known firmware limitation above.

Continues #718

Depends on #970

Fixes #1145