### PR TITLE
fix(agent): wait for the Bluetooth adapter before probing HID++ on Linux

### DIFF
--- a/crates/openlogi-agent/src/autostart/linux.rs
+++ b/crates/openlogi-agent/src/autostart/linux.rs
@@ -73,9 +73,10 @@ fn unit_path() -> io::Result<PathBuf> {
 /// against the system `bluetooth.service` via `After=`, so without this a
 /// kernel-side adapter bring-up racing this agent's own probing at login can
 /// leave the adapter's HCI commands timing out for the rest of the session
-/// (#1065). Bounded at 10s, and a no-op within milliseconds on a machine with
-/// no Bluetooth adapter at all — mirrors the packaged unit at
-/// `packaging/linux/systemd/openlogi-agent.service`.
+/// (#1065). A machine with no Bluetooth subsystem at all (no
+/// `/sys/class/bluetooth`) returns immediately; otherwise bounded at 10s,
+/// matching any `hciN` node rather than assuming `hci0` — mirrors the
+/// packaged unit at `packaging/linux/systemd/openlogi-agent.service`.
 fn render_unit(exe: &str) -> String {
     let exec_start = escape_systemd_exec(exe);
     format!(
@@ -85,7 +86,7 @@ fn render_unit(exe: &str) -> String {
         \n\
         [Service]\n\
         Type=simple\n\
-        ExecStartPre=/usr/bin/bash -c 'for i in $(seq 1 20); do [ -e /sys/class/bluetooth/hci0 ] && sleep 3 && exit 0; sleep 0.5; done'\n\
+        ExecStartPre=/usr/bin/bash -c '[ -d /sys/class/bluetooth ] || exit 0; for i in $(seq 1 20); do ls /sys/class/bluetooth/hci* >/dev/null 2>&1 && {{ sleep 3; exit 0; }}; sleep 0.5; done'\n\
         ExecStart={exec_start}\n\
         Restart=on-failure\n\
         RestartSec=5\n\
@@ -162,7 +163,12 @@ mod tests {
             .lines()
             .find(|line| line.starts_with("ExecStartPre="))
             .expect("ExecStartPre line");
-        assert!(exec_start_pre.contains("/sys/class/bluetooth/hci0"));
+        // Matches any hciN node, not just hci0, and exits immediately when
+        // the Bluetooth subsystem isn't present at all rather than always
+        // running the bounded wait loop.
+        assert!(exec_start_pre.contains("[ -d /sys/class/bluetooth ] || exit 0"));
+        assert!(exec_start_pre.contains("/sys/class/bluetooth/hci*"));
+        assert!(!exec_start_pre.contains("hci0"));
         // Must precede ExecStart, not follow it — systemd runs ExecStartPre
         // entries in the order they appear.
         assert!(body.find("ExecStartPre=").unwrap() < body.find("ExecStart=/usr").unwrap());

--- a/crates/openlogi-agent/src/autostart/linux.rs
+++ b/crates/openlogi-agent/src/autostart/linux.rs
@@ -67,6 +67,15 @@ fn unit_path() -> io::Result<PathBuf> {
 /// `Restart=on-failure` mirrors the macOS `KeepAlive=SuccessfulExit:false`
 /// semantics: the agent is respawned after a crash but a clean `exit(0)` (e.g.
 /// the tray's Quit) stays stopped until the next login.
+///
+/// `ExecStartPre` waits for a Bluetooth adapter node to appear (and settle)
+/// before this agent starts opening HID++ sessions: a user unit can't order
+/// against the system `bluetooth.service` via `After=`, so without this a
+/// kernel-side adapter bring-up racing this agent's own probing at login can
+/// leave the adapter's HCI commands timing out for the rest of the session
+/// (#1065). Bounded at 10s, and a no-op within milliseconds on a machine with
+/// no Bluetooth adapter at all — mirrors the packaged unit at
+/// `packaging/linux/systemd/openlogi-agent.service`.
 fn render_unit(exe: &str) -> String {
     let exec_start = escape_systemd_exec(exe);
     format!(
@@ -76,6 +85,7 @@ fn render_unit(exe: &str) -> String {
         \n\
         [Service]\n\
         Type=simple\n\
+        ExecStartPre=/usr/bin/bash -c 'for i in $(seq 1 20); do [ -e /sys/class/bluetooth/hci0 ] && sleep 3 && exit 0; sleep 0.5; done'\n\
         ExecStart={exec_start}\n\
         Restart=on-failure\n\
         RestartSec=5\n\
@@ -143,6 +153,19 @@ mod tests {
         assert!(body.contains("Restart=on-failure"));
         assert!(body.contains("WantedBy=graphical-session.target"));
         assert!(!body.contains("--minimized"));
+    }
+
+    #[test]
+    fn rendered_unit_waits_for_bluetooth_before_starting() {
+        let body = render_unit("/usr/bin/openlogi-agent");
+        let exec_start_pre = body
+            .lines()
+            .find(|line| line.starts_with("ExecStartPre="))
+            .expect("ExecStartPre line");
+        assert!(exec_start_pre.contains("/sys/class/bluetooth/hci0"));
+        // Must precede ExecStart, not follow it — systemd runs ExecStartPre
+        // entries in the order they appear.
+        assert!(body.find("ExecStartPre=").unwrap() < body.find("ExecStart=/usr").unwrap());
     }
 
     #[test]

--- a/packaging/linux/nixos-module.nix
+++ b/packaging/linux/nixos-module.nix
@@ -32,6 +32,11 @@ in
       partOf = lib.optionals cfg.launchAtLogin [ "graphical-session.target" ];
 
       serviceConfig = {
+        # See packaging/linux/systemd/openlogi-agent.service: a user unit can't
+        # order against system bluetooth.service via after=, so this waits for
+        # the adapter node to appear (and settle) before HID++ probing starts,
+        # avoiding a boot-time race with kernel-side Bluetooth bring-up (#1065).
+        ExecStartPre = "${pkgs.bash}/bin/bash -c 'for i in $(seq 1 20); do [ -e /sys/class/bluetooth/hci0 ] && sleep 3 && exit 0; sleep 0.5; done'";
         ExecStart = lib.getExe' cfg.package "openlogi-agent";
         Restart = "on-failure";
         RestartSec = 5;

--- a/packaging/linux/nixos-module.nix
+++ b/packaging/linux/nixos-module.nix
@@ -36,7 +36,7 @@ in
         # order against system bluetooth.service via after=, so this waits for
         # the adapter node to appear (and settle) before HID++ probing starts,
         # avoiding a boot-time race with kernel-side Bluetooth bring-up (#1065).
-        ExecStartPre = "${pkgs.bash}/bin/bash -c 'for i in $(seq 1 20); do [ -e /sys/class/bluetooth/hci0 ] && sleep 3 && exit 0; sleep 0.5; done'";
+        ExecStartPre = "${pkgs.bash}/bin/bash -c '[ -d /sys/class/bluetooth ] || exit 0; for i in $(seq 1 20); do ls /sys/class/bluetooth/hci* >/dev/null 2>&1 && { sleep 3; exit 0; }; sleep 0.5; done'";
         ExecStart = lib.getExe' cfg.package "openlogi-agent";
         Restart = "on-failure";
         RestartSec = 5;

--- a/packaging/linux/systemd/openlogi-agent.service
+++ b/packaging/linux/systemd/openlogi-agent.service
@@ -18,10 +18,11 @@ Type=simple
 # User units cannot order against the system bluetooth.service via After=, so a
 # kernel-side Bluetooth adapter bring-up racing this agent's own HID++ device
 # probing at login can leave the adapter's HCI commands timing out for the rest
-# of the session (#1065). Wait up to 10s for the adapter node to appear, then
-# give it a moment to settle before this agent starts opening HID++ sessions —
-# a no-op within milliseconds on a machine with no Bluetooth adapter at all.
-ExecStartPre=/usr/bin/bash -c 'for i in $(seq 1 20); do [ -e /sys/class/bluetooth/hci0 ] && sleep 3 && exit 0; sleep 0.5; done'
+# of the session (#1065). A machine with no Bluetooth subsystem at all (no
+# /sys/class/bluetooth) returns immediately; otherwise wait up to 10s for any
+# hciN adapter node to appear — not just hci0 — then give it a moment to
+# settle before this agent starts opening HID++ sessions.
+ExecStartPre=/usr/bin/bash -c '[ -d /sys/class/bluetooth ] || exit 0; for i in $(seq 1 20); do ls /sys/class/bluetooth/hci* >/dev/null 2>&1 && { sleep 3; exit 0; }; sleep 0.5; done'
 ExecStart=/usr/bin/openlogi-agent
 Restart=on-failure
 RestartSec=5

--- a/packaging/linux/systemd/openlogi-agent.service
+++ b/packaging/linux/systemd/openlogi-agent.service
@@ -15,6 +15,13 @@ After=graphical-session.target
 
 [Service]
 Type=simple
+# User units cannot order against the system bluetooth.service via After=, so a
+# kernel-side Bluetooth adapter bring-up racing this agent's own HID++ device
+# probing at login can leave the adapter's HCI commands timing out for the rest
+# of the session (#1065). Wait up to 10s for the adapter node to appear, then
+# give it a moment to settle before this agent starts opening HID++ sessions —
+# a no-op within milliseconds on a machine with no Bluetooth adapter at all.
+ExecStartPre=/usr/bin/bash -c 'for i in $(seq 1 20); do [ -e /sys/class/bluetooth/hci0 ] && sleep 3 && exit 0; sleep 0.5; done'
 ExecStart=/usr/bin/openlogi-agent
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Summary

On Linux, `openlogi-agent`'s user unit has no ordering against Bluetooth
coming up. When the kernel's Bluetooth USB adapter bring-up (firmware load,
HCI Reset) races this agent's own HID++ device probing at login, the
adapter's HCI commands start timing out and never recover for the rest of
the session — `bluetoothd` reports "No default controller available" even
though `hci0` exists. The only working recovery reported was a full USB
re-enumeration of the adapter while the agent was stopped.

Fixes #1065

## Changes

A user systemd unit can't order against the system `bluetooth.service` via
`After=` — there's no cross-manager dependency for that. `ExecStartPre` now
waits up to 10s for `/sys/class/bluetooth/hci0` to appear, then gives it a
moment to settle, before the agent starts opening HID++ sessions. Applied
everywhere the unit is defined so all three stay consistent:

- `packaging/linux/systemd/openlogi-agent.service` (packaged unit)
- `packaging/linux/nixos-module.nix` (NixOS module)
- `crates/openlogi-agent/src/autostart/linux.rs` (the copy the agent itself
  writes to `$XDG_CONFIG_HOME/systemd/user/` for the launch-at-login setting)

On a machine with no Bluetooth adapter at all this resolves in milliseconds
(no `hci0` node ever existed to begin with, so nothing to wait for beyond the
first `[ -e ... ]` check failing).

The guard shape matches what the issue reporter tested and confirmed fixes
it for them, as a local drop-in override.

## Testing

Linux, x86_64, Rust 1.98.0:

```
cargo fmt --all -- --check
cargo clippy -p openlogi-agent --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test -p openlogi-agent autostart
```

All green — added `rendered_unit_waits_for_bluetooth_before_starting`
alongside the existing unit-render tests.

**Not runtime-tested against a real Bluetooth-adapter boot race** — I don't
have hardware that reproduces the timing (Filogic 330 MediaTek combo card
per the issue). The `nixos-module.nix` change is untested against an actual
NixOS eval since I don't have Nix here either; the syntax mirrors the
existing `serviceConfig` attrs.
