### PR TITLE
fix(gui): mount dialog layers and apply profile removal on confirm

### DIFF
--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -1,11 +1,11 @@
 use gpui::{
-    App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
-    MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription, Window, div,
-    prelude::FluentBuilder as _, rgb,
+    AnyElement, App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement,
+    IntoElement, MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription,
+    Window, div, prelude::FluentBuilder as _, rgb,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
-    Icon, IconName, TitleBar,
+    Icon, IconName, Root, TitleBar,
     button::{Button, ButtonVariants as _},
     v_flex,
 };
@@ -372,6 +372,22 @@ impl AppView {
         }))
     }
 
+    /// gpui-component registers dialogs/sheets/notifications on [`Root`], but
+    /// [`Root::render`] does not paint those layers — the inner view must.
+    fn mount_modal_layers(
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        content: impl IntoElement,
+    ) -> AnyElement {
+        div()
+            .size_full()
+            .child(content)
+            .children(Root::render_sheet_layer(window, cx))
+            .children(Root::render_dialog_layer(window, cx))
+            .children(Root::render_notification_layer(window, cx))
+            .into_any_element()
+    }
+
     fn accessibility_gate(cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
         v_flex()
@@ -513,9 +529,11 @@ impl Render for AppView {
         self.config_issue_visible = config_issue.is_some();
         if let Some(issue) = config_issue {
             window.set_window_title("OpenLogi");
-            return root
-                .child(status::config_issue_body(issue, cx))
-                .into_any_element();
+            return Self::mount_modal_layers(
+                window,
+                cx,
+                root.child(status::config_issue_body(issue, cx)),
+            );
         }
 
         // The agent is the source of truth for both the permission state and
@@ -531,15 +549,15 @@ impl Render for AppView {
         let status = match link {
             AgentLink::Connecting => {
                 window.set_window_title("OpenLogi");
-                return root.child(status::connecting_body(cx)).into_any_element();
+                return Self::mount_modal_layers(window, cx, root.child(status::connecting_body(cx)));
             }
             AgentLink::Unreachable => {
                 window.set_window_title("OpenLogi");
-                return root.child(status::unreachable_body(cx)).into_any_element();
+                return Self::mount_modal_layers(window, cx, root.child(status::unreachable_body(cx)));
             }
             AgentLink::OutdatedGui => {
                 window.set_window_title("OpenLogi");
-                return root.child(status::outdated_gui_body(cx)).into_any_element();
+                return Self::mount_modal_layers(window, cx, root.child(status::outdated_gui_body(cx)));
             }
             AgentLink::Ready(status) => status,
         };
@@ -547,7 +565,10 @@ impl Render for AppView {
         let granted = status.accessibility_granted;
         if !granted && !self.accessibility_dismissed {
             window.set_window_title("OpenLogi");
-            return root.child(Self::accessibility_gate(cx)).into_any_element();
+            let content = root
+                .child(Self::accessibility_gate(cx).into_any_element())
+                .into_any_element();
+            return Self::mount_modal_layers(window, cx, content);
         }
 
         let has_device = AppState::try_global(cx)
@@ -641,10 +662,13 @@ impl Render for AppView {
             )
         };
 
-        root.child(header_el)
-            .child(content_el)
-            .when(!granted, |this| this.child(status::attention_footer(cx)))
-            .into_any_element()
+        Self::mount_modal_layers(
+            window,
+            cx,
+            root.child(header_el)
+                .child(content_el)
+                .when(!granted, |this| this.child(status::attention_footer(cx))),
+        )
     }
 }
 

--- a/crates/openlogi-desktop/src/features/profiles.rs
+++ b/crates/openlogi-desktop/src/features/profiles.rs
@@ -10,10 +10,11 @@ use std::rc::Rc;
 use gpui::{App, Entity, ParentElement, Styled, Window, div};
 use gpui_component::{WindowExt as _, button::ButtonVariant, dialog::DialogButtonProps, h_flex};
 use openlogi_core::binding::{ActionRingConfig, ActionRingLayout, ActionRingSlot};
+use openlogi_core::device::DeviceKey;
 
 pub(crate) use self::catalog::{AppCatalogPicker, ProfileIconCache};
 use self::shell::ProfileScopeShell;
-use crate::state::AppState;
+use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::theme::{self, Typography as _};
 
 #[derive(Clone)]
@@ -297,6 +298,18 @@ fn profile_summary(editing_app: Option<&str>, override_count: usize) -> gpui::Sh
 }
 
 fn open_button_remove_confirmation(window: &mut Window, cx: &mut App, profile: &ProfileChoice) {
+    let Some(device_key) = AppState::try_read(cx).and_then(|state| {
+        if !state.current_device_is_persistent() {
+            return None;
+        }
+        state
+            .current_record()
+            .and_then(DeviceRecord::persistent_config_key)
+            .map(str::to_string)
+    }) else {
+        return;
+    };
+    let app = profile.app.clone();
     let question = remove_profile_question(profile);
     window.open_alert_dialog(cx, move |alert, _, _| {
         alert
@@ -311,11 +324,16 @@ fn open_button_remove_confirmation(window: &mut Window, cx: &mut App, profile: &
                     .cancel_text(tr!("Cancel"))
                     .show_cancel(true),
             )
-            .on_ok(move |_event, _window, cx| {
-                AppState::update_bindings(cx, |state| {
-                    state.remove_editing_app_profile();
-                });
-                true
+            .on_ok({
+                let device_key = device_key.clone();
+                move |_event, _window, cx| {
+                    let event_key = DeviceKey::from(device_key.as_str());
+                    AppState::update(cx, |state, cx| {
+                        state.remove_app_profile_for_device(&device_key, &app);
+                        cx.emit(StateEvent::BindingsChanged(event_key));
+                    });
+                    true
+                }
             })
     });
 }

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -74,7 +74,7 @@ mod settings;
 mod smartshift;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 /// Default DPI value applied to a fresh AppState. Matches a common Logitech
 /// mid-range mouse and keeps the dot-preview visually obvious from frame one.

--- a/crates/openlogi-desktop/src/state/bindings.rs
+++ b/crates/openlogi-desktop/src/state/bindings.rs
@@ -67,6 +67,16 @@ impl BindingState {
         self.refresh_device(config, persistent_key);
     }
 
+    fn clear_editing_scope_for(&mut self, device_key: &str) {
+        if self
+            .editing_scope
+            .as_ref()
+            .is_some_and(|scope| scope.device_key == device_key)
+        {
+            self.editing_scope = None;
+        }
+    }
+
     fn refresh_device(&mut self, config: &Config, persistent_key: Option<&str>) {
         let button_bindings =
             bindings_for(config, persistent_key, self.editing_app(persistent_key));
@@ -269,8 +279,8 @@ impl AppState {
         self.config
             .edit(|config| config.remove_app_profile(device_key, app));
         if self.bindings.editing_app(Some(device_key)) == Some(app) {
-            self.bindings
-                .set_editing_app(&self.config, Some(device_key), None);
+            self.bindings.clear_editing_scope_for(device_key);
+            self.refresh_binding_projections();
         }
         self.persist_and_reload("per-app profile");
     }

--- a/crates/openlogi-desktop/src/state/bindings.rs
+++ b/crates/openlogi-desktop/src/state/bindings.rs
@@ -271,8 +271,6 @@ impl AppState {
         if self.bindings.editing_app(Some(device_key)) == Some(app) {
             self.bindings
                 .set_editing_app(&self.config, Some(device_key), None);
-        } else if self.editing_app() == Some(app) {
-            self.set_editing_app(None);
         }
         self.persist_and_reload("per-app profile");
     }

--- a/crates/openlogi-desktop/src/state/bindings.rs
+++ b/crates/openlogi-desktop/src/state/bindings.rs
@@ -258,6 +258,25 @@ impl AppState {
         self.persist_and_reload("per-app binding");
     }
 
+    /// Delete `app`'s profile for `device_key`. If that profile is the one this
+    /// window has open, fall back to editing the device's global bindings.
+    ///
+    /// Confirm dialogs must capture the device key up front and call this
+    /// instead of [`Self::remove_editing_app_profile`] so removal does not
+    /// depend on [`Self::current_record`] still being available when the
+    /// dialog closes.
+    pub(crate) fn remove_app_profile_for_device(&mut self, device_key: &str, app: &str) {
+        self.config
+            .edit(|config| config.remove_app_profile(device_key, app));
+        if self.bindings.editing_app(Some(device_key)) == Some(app) {
+            self.bindings
+                .set_editing_app(&self.config, Some(device_key), None);
+        } else if self.editing_app() == Some(app) {
+            self.set_editing_app(None);
+        }
+        self.persist_and_reload("per-app profile");
+    }
+
     /// Delete the open per-app profile outright and fall back to editing the
     /// device's global bindings.
     pub fn remove_editing_app_profile(&mut self) {
@@ -271,10 +290,7 @@ impl AppState {
         let Some(app) = self.editing_app().map(str::to_string) else {
             return;
         };
-        self.config
-            .edit(|config| config.remove_app_profile(&key, &app));
-        self.set_editing_app(None);
-        self.persist_and_reload("per-app profile");
+        self.remove_app_profile_for_device(&key, &app);
     }
 
     /// The open per-app profile's overrides, so the panel can tell an override

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -750,6 +750,60 @@ fn a_profile_belongs_to_the_device_it_was_opened_on() {
 }
 
 #[test]
+fn removing_a_profile_on_a_background_device_does_not_clobber_active_projections() {
+    const SECOND_MOUSE_KEY: &str = "unit:11223344";
+
+    let cache = AssetResolver::new();
+    let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[
+            direct_inventory([0xa3, 0x93, 0xca, 0xe0]),
+            second_mouse_inventory(),
+        ],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+    let other = state
+        .devices()
+        .iter()
+        .position(|record| record.config_key == SECOND_MOUSE_KEY)
+        .expect("the fixture pairs a second device");
+    let known = state
+        .devices()
+        .iter()
+        .position(|record| record.config_key == KNOWN_MOUSE_KEY)
+        .expect("the fixture pairs the known mouse");
+
+    state.set_current_device(known);
+    state.set_editing_app(Some("com.apple.Safari".into()));
+    state.commit_binding(ButtonId::Back, Action::Undo);
+
+    state.set_current_device(other);
+    state.set_editing_app(Some("com.apple.Safari".into()));
+    state.commit_binding(ButtonId::Back, Action::Redo);
+    let active_bindings = state.button_bindings().clone();
+
+    state.remove_app_profile_for_device(KNOWN_MOUSE_KEY, "com.apple.Safari");
+
+    assert_eq!(state.button_bindings(), &active_bindings);
+    assert_eq!(state.editing_app(), Some("com.apple.Safari"));
+    assert_eq!(
+        state.config.per_app_overrides(SECOND_MOUSE_KEY, "com.apple.Safari"),
+        Some(&BTreeMap::from([(ButtonId::Back, Action::Redo)]))
+    );
+    assert!(
+        state
+            .config
+            .per_app_overrides(KNOWN_MOUSE_KEY, "com.apple.Safari")
+            .is_none()
+    );
+}
+
+#[test]
 fn invalid_device_selection_preserves_the_valid_current_device() {
     let mut state = state_with_a_known_mouse();
     let selected = state.selected_device_index();


### PR DESCRIPTION
## Summary

Two GUI fixes for per-app profile removal:

1. **Dialog layers** — mount gpui-component dialog/sheet/notification layers from `AppView` so confirm alerts actually paint.
2. **Synchronous removal** — capture the device key when opening the remove-profile confirm dialog so removal succeeds even if selection drifts before the user confirms.

Independent PR — no dependency on other open work.

Ported to the refactored `features/profiles/` module on current `master`.

## Testing

```sh
cargo check -p openlogi-desktop
cargo test -p openlogi-desktop
```

Made with [Cursor](https://cursor.com)