### PR TITLE
fix(hid): end capture when liveness writes fail

### DIFF
--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -53,12 +53,58 @@ use crate::thumbwheel::{self, Thumbwheel, WheelDirection, WheelResolution};
 
 /// How often the capture session pings its device to prove the channel still
 /// delivers input reports. Cheap: one HID++ round-trip per interval.
+///
+/// Tests shrink this so the real-time response wait (a paused tokio clock
+/// cannot govern the channel's `futures_timer` deadline) still runs fast.
+#[cfg(not(test))]
 const LIVENESS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+#[cfg(test)]
+const LIVENESS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
 /// Consecutive all-silent pings after which the capture channel is declared
 /// dead. Two, so one ping lost to transient receiver congestion (which does
 /// happen under pointer load) doesn't churn the session.
 const LIVENESS_PING_STRIKES: u8 = 2;
+
+/// The data byte that marks the session's own liveness ping on the wire
+/// (`root.ping(0x5a)`), so a scripted transport can fail exactly this
+/// request and leave the version probe alone.
+const LIVENESS_PING_DATA: u8 = 0x5a;
+
+/// What one liveness ping says about the channel's delivery path.
+#[derive(Debug, PartialEq, Eq)]
+enum Liveness {
+    /// A transport-level failure: the request never went out. Nothing can
+    /// prove delivery through this channel again — the Windows BT path
+    /// surfaces its removed HID instance this way (write errors), which the
+    /// reply-only classification used to read as "healthy".
+    Dead,
+    /// No reply within the response budget. One lost ping is not proof —
+    /// receiver congestion swallows single round-trips — so this only
+    /// strikes.
+    Silent,
+    /// A pong or a HID++-level error reply arrived, proving the channel
+    /// delivered *something* the device originated.
+    Alive,
+}
+
+/// Classify one liveness-ping outcome. Match order matters: silence is the
+/// only two-strike path; any other `Channel` error is a transport failure,
+/// and a `Feature` error is still a device-originated reply.
+#[expect(
+    clippy::match_same_arms,
+    reason = "a pong and a HID++ error reply are distinct delivery proofs; merging them would hide the contract the doc comment promises"
+)]
+fn classify_ping(result: &Result<u8, v20::Hidpp20Error>) -> Liveness {
+    match result {
+        Ok(_) => Liveness::Alive,
+        Err(v20::Hidpp20Error::Channel(
+            hidpp::channel::ChannelError::Timeout | hidpp::channel::ChannelError::NoResponse,
+        )) => Liveness::Silent,
+        Err(v20::Hidpp20Error::Channel(_)) => Liveness::Dead,
+        Err(_) => Liveness::Alive,
+    }
+}
 
 /// One input captured from the active device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -328,12 +374,14 @@ async fn run_capture_session_on(
     // Liveness watchdog: this session's channel is the sole delivery path for
     // every diverted control, and a channel whose input-report delivery dies
     // (observed on macOS with concurrent opens of one node: writes accepted,
-    // replies and events silently routed elsewhere) turns every captured
-    // button to dead air with nothing to notice. Ping the device through this
-    // channel; consecutive all-silent pings mean the channel — not the device
-    // — is gone (a sleeping/unreachable device still gets us an error *reply*,
-    // which proves delivery and resets the count). Exiting lets the manager
-    // re-arm on a fresh channel.
+    // replies and events silently routed elsewhere; on Windows a removed
+    // Bluetooth HID instance fails every write) turns every captured button
+    // to dead air with nothing to notice. Ping the device through this
+    // channel: a transport write failure is proof enough to restart at once,
+    // consecutive all-silent pings mean the channel no longer delivers
+    // (a sleeping/unreachable device still gets us an error *reply*, which
+    // proves delivery and resets the count). Exiting lets the manager re-arm
+    // on a fresh channel.
     let root = RootFeature::new(Arc::clone(&chan), device_index, 0);
     let wireless = root
         .get_feature(WirelessDeviceStatusFeature::ID)
@@ -562,20 +610,19 @@ async fn monitor_capture(
                 context.armed.rearm().await;
             }
             () = tokio::time::sleep(LIVENESS_PING_INTERVAL) => {
-                match context.root.ping(0x5a).await {
-                    Err(v20::Hidpp20Error::Channel(
-                        hidpp::channel::ChannelError::Timeout
-                        | hidpp::channel::ChannelError::NoResponse,
-                    )) => {
+                match classify_ping(&context.root.ping(LIVENESS_PING_DATA).await) {
+                    Liveness::Silent => {
                         silent_pings = silent_pings.saturating_add(1);
                         if silent_pings >= LIVENESS_PING_STRIKES {
                             warn!(index = context.device_index, "capture channel stopped delivering — restarting session on a fresh channel");
                             return stop_for_current_publication(context.registry, context.shared);
                         }
                     }
-                    // Any reply — pong, feature error, unreachable-device
-                    // error — proves the channel still delivers.
-                    _ => silent_pings = 0,
+                    Liveness::Dead => {
+                        warn!(index = context.device_index, "capture channel write failed — restarting session on a fresh channel");
+                        return stop_for_current_publication(context.registry, context.shared);
+                    }
+                    Liveness::Alive => silent_pings = 0,
                 }
             }
         }

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::backend::NodeId;
-use crate::channel::scripted::{ScriptedRawHidChannel, scripted_channel};
+use crate::channel::scripted::{ScriptedRawHidChannel, scripted_channel, scripted_node_info};
 
 const GESTURE: &[u16] = &[reprog_controls::GESTURE_BUTTON_CID];
 const PANEL: &[u16] = &[reprog_controls::HAPTIC_PANEL_CID];
@@ -961,4 +961,140 @@ fn contact_without_rotation_or_a_tap_carries_no_input() {
         ),
         None
     );
+}
+
+/// How long a liveness test waits for the session to end on its own before
+/// concluding the watchdog kept a dead channel alive.
+const WATCHDOG_BUDGET: std::time::Duration = std::time::Duration::from_secs(3);
+
+use std::sync::RwLock;
+
+use crate::backend::{BackendError, HotplugStream, NodeInfo, RawWriter};
+
+/// A minimal HID++ 2.0 mouse: answers the root ping (so the version probe
+/// during arming succeeds) and reports every feature as unsupported, so
+/// arming diverts nothing and the session reaches its watchdog.
+fn featureless_mouse(request: &[u8]) -> Option<Vec<u8>> {
+    match request[3] >> 4 {
+        // Root ping: echo the header, report protocol 4.
+        1 => Some(vec![
+            0x10, request[1], request[2], request[3], 0x04, 0x00, request[6],
+        ]),
+        // Root getFeature: payload[0] == 0 means "not supported".
+        0 => Some(vec![0x10, request[1], request[2], request[3], 0, 0, 0]),
+        _ => None,
+    }
+}
+
+/// A backend presenting exactly one node, served by a pre-opened channel.
+struct LiveBackend(Arc<HidppChannel>);
+
+#[hidpp::async_trait]
+impl HidBackend for LiveBackend {
+    async fn enumerate(&self) -> Result<Vec<NodeInfo>, BackendError> {
+        Ok(vec![scripted_node_info("bt-mouse")])
+    }
+
+    async fn enumerate_hidpp(&self) -> Result<Vec<NodeInfo>, BackendError> {
+        self.enumerate().await
+    }
+
+    async fn open_hidpp(
+        &self,
+        _node: &NodeInfo,
+    ) -> Result<Option<Arc<HidppChannel>>, BackendError> {
+        Ok(Some(Arc::clone(&self.0)))
+    }
+
+    async fn open_raw_writer(&self, _node: &NodeInfo) -> Result<Box<dyn RawWriter>, BackendError> {
+        Err(BackendError::Backend(
+            "capture tests open no raw writer".into(),
+        ))
+    }
+
+    fn watch(&self) -> Result<HotplugStream, BackendError> {
+        Ok(Box::new(futures_lite::stream::empty()))
+    }
+}
+
+/// A channel whose writes fail at the transport — the shape of a Bluetooth
+/// node that went away while the OS still lists it — must end the capture
+/// session, not live on forever as a zombie. The failure is scoped to the
+/// liveness ping (its data byte marks it), so arming succeeds and the session
+/// reaches its watchdog with a channel that looks healthy until it dies.
+#[tokio::test]
+async fn a_channel_whose_writes_fail_ends_the_capture_session() {
+    let (raw, _handle) = ScriptedRawHidChannel::with_failing_writes(featureless_mouse, |request| {
+        request.last() == Some(&super::LIVENESS_PING_DATA)
+    });
+    let backend: Arc<dyn HidBackend> = Arc::new(LiveBackend(scripted_channel(raw).await));
+    let (sink, _rx) = mpsc::unbounded_channel();
+    let (_stop_tx, stop_rx) = oneshot::channel();
+    let slot: CaptureChannel = Arc::new(RwLock::new(None));
+    let session_slot = Arc::clone(&slot);
+
+    let session = tokio::spawn(async move {
+        run_capture_session(
+            &*backend,
+            DeviceRoute::Direct {
+                vendor_id: 0x046d,
+                product_id: 0xb35b,
+            },
+            CaptureSpec::default(),
+            sink,
+            stop_rx,
+            session_slot,
+        )
+        .await
+    });
+
+    let result = tokio::time::timeout(WATCHDOG_BUDGET, session)
+        .await
+        .expect("a channel whose writes fail kept the capture session alive")
+        .expect("the session should exit cleanly, not with an error");
+    assert!(
+        slot.read().unwrap().is_none(),
+        "an exited session must release the capture slot"
+    );
+    assert!(
+        matches!(result, Ok(CaptureSessionOutcome::Restored)),
+        "the session should exit restored, not pending restoration"
+    );
+}
+
+/// A pong proves delivery.
+#[test]
+fn a_pong_ping_classifies_alive() {
+    assert_eq!(super::classify_ping(&Ok(0x04)), super::Liveness::Alive,);
+}
+
+/// A HID++-level error reply is still a device-originated reply — delivery
+/// proven. A sleeping device answers like this, and must not churn the
+/// session.
+#[test]
+fn a_feature_error_reply_classifies_alive() {
+    let error = super::v20::Hidpp20Error::Feature(super::v20::ErrorType::InvalidArgument);
+    assert_eq!(super::classify_ping(&Err(error)), super::Liveness::Alive);
+}
+
+/// Silence strikes: one lost ping is congestion, two declare the channel
+/// dead — the pre-existing anti-churn contract, unchanged.
+#[test]
+fn a_timed_out_ping_classifies_silent() {
+    let error = super::v20::Hidpp20Error::Channel(hidpp::channel::ChannelError::Timeout);
+    assert_eq!(super::classify_ping(&Err(error)), super::Liveness::Silent);
+
+    let error = super::v20::Hidpp20Error::Channel(hidpp::channel::ChannelError::NoResponse);
+    assert_eq!(super::classify_ping(&Err(error)), super::Liveness::Silent);
+}
+
+/// A transport-level write failure is the Windows Bluetooth signature: the
+/// request never reached the device, so no reply can ever prove delivery
+/// through this channel again. Dead on first sight.
+#[test]
+fn a_transport_write_failure_classifies_dead() {
+    let error = super::v20::Hidpp20Error::Channel(hidpp::channel::ChannelError::Implementation(
+        crate::channel::scripted::mock_error(),
+    ));
+    assert_eq!(super::classify_ping(&Err(error)), super::Liveness::Dead);
 }


### PR DESCRIPTION
## Summary

Fix a liveness classification that leaves Windows Bluetooth gesture capture dead until the agent restarts.

## Changes

- `openlogi-device`: treat non-timeout channel failures as dead while preserving the two-strike silence policy and device-reply handling.
- `openlogi-device`: add scripted regression coverage for live, silent, feature-error, and write-dead channels.

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `cargo clippy -p openlogi-device -p openlogi-hid -p openlogi-agent -p openlogi-agent-core --all-targets -- -D warnings`
- `cargo test -p openlogi-device -p openlogi-hid -p openlogi-agent -p openlogi-agent-core` (416 passed)
- A v0.8.1 backport recovered after a 30-second MX Master 3 power cycle on Windows. The current-master branch was not runtime-tested on hardware.

Fixes #1125
