### PR TITLE
fix(gui): capture custom shortcuts with distinct numpad keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2784,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2812,7 +2812,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "getrandom 0.3.4",
- "gpui_macros",
+ "gpui_macros 0.1.0 (git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys)",
  "gpui_shared_string",
  "gpui_util",
  "heapless",
@@ -2877,7 +2877,7 @@ dependencies = [
  "async-channel",
  "chrono",
  "gpui",
- "gpui_macros",
+ "gpui_macros 0.1.0 (git+https://github.com/zed-industries/zed)",
  "instant",
  "lsp-types",
  "objc2 0.6.4",
@@ -2911,7 +2911,7 @@ dependencies = [
  "gpui-base",
  "gpui-component-assets",
  "gpui-component-macros",
- "gpui_macros",
+ "gpui_macros 0.1.0 (git+https://github.com/zed-industries/zed)",
  "html5ever",
  "instant",
  "itertools 0.13.0",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3037,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3086,6 +3086,17 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "gpui_macros"
+version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "heck 0.5.0",
@@ -3097,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3110,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "schemars",
  "serde",
@@ -3120,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "anyhow",
  "log",
@@ -3130,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3153,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3183,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3436,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4439,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -5524,6 +5535,7 @@ dependencies = [
  "appcatalog",
  "appicon",
  "backon",
+ "block2 0.6.2",
  "derive_more",
  "disclaim",
  "embed-resource",
@@ -5902,7 +5914,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "collections",
  "serde",
@@ -6687,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "derive_refineable",
 ]
@@ -7091,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7681,7 +7693,7 @@ dependencies = [
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "heapless",
  "log",
@@ -8771,7 +8783,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "perf",
  "quote",
@@ -10748,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10765,7 +10777,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -10776,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
+source = "git+https://github.com/tournierjc/zed?branch=openlogi%2Fnumpad-digit-keys#41d752258a4ab128063a23247dfe2d981a0c7271"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,4 +154,13 @@ strip = "symbols"
 # the two `gpui` packages now present in the zed repository; the exact commit
 # stays pinned in Cargo.lock so this patch does not fork the git source.
 [patch.crates-io]
-gpui = { git = "https://github.com/zed-industries/zed", version = "=0.2.2" }
+gpui = { git = "https://github.com/tournierjc/zed", branch = "openlogi/numpad-digit-keys", version = "=0.2.2" }
+
+# Preserve numpad digit identity in GPUI keystrokes for shortcut capture.
+# Fork: https://github.com/tournierjc/zed/tree/openlogi/numpad-digit-keys
+[patch."https://github.com/zed-industries/zed"]
+gpui = { git = "https://github.com/tournierjc/zed", branch = "openlogi/numpad-digit-keys" }
+gpui_platform = { git = "https://github.com/tournierjc/zed", branch = "openlogi/numpad-digit-keys" }
+gpui_linux = { git = "https://github.com/tournierjc/zed", branch = "openlogi/numpad-digit-keys" }
+gpui_macos = { git = "https://github.com/tournierjc/zed", branch = "openlogi/numpad-digit-keys" }
+gpui_windows = { git = "https://github.com/tournierjc/zed", branch = "openlogi/numpad-digit-keys" }

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -35,7 +35,9 @@ pub use category::Category;
 pub use defaults::{default_binding, default_binding_for, default_gesture_binding};
 pub use effect::{Effect, MediaKey, MouseButton, NativeAction, Script, Shortcut};
 pub use gesture::GestureDirection;
-pub use key_combo::{KeyCombo, KeyComboParseError, KeyboardUsage, KeyboardUsageError};
+pub use key_combo::{
+    CapturedKeystroke, KeyCombo, KeyComboParseError, KeyboardUsage, KeyboardUsageError,
+};
 pub use swipe::{
     GESTURE_HOLD_FOR_SWIPE, GESTURE_SWIPE_DEADZONE, GESTURE_SWIPE_THRESHOLD, SwipeAccumulator,
     detect_swipe,

--- a/crates/openlogi-core/src/binding/key_combo.rs
+++ b/crates/openlogi-core/src/binding/key_combo.rs
@@ -53,7 +53,12 @@ impl KeyboardUsage {
             0x36 => ",".to_string(),
             0x37 => ".".to_string(),
             0x38 => "/".to_string(),
+            0x39 => "CapsLock".to_string(),
             0x3a..=0x45 => format!("F{}", code - 0x3a + 1),
+            0x46 => "PrintScreen".to_string(),
+            0x47 => "ScrollLock".to_string(),
+            0x48 => "Pause".to_string(),
+            0x49 => "Insert".to_string(),
             0x4a => "Home".to_string(),
             0x4b => "PageUp".to_string(),
             0x4c => "Delete".to_string(),
@@ -63,6 +68,17 @@ impl KeyboardUsage {
             0x50 => "Left".to_string(),
             0x51 => "Down".to_string(),
             0x52 => "Up".to_string(),
+            0x53 => "NumLock".to_string(),
+            0x54 => "KpDivide".to_string(),
+            0x55 => "KpMultiply".to_string(),
+            0x56 => "KpMinus".to_string(),
+            0x57 => "KpPlus".to_string(),
+            0x58 => "KpEnter".to_string(),
+            0x59..=0x61 => format!("Kp{}", code - 0x59 + 1),
+            0x62 => "Kp0".to_string(),
+            0x63 => "KpDecimal".to_string(),
+            0x65 => "Menu".to_string(),
+            0x67 => "KpEquals".to_string(),
             0x68..=0x6f => format!("F{}", code - 0x68 + 13),
             _ => format!("Usage 0x{code:02X}"),
         }
@@ -80,8 +96,8 @@ pub struct KeyboardUsageError(pub u8);
 )]
 const fn validate_keyboard_usage(value: &u8) -> Result<(), KeyboardUsageError> {
     if matches!(
-        value,
-        0x04..=0x31 | 0x33..=0x38 | 0x3a..=0x45 | 0x4a..=0x52 | 0x68..=0x6f
+        *value,
+        0x04..=0x31 | 0x33..=0x63 | 0x65 | 0x67..=0x6f
     ) {
         Ok(())
     } else {
@@ -161,6 +177,32 @@ impl<'de> Deserialize<'de> for KeyCombo {
 }
 
 impl KeyCombo {
+    /// Build a chord from a HID keyboard report's modifier bitmap and usage ID.
+    ///
+    /// Left and right HID modifiers collapse into OpenLogi's four modifier
+    /// bits. Returns `None` when `usage` is not a [`KeyboardUsage`] we persist.
+    #[must_use]
+    pub fn from_hid_report(modifiers: u8, usage: u8) -> Option<Self> {
+        let key = KeyboardUsage::try_from(usage).ok()?;
+        let mut bits = 0u8;
+        if modifiers & (0x01 | 0x10) != 0 {
+            bits |= MOD_CONTROL;
+        }
+        if modifiers & (0x02 | 0x20) != 0 {
+            bits |= MOD_SHIFT;
+        }
+        if modifiers & (0x04 | 0x40) != 0 {
+            bits |= MOD_OPTION;
+        }
+        if modifiers & (0x08 | 0x80) != 0 {
+            bits |= MOD_COMMAND;
+        }
+        Some(Self {
+            modifiers: bits,
+            key,
+        })
+    }
+
     /// USB HID keyboard usage for the ordinary key.
     #[must_use]
     pub const fn key(&self) -> KeyboardUsage {
@@ -191,6 +233,24 @@ impl KeyCombo {
         self.modifiers & MOD_OPTION != 0
     }
 
+    /// Build a chord from a GUI key-capture event.
+    ///
+    /// `key` is the GPUI/xkb key name (`home`, `insert`, `subtract`, `6`),
+    /// not the character the layout would type. AZERTY number-row punctuation
+    /// (`-` on the 6 key) is mapped back to the physical HID usage so a G502
+    /// binding injects KEY_6 rather than KEY_MINUS.
+    #[must_use]
+    pub fn from_captured(stroke: CapturedKeystroke<'_>) -> Option<Self> {
+        if stroke.key.is_empty() || is_modifier_key_name(stroke.key) {
+            return None;
+        }
+        let key = parse_key(remap_captured_key(stroke.key, stroke.layout_name)).ok()?;
+        Some(Self {
+            modifiers: stroke.modifiers,
+            key,
+        })
+    }
+
     /// Canonical user-facing chord label.
     #[must_use]
     pub fn rendered_label(&self) -> String {
@@ -209,6 +269,62 @@ impl KeyCombo {
         }
         parts.push(self.key.label());
         parts.join("+")
+    }
+}
+
+/// One key-down from the settings app's shortcut recorder.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CapturedKeystroke<'a> {
+    modifiers: u8,
+    key: &'a str,
+    layout_name: &'a str,
+}
+
+impl<'a> CapturedKeystroke<'a> {
+    /// GPUI `Keystroke.key` plus the host layout name (`French`, `English (US)`, …).
+    #[must_use]
+    pub const fn new(key: &'a str, layout_name: &'a str) -> Self {
+        Self {
+            modifiers: 0,
+            key,
+            layout_name,
+        }
+    }
+
+    /// Command/Meta/Super is down.
+    #[must_use]
+    pub const fn command(mut self, down: bool) -> Self {
+        if down {
+            self.modifiers |= MOD_COMMAND;
+        }
+        self
+    }
+
+    /// Shift is down.
+    #[must_use]
+    pub const fn shift(mut self, down: bool) -> Self {
+        if down {
+            self.modifiers |= MOD_SHIFT;
+        }
+        self
+    }
+
+    /// Control is down.
+    #[must_use]
+    pub const fn control(mut self, down: bool) -> Self {
+        if down {
+            self.modifiers |= MOD_CONTROL;
+        }
+        self
+    }
+
+    /// Option/Alt is down.
+    #[must_use]
+    pub const fn option(mut self, down: bool) -> Self {
+        if down {
+            self.modifiers |= MOD_OPTION;
+        }
+        self
     }
 }
 
@@ -304,6 +420,15 @@ fn parse_key(token: &str) -> Result<KeyboardUsage, KeyComboParseError> {
             13..=20 => 0x68 + number - 13,
             _ => return Err(KeyComboParseError::UnknownToken(token.to_string())),
         }
+    } else if let Some(number) = lowercase
+        .strip_prefix("kp")
+        .and_then(|number| number.parse::<u8>().ok())
+    {
+        match number {
+            0 => 0x62,
+            1..=9 => 0x59 + number - 1,
+            _ => return Err(KeyComboParseError::UnknownToken(token.to_string())),
+        }
     } else {
         match lowercase.as_str() {
             "enter" | "return" => 0x28,
@@ -311,6 +436,11 @@ fn parse_key(token: &str) -> Result<KeyboardUsage, KeyComboParseError> {
             "backspace" => 0x2a,
             "tab" => 0x2b,
             "space" => 0x2c,
+            "capslock" | "caps" => 0x39,
+            "printscreen" | "print-screen" => 0x46,
+            "scrolllock" | "scroll-lock" => 0x47,
+            "pause" => 0x48,
+            "insert" | "ins" => 0x49,
             "home" => 0x4a,
             "pageup" | "page-up" => 0x4b,
             "delete" => 0x4c,
@@ -320,10 +450,107 @@ fn parse_key(token: &str) -> Result<KeyboardUsage, KeyComboParseError> {
             "left" => 0x50,
             "down" => 0x51,
             "up" => 0x52,
+            "numlock" | "num-lock" => 0x53,
+            "minus" => 0x2d,
+            "kpdivide" | "kp-divide" | "kp_divide" | "divide" => 0x54,
+            "kpmultiply" | "kp-multiply" | "kp_multiply" | "multiply" => 0x55,
+            "kpminus" | "kp-minus" | "kp_minus" | "subtract" | "kp-subtract" | "kp_subtract" => {
+                0x56
+            }
+            "kpplus" | "kp-plus" | "kp_plus" | "add" | "kp-add" | "kp_add" => 0x57,
+            "kpenter" | "kp-enter" | "kp_enter" | "numpadenter" => 0x58,
+            "kpdecimal" | "kp-decimal" | "kp_decimal" | "decimal" | "kp-separator"
+            | "kp_separator" => 0x63,
+            "menu" => 0x65,
+            "kpequals" | "kp-equals" => 0x67,
             _ => return Err(KeyComboParseError::UnknownToken(token.to_string())),
         }
     };
     KeyboardUsage::try_from(usage).map_err(|_| KeyComboParseError::UnknownToken(token.to_string()))
+}
+
+fn is_modifier_key_name(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "control"
+            | "ctrl"
+            | "shift"
+            | "alt"
+            | "option"
+            | "cmd"
+            | "command"
+            | "meta"
+            | "win"
+            | "super"
+            | "fn"
+            | "function"
+    )
+}
+
+/// GPUI Linux reports the xkb keysym, so AZERTY's 6 key arrives as `-`.
+/// Non-ASCII unshifted glyphs (`é`) arrive as xkb names (`eacute`).
+fn remap_captured_key<'a>(key: &'a str, layout_name: &str) -> &'a str {
+    if is_french_france_layout(layout_name) {
+        return remap_french_number_row(key);
+    }
+    if is_belgian_layout(layout_name) {
+        return remap_belgian_number_row(key);
+    }
+    key
+}
+
+fn remap_french_number_row(key: &str) -> &str {
+    match key {
+        "&" => "1",
+        "é" | "eacute" => "2",
+        "\"" => "3",
+        "'" => "4",
+        "(" => "5",
+        "-" => "6",
+        "è" | "egrave" => "7",
+        "_" => "8",
+        "ç" | "ccedilla" => "9",
+        "à" | "agrave" => "0",
+        ")" => "-",
+        "²" | "twosuperior" => "`",
+        _ => key,
+    }
+}
+
+fn remap_belgian_number_row(key: &str) -> &str {
+    match key {
+        "&" => "1",
+        "é" | "eacute" => "2",
+        "\"" => "3",
+        "'" => "4",
+        "(" => "5",
+        "§" | "section" => "6",
+        "è" | "egrave" => "7",
+        "!" => "8",
+        "ç" | "ccedilla" => "9",
+        "à" | "agrave" => "0",
+        _ => key,
+    }
+}
+
+fn is_french_france_layout(name: &str) -> bool {
+    if is_belgian_layout(name) {
+        return false;
+    }
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("switzerland") || lower.contains("canada") {
+        return false;
+    }
+    lower.contains("azerty")
+        || lower == "fr"
+        || lower == "french"
+        || lower.starts_with("french ")
+        || lower.starts_with("français")
+}
+
+fn is_belgian_layout(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.contains("belgian") || lower.contains("belge") || lower == "be"
 }
 
 #[cfg(test)]
@@ -354,6 +581,59 @@ mod tests {
         let combo = "Cmd+A".parse::<KeyCombo>().expect("valid shortcut failed");
         assert_eq!(combo.key().code(), 0x04);
         assert_eq!(combo.rendered_label(), "Cmd+A");
+    }
+
+    #[test]
+    fn hid_report_collapses_left_and_right_modifiers() {
+        let combo = KeyCombo::from_hid_report(0x01 | 0x20 | 0x80, 0x04)
+            .expect("0x04 is a valid keyboard usage");
+        assert!(combo.has_control());
+        assert!(combo.has_shift());
+        assert!(combo.has_command());
+        assert!(!combo.has_option());
+        assert_eq!(combo.key().code(), 0x04);
+        assert!(KeyCombo::from_hid_report(0, 0xff).is_none());
+        let plus = KeyCombo::from_hid_report(0, 0x57).expect("keypad plus is a valid usage");
+        assert_eq!(plus.rendered_label(), "KpPlus");
+        assert_eq!("KpPlus".parse::<KeyCombo>(), Ok(plus));
+    }
+
+    fn captured(key: &str, layout: &str) -> KeyCombo {
+        KeyCombo::from_captured(CapturedKeystroke::new(key, layout))
+            .unwrap_or_else(|| panic!("captured {key:?} on {layout:?}"))
+    }
+
+    #[test]
+    fn captured_named_keys_and_keypad_operators() {
+        assert_eq!(captured("home", "English (US)").key().code(), 0x4a);
+        assert_eq!(captured("insert", "English (US)").key().code(), 0x49);
+        assert_eq!(captured("minus", "English (US)").key().code(), 0x2d);
+        assert_eq!(captured("subtract", "English (US)").key().code(), 0x56);
+        assert_eq!(captured("kp_subtract", "English (US)").key().code(), 0x56);
+        assert_eq!(captured("add", "English (US)").key().code(), 0x57);
+        assert_eq!(captured("6", "English (US)").key().code(), 0x23);
+        assert_eq!(captured("kp6", "English (US)").key().code(), 0x5e);
+        assert_eq!(captured("kp0", "English (US)").key().code(), 0x62);
+        assert_eq!(captured("-", "English (US)").key().code(), 0x2d);
+        assert_eq!(
+            KeyCombo::from_captured(CapturedKeystroke::new("home", "English (US)").control(true),)
+                .expect("Ctrl+Home")
+                .rendered_label(),
+            "Ctrl+Home"
+        );
+    }
+
+    #[test]
+    fn azerty_number_row_punctuation_maps_to_physical_hid_keys() {
+        assert_eq!(captured("-", "French").key().code(), 0x23);
+        assert_eq!(captured("eacute", "French").key().code(), 0x1f);
+        assert_eq!(captured(")", "French").key().code(), 0x2d);
+        assert_eq!(captured("subtract", "French").key().code(), 0x56);
+        assert_eq!(captured("-", "Belgian").key().code(), 0x2d);
+        assert_eq!(captured("section", "Belgian").key().code(), 0x23);
+        assert_eq!(captured("-", "English (US)").key().code(), 0x2d);
+        assert_eq!(captured("-", "French (Switzerland)").key().code(), 0x2d);
+        assert!(KeyCombo::from_captured(CapturedKeystroke::new("shift", "French")).is_none());
     }
 
     #[test]

--- a/crates/openlogi-desktop/Cargo.toml
+++ b/crates/openlogi-desktop/Cargo.toml
@@ -65,8 +65,9 @@ embed-resource = "3.0.9"
 # Window chrome, host OS string, and installed-app icon lookup only — the
 # menu-bar status item lives in the agent, not here.
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = { workspace = true }
 objc2 = { workspace = true }
-objc2-app-kit = { workspace = true, features = ["NSApplication", "NSAppearance"] }
+objc2-app-kit = { workspace = true, features = ["NSApplication", "NSAppearance", "NSEvent", "block2"] }
 objc2-foundation = { workspace = true, features = ["NSProcessInfo", "NSString", "NSError"] }
 objc2-service-management = { workspace = true, features = ["std", "SMAppService", "SMErrors", "objc2", "objc2-foundation"] }
 

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -14,13 +14,14 @@ use gpui_component::{
     v_flex,
 };
 use openlogi_core::binding::{
-    ActionRingConfig, ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot,
+    Action, ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot, KeyCombo,
 };
 use openlogi_ui::action_icons::RING_CANCEL_ICON;
 
 use self::action_icons::action_icon_path;
 use self::editor::action_library;
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::shortcut_capture::ShortcutCapture;
 use crate::ui::theme::{self, Palette, Typography as _};
 
 /// Stateful Actions Ring editor. Ring configuration itself lives in
@@ -29,10 +30,11 @@ pub struct ActionRingPanel {
     focus_handle: FocusHandle,
     selected_slot: ActionRingSlot,
     application_input: Option<Entity<InputState>>,
-    shortcut_input: Option<Entity<InputState>>,
+    shortcut_input: Entity<ShortcutCapture>,
     library_scroll: ScrollHandle,
     #[expect(dead_code, reason = "held to keep the AppState subscription alive")]
     state_obs: Subscription,
+    _shortcut_obs: Subscription,
 }
 
 impl ActionRingPanel {
@@ -50,13 +52,22 @@ impl ActionRingPanel {
                 cx.notify();
             }
         });
+        let shortcut_input = cx.new(|cx| ShortcutCapture::new("ring-shortcut-capture", cx));
+        let shortcut_obs = cx.subscribe(&shortcut_input, |this, _, combo: &KeyCombo, cx| {
+            editor::commit_action(
+                this.selected_slot,
+                Action::CustomShortcut(combo.clone()),
+                cx,
+            );
+        });
         Self {
             focus_handle: cx.focus_handle(),
             selected_slot: ActionRingSlot::Top,
             application_input: None,
-            shortcut_input: None,
+            shortcut_input,
             library_scroll: ScrollHandle::new(),
             state_obs,
+            _shortcut_obs: shortcut_obs,
         }
     }
 }
@@ -70,7 +81,9 @@ impl Focusable for ActionRingPanel {
 impl Render for ActionRingPanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
-        let (ring, layout) = action_ring_editor_state(cx);
+        let ring = AppState::try_read(cx)
+            .map(AppState::current_action_ring)
+            .unwrap_or_default();
         let haptics_supported = current_device_supports_haptics(cx);
         let application_input = editor_input(
             &mut self.application_input,
@@ -78,12 +91,13 @@ impl Render for ActionRingPanel {
             window,
             cx,
         );
-        let shortcut_input = editor_input(
-            &mut self.shortcut_input,
-            tr!("Shortcut, e.g. Cmd+Shift+P"),
-            window,
-            cx,
-        );
+        let shortcut_input = {
+            let capture = self.shortcut_input.clone();
+            capture.update(cx, |capture, cx| {
+                capture.set_placeholder(tr!("Press a shortcut"), cx);
+            });
+            capture
+        };
         let view = cx.entity();
 
         v_flex()
@@ -108,10 +122,10 @@ impl Render for ActionRingPanel {
                     .items_start()
                     .justify_center()
                     .gap_4()
-                    .child(ring_preview(&layout, self.selected_slot, &view, pal))
+                    .child(ring_preview(&ring.default, self.selected_slot, &view, pal))
                     .child(action_library(
                         self.selected_slot,
-                        layout.slots.get(&self.selected_slot),
+                        ring.default.slots.get(&self.selected_slot),
                         &application_input,
                         &shortcut_input,
                         &self.library_scroll,
@@ -167,21 +181,6 @@ impl Render for ActionRingPanel {
                 )
             })
     }
-}
-
-fn action_ring_editor_state(cx: &Context<ActionRingPanel>) -> (ActionRingConfig, ActionRingLayout) {
-    AppState::try_read(cx).map_or_else(
-        || {
-            let ring = ActionRingConfig::default();
-            let layout = ring.default.clone();
-            (ring, layout)
-        },
-        |state| {
-            let ring = state.current_action_ring();
-            let layout = state.current_action_ring_layout();
-            (ring, layout)
-        },
-    )
 }
 
 fn editor_input(

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -14,7 +14,8 @@ use gpui_component::{
     v_flex,
 };
 use openlogi_core::binding::{
-    Action, ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot, KeyCombo,
+    Action, ActionRingConfig, ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot,
+    KeyCombo,
 };
 use openlogi_ui::action_icons::RING_CANCEL_ICON;
 
@@ -81,9 +82,7 @@ impl Focusable for ActionRingPanel {
 impl Render for ActionRingPanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
-        let ring = AppState::try_read(cx)
-            .map(AppState::current_action_ring)
-            .unwrap_or_default();
+        let (ring, layout) = action_ring_editor_state(cx);
         let haptics_supported = current_device_supports_haptics(cx);
         let application_input = editor_input(
             &mut self.application_input,
@@ -122,10 +121,10 @@ impl Render for ActionRingPanel {
                     .items_start()
                     .justify_center()
                     .gap_4()
-                    .child(ring_preview(&ring.default, self.selected_slot, &view, pal))
+                    .child(ring_preview(&layout, self.selected_slot, &view, pal))
                     .child(action_library(
                         self.selected_slot,
-                        ring.default.slots.get(&self.selected_slot),
+                        layout.slots.get(&self.selected_slot),
                         &application_input,
                         &shortcut_input,
                         &self.library_scroll,
@@ -181,6 +180,21 @@ impl Render for ActionRingPanel {
                 )
             })
     }
+}
+
+fn action_ring_editor_state(cx: &Context<ActionRingPanel>) -> (ActionRingConfig, ActionRingLayout) {
+    AppState::try_read(cx).map_or_else(
+        || {
+            let ring = ActionRingConfig::default();
+            let layout = ring.default.clone();
+            (ring, layout)
+        },
+        |state| {
+            let ring = state.current_action_ring();
+            let layout = state.current_action_ring_layout();
+            (ring, layout)
+        },
+    )
 }
 
 fn editor_input(

--- a/crates/openlogi-desktop/src/features/action_ring/editor.rs
+++ b/crates/openlogi-desktop/src/features/action_ring/editor.rs
@@ -9,7 +9,7 @@ use gpui_component::{
     scroll::ScrollableElement as _, v_flex,
 };
 use openlogi_core::binding::{
-    Action, ActionRingEntry, ActionRingIcon, ActionRingSlot, ApplicationTarget, Category, KeyCombo,
+    Action, ActionRingEntry, ActionRingIcon, ActionRingSlot, ApplicationTarget, Category,
     RingAction,
 };
 
@@ -18,13 +18,14 @@ use crate::features::mouse::picker::editor_section;
 use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::action::localized_action_label;
 use crate::ui::components::{MenuRow, control_input};
+use crate::ui::shortcut_capture::ShortcutCapture;
 use crate::ui::theme::{self, Palette, Typography as _};
 
 pub(super) fn action_library(
     slot: ActionRingSlot,
     current: Option<&ActionRingEntry>,
     application_input: &Entity<InputState>,
-    shortcut_input: &Entity<InputState>,
+    shortcut_input: &Entity<ShortcutCapture>,
     library_scroll: &ScrollHandle,
     pal: Palette,
 ) -> impl IntoElement {
@@ -80,7 +81,7 @@ pub(super) fn action_library(
                         pal,
                     ))
                 })
-                .child(shortcut_editor(slot, shortcut_input, pal))
+                .child(shortcut_editor(shortcut_input, pal))
                 .child(path_editor(slot, application_input, pal))
                 .children(action_sections(slot, current_action.as_ref(), pal)),
             library_scroll,
@@ -152,36 +153,11 @@ fn icon_button(
         .tooltip(label)
 }
 
-fn shortcut_editor(
-    slot: ActionRingSlot,
-    input: &Entity<InputState>,
-    pal: Palette,
-) -> impl IntoElement {
-    let submit_input = input.clone();
+fn shortcut_editor(capture: &Entity<ShortcutCapture>, pal: Palette) -> impl IntoElement {
     v_flex()
         .gap_1()
         .child(editor_section(tr!("Custom shortcut"), pal))
-        .child(
-            h_flex()
-                .gap_2()
-                .child(
-                    div()
-                        .flex_1()
-                        .min_w_0()
-                        .child(control_input(input).cleanable(true)),
-                )
-                .child(
-                    Button::new("ring-add-shortcut")
-                        .compact()
-                        .label(tr!("Add"))
-                        .on_click(move |_, _, cx| {
-                            let shortcut = submit_input.read(cx).value().to_string();
-                            if let Ok(combo) = shortcut.parse::<KeyCombo>() {
-                                commit_action(slot, Action::CustomShortcut(combo), cx);
-                            }
-                        }),
-                ),
-        )
+        .child(capture.clone())
 }
 
 fn path_editor(slot: ActionRingSlot, input: &Entity<InputState>, pal: Palette) -> impl IntoElement {
@@ -278,7 +254,7 @@ fn ring_catalog() -> Vec<(Category, Vec<Action>)> {
     sections
 }
 
-fn commit_action(slot: ActionRingSlot, action: Action, cx: &mut gpui::App) {
+pub(super) fn commit_action(slot: ActionRingSlot, action: Action, cx: &mut gpui::App) {
     let Ok(action) = RingAction::new(action) else {
         return;
     };

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -24,6 +24,7 @@ use super::view::MouseModelView;
 use crate::state::AppState;
 use crate::ui::action::localized_action_label;
 use crate::ui::components::{MenuRow, control_button, control_input};
+use crate::ui::shortcut_capture::ShortcutCapture;
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 
 pub(super) const INSPECTOR_W: f32 = 328.;
@@ -43,12 +44,14 @@ pub(super) struct BindingInspectorData<'a> {
 struct ActionPickerContext<'a> {
     open: bool,
     search: &'a Entity<InputState>,
+    shortcut: &'a Entity<ShortcutCapture>,
     view: &'a Entity<MouseModelView>,
 }
 
 pub(super) fn binding_inspector(
     data: BindingInspectorData<'_>,
     action_search: &Entity<InputState>,
+    shortcut_input: &Entity<ShortcutCapture>,
     view: &Entity<MouseModelView>,
     cx: &Context<MouseModelView>,
 ) -> gpui::Div {
@@ -56,6 +59,7 @@ pub(super) fn binding_inspector(
     let picker = ActionPickerContext {
         open: data.action_picker_open,
         search: action_search,
+        shortcut: shortcut_input,
         view,
     };
     let body = match data.selected {
@@ -212,6 +216,7 @@ fn button_inspector(
                 "inspector-action",
                 Some(&action),
                 picker.search,
+                picker.shortcut,
                 &on_pick,
                 pal,
                 cx,
@@ -265,6 +270,7 @@ fn inherited_gesture_inspector(
                 "inspector-gesture-override",
                 None,
                 picker.search,
+                picker.shortcut,
                 &on_pick,
                 pal,
                 cx,
@@ -328,6 +334,7 @@ fn gesture_inspector(
                 "inspector-gesture-action",
                 Some(&current),
                 picker.search,
+                picker.shortcut,
                 &on_pick,
                 pal,
                 cx,
@@ -620,6 +627,7 @@ fn action_library(
     id_prefix: &'static str,
     current: Option<&Action>,
     action_search: &Entity<InputState>,
+    shortcut_input: &Entity<ShortcutCapture>,
     on_pick: &PickFn,
     pal: Palette,
     cx: &Context<MouseModelView>,
@@ -629,6 +637,7 @@ fn action_library(
     v_flex()
         .gap_2()
         .pt_1()
+        .child(shortcut_editor(shortcut_input, pal))
         .child(editor_section(tr!("Actions"), pal))
         .child(control_input(action_search).cleanable(true))
         .child(
@@ -645,6 +654,13 @@ fn action_library(
                 })
                 .children(rows),
         )
+}
+
+fn shortcut_editor(capture: &Entity<ShortcutCapture>, pal: Palette) -> impl IntoElement {
+    v_flex()
+        .gap_1()
+        .child(editor_section(tr!("Custom shortcut"), pal))
+        .child(capture.clone())
 }
 
 fn gesture_action(

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use gpui::{
@@ -9,15 +10,16 @@ use gpui::{
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
-    Icon, IconName, h_flex,
+    Icon, IconName, Selectable as _, h_flex,
     input::{InputEvent, InputState},
     v_flex,
 };
-use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
+use openlogi_core::binding::{Action, ButtonId, GestureDirection, KeyCombo, default_binding};
 
 use super::geometry::{
-    LABEL_H, LabelDistribution, asset_dimensions_for_png, asset_has_button_labels,
-    asset_hotspots_for_png, default_labels, labels_from_hotspots,
+    LABEL_H, LabelDistribution, asset_dimensions, asset_dimensions_for_png,
+    asset_has_button_labels, asset_hotspots_for_image, asset_hotspots_for_png, default_labels,
+    labels_from_hotspots,
 };
 use super::hotspots::{Hotspot, MOUSE_MODEL_SIZE, MouseControlId, default_hotspots};
 use super::inspector::{BindingInspectorData, binding_inspector};
@@ -25,10 +27,12 @@ use super::leader_lines::{Geometry as LeaderGeometry, Label, Side, paint as pain
 use super::picker::{GESTURE_BUTTON_ICON, action_icon_path};
 use super::thumbwheel::ThumbwheelPreset;
 use crate::app::{glow_canvas, keyboard_glow};
-use crate::features::profiles::{friendly_app_name, profile_canvas_status};
+use crate::features::profile_scope::{friendly_app_name, profile_canvas_status};
 use crate::services::assets::{GlowGeometry, ResolvedAsset};
 use crate::state::{AppState, StateEvent};
 use crate::ui::action::localized_action_label;
+use crate::ui::components::control_button;
+use crate::ui::shortcut_capture::ShortcutCapture;
 use crate::ui::theme::{self, ACCENT_BLUE, Typography as _};
 
 const SIDE_GAP: f32 = 24.;
@@ -126,7 +130,11 @@ pub struct MouseModelView {
     gesture_active_dir: Option<GestureDirection>,
     action_picker_open: bool,
     action_search: Entity<InputState>,
+    shortcut_input: Entity<ShortcutCapture>,
+    /// G-series depots split thumb buttons onto `device_side`.
+    show_side: bool,
     _state_obs: Subscription,
+    _shortcut_obs: Subscription,
 }
 
 impl MouseModelView {
@@ -140,6 +148,10 @@ impl MouseModelView {
             }
         })
         .detach();
+        let shortcut_input = cx.new(|cx| ShortcutCapture::new("inspector-shortcut-capture", cx));
+        let shortcut_obs = cx.subscribe(&shortcut_input, |this, _, combo: &KeyCombo, cx| {
+            this.apply_custom_shortcut(combo.clone(), cx);
+        });
         let state = AppState::global(cx);
         let state_obs = cx.subscribe(&state, |_view, _, event: &StateEvent, cx| {
             let relevant = match event {
@@ -165,7 +177,10 @@ impl MouseModelView {
             gesture_active_dir: None,
             action_picker_open: false,
             action_search,
+            shortcut_input,
+            show_side: false,
             _state_obs: state_obs,
+            _shortcut_obs: shortcut_obs,
         }
     }
 
@@ -184,6 +199,22 @@ impl MouseModelView {
         self.action_picker_open = false;
     }
 
+    fn apply_custom_shortcut(&mut self, combo: KeyCombo, cx: &mut Context<Self>) {
+        let Some(MouseControlId::Button(button)) = self.selected else {
+            return;
+        };
+        let action = Action::CustomShortcut(combo);
+        AppState::update_bindings(cx, |state| {
+            if let Some(direction) = self.gesture_active_dir {
+                state.commit_gesture_binding(button, direction, action);
+            } else {
+                state.commit_binding(button, action);
+            }
+        });
+        self.close_action_picker();
+        cx.notify();
+    }
+
     fn reset_for_device(&mut self, device_key: Option<&str>) {
         if self.current_device_key.as_deref() == device_key {
             return;
@@ -193,6 +224,7 @@ impl MouseModelView {
         self.selected = None;
         self.gesture_active_dir = None;
         self.action_picker_open = false;
+        self.show_side = false;
     }
 
     fn select(&mut self, control: MouseControlId) {
@@ -227,6 +259,10 @@ fn set_control_hovered(
 }
 
 impl Render for MouseModelView {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one screen: model canvas, optional Top/Side toggle, inspector"
+    )]
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         crate::ui::components::localize_placeholder(
             &self.action_search,
@@ -234,6 +270,9 @@ impl Render for MouseModelView {
             window,
             cx,
         );
+        self.shortcut_input.update(cx, |capture, cx| {
+            capture.set_placeholder(tr!("Press a shortcut"), cx);
+        });
         let (empty_bindings, empty_gesture_maps) = (BTreeMap::new(), BTreeMap::new());
         let MouseWorkspaceData {
             device_key,
@@ -268,7 +307,7 @@ impl Render for MouseModelView {
             mouse_h,
             hotspots,
             labels,
-        } = model_layout(asset, viewport_w, viewport_h, thumbwheel);
+        } = model_layout(asset, viewport_w, viewport_h, thumbwheel, self.show_side);
         let canvas_h = mouse_h;
 
         let highlight = self.hovered.or(active).or(self.selected);
@@ -279,7 +318,8 @@ impl Render for MouseModelView {
         let hotspots_outer = hotspots.clone();
         let labels_outer = labels.clone();
         let leader_canvas = leader_canvas(hotspots, labels, highlight, mouse_left, mouse_w);
-        let breathing_art = breathing_art(asset, mouse_left, mouse_w, mouse_h, glow);
+        let breathing_art =
+            breathing_art(asset, mouse_left, mouse_w, mouse_h, glow, self.show_side);
         let model = ModelRect {
             left: mouse_left,
             width: mouse_w,
@@ -313,6 +353,14 @@ impl Render for MouseModelView {
             }))
             .child(hotspots_layer);
 
+        let has_side = asset.is_some_and(has_g_series_side);
+        let show_side = self.show_side;
+        let canvas_stack = v_flex()
+            .items_center()
+            .gap_2()
+            .when(has_side, |this| this.child(view_toggle(show_side, &view)))
+            .child(canvas);
+
         let inspector = binding_inspector(
             BindingInspectorData {
                 selected: self.selected,
@@ -324,10 +372,11 @@ impl Render for MouseModelView {
                 overridden,
             },
             &self.action_search,
+            &self.shortcut_input,
             &view,
             cx,
         );
-        workspace_layout(canvas, profile_status, inspector, &self.focus_handle)
+        workspace_layout(canvas_stack, profile_status, inspector, &self.focus_handle)
     }
 }
 
@@ -384,6 +433,7 @@ fn model_layout(
     viewport_w: f32,
     viewport_h: f32,
     thumbwheel: bool,
+    show_side: bool,
 ) -> ModelLayout {
     let target_h = (viewport_h - MODEL_VERTICAL_RESERVE).clamp(MODEL_MIN_H, MOUSE_MODEL_SIZE.1);
     let has_labels = asset.is_none_or(asset_has_button_labels) && viewport_w >= 960.;
@@ -401,8 +451,14 @@ fn model_layout(
         0.
     };
     let max_image_w = (content_w - left_gutter - right_gutter).max(MODEL_MIN_CONTENT_W / 2.);
-    let (mouse_w, mouse_h, hotspots, mut labels) =
-        scaled_model(asset, target_h, max_image_w, thumbwheel, label_distribution);
+    let (mouse_w, mouse_h, hotspots, mut labels) = scaled_model(
+        asset,
+        target_h,
+        max_image_w,
+        thumbwheel,
+        label_distribution,
+        show_side,
+    );
     if !has_labels {
         labels.clear();
     }
@@ -427,10 +483,19 @@ fn scaled_model(
     max_w: f32,
     thumbwheel: bool,
     label_distribution: LabelDistribution,
+    show_side: bool,
 ) -> (f32, f32, Vec<Hotspot>, Vec<Label>) {
     if let Some(a) = asset {
-        let (w, h) = asset_dimensions_for_png(a, target_h, max_w);
-        let hotspots = asset_hotspots_for_png(a, w, h);
+        let side = show_side.then(|| g_series_side_render(a)).flatten();
+        let (w, h, hotspots) = if let Some((_, png_w, png_h)) = side {
+            let (w, h) = asset_dimensions(png_w, png_h, target_h, max_w);
+            let hotspots = asset_hotspots_for_image(a, w, h, "device_side", png_w, png_h);
+            (w, h, hotspots)
+        } else {
+            let (w, h) = asset_dimensions_for_png(a, target_h, max_w);
+            let hotspots = asset_hotspots_for_png(a, w, h);
+            (w, h, hotspots)
+        };
         let labels = labels_from_hotspots(&hotspots, h, label_distribution);
         (w, h, hotspots, labels)
     } else {
@@ -495,12 +560,17 @@ fn breathing_art(
     mouse_w: f32,
     mouse_h: f32,
     glow: Option<(Arc<GlowGeometry>, Hsla)>,
+    show_side: bool,
 ) -> impl IntoElement {
     let device_art: AnyElement = match asset {
-        Some(a) => img(a.image_path.clone())
-            .w(px(mouse_w))
-            .h(px(mouse_h))
-            .into_any_element(),
+        Some(a) => {
+            let path = if show_side {
+                g_series_side_render(a).map_or_else(|| a.image_path.clone(), |(path, _, _)| path)
+            } else {
+                a.image_path.clone()
+            };
+            img(path).w(px(mouse_w)).h(px(mouse_h)).into_any_element()
+        }
         None => Silhouette {
             w: mouse_w,
             h: mouse_h,
@@ -521,6 +591,58 @@ fn breathing_art(
             this.child(glow_canvas(geom, color))
         })
         .child(device_art)
+}
+
+fn has_g_series_side(asset: &ResolvedAsset) -> bool {
+    g_series_side_render(asset).is_some()
+}
+
+fn g_series_side_render(asset: &ResolvedAsset) -> Option<(PathBuf, u32, u32)> {
+    asset.metadata.assignments_on("device_side").next()?;
+    if let Some(path) = asset.side_image_path.as_ref()
+        && let Ok((width, height)) = crate::services::assets::read_png_dimensions(path)
+    {
+        return Some((path.clone(), width, height));
+    }
+    let parent = asset.image_path.parent()?;
+    for name in ["side_spectrum.png", "side_core.png", "side.png"] {
+        let path = parent.join(name);
+        if path.exists()
+            && let Ok((width, height)) = crate::services::assets::read_png_dimensions(&path)
+        {
+            return Some((path, width, height));
+        }
+    }
+    None
+}
+
+fn view_toggle(show_side: bool, view: &Entity<MouseModelView>) -> impl IntoElement {
+    let front_view = view.clone();
+    let side_view = view.clone();
+    h_flex()
+        .gap_1()
+        .child(
+            control_button("mouse-view-top")
+                .label(tr!("Top"))
+                .selected(!show_side)
+                .on_click(move |_, _, cx| {
+                    front_view.update(cx, |this, cx| {
+                        this.show_side = false;
+                        cx.notify();
+                    });
+                }),
+        )
+        .child(
+            control_button("mouse-view-side")
+                .label(tr!("Side"))
+                .selected(show_side)
+                .on_click(move |_, _, cx| {
+                    side_view.update(cx, |this, cx| {
+                        this.show_side = true;
+                        cx.notify();
+                    });
+                }),
+        )
 }
 
 #[derive(Clone, Copy)]
@@ -975,6 +1097,7 @@ mod tests {
                     overridden: None,
                 },
                 &view.action_search,
+                &view.shortcut_input,
                 &entity,
                 cx,
             );
@@ -1019,8 +1142,10 @@ mod tests {
 
     #[test]
     fn fallback_model_only_adds_thumbwheel_when_capability_is_measured() {
-        let (_, _, without, _) = scaled_model(None, 560., 420., false, LabelDistribution::LeftOnly);
-        let (_, _, with, _) = scaled_model(None, 560., 420., true, LabelDistribution::LeftOnly);
+        let (_, _, without, _) =
+            scaled_model(None, 560., 420., false, LabelDistribution::LeftOnly, false);
+        let (_, _, with, _) =
+            scaled_model(None, 560., 420., true, LabelDistribution::LeftOnly, false);
         assert_eq!(
             without
                 .iter()

--- a/crates/openlogi-desktop/src/ui/gallery.rs
+++ b/crates/openlogi-desktop/src/ui/gallery.rs
@@ -1,8 +1,8 @@
 //! Debug-only gallery for reviewing shared controls without app runtime state.
 
 use gpui::{
-    App, AppContext as _, Bounds, Context, InteractiveElement, IntoElement, ParentElement, Render,
-    Role, SharedString, Size, Styled, Window, WindowBounds, WindowOptions, div, px, rems,
+    App, AppContext as _, Bounds, Context, Entity, InteractiveElement, IntoElement, ParentElement,
+    Render, Role, SharedString, Size, Styled, Window, WindowBounds, WindowOptions, div, px, rems,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -21,6 +21,7 @@ use super::battery::BatteryIndicator;
 use super::carousel::Carousel;
 use super::choice_card::ChoiceCard;
 use super::components::{MenuRow, PanelCard, PresetChip, ProfileTab, Toggle};
+use super::shortcut_capture::ShortcutCapture;
 use super::theme::{self, ContentWidth, OPENLOGI_DARK, OPENLOGI_LIGHT, Palette, Typography as _};
 
 const TITLE: &str = "OpenLogi Component Gallery";
@@ -94,10 +95,11 @@ struct ComponentGallery {
     profile_selected: usize,
     preset_selected: bool,
     carousel_selected: usize,
+    shortcut: Entity<ShortcutCapture>,
 }
 
 impl ComponentGallery {
-    fn new(_: &mut Context<Self>) -> Self {
+    fn new(cx: &mut Context<Self>) -> Self {
         Self {
             mode: ThemeMode::Light,
             scale: UiScale::Normal,
@@ -107,6 +109,11 @@ impl ComponentGallery {
             profile_selected: 1,
             preset_selected: true,
             carousel_selected: 1,
+            shortcut: cx.new(|cx| {
+                let mut capture = ShortcutCapture::new("gallery-shortcut-capture", cx);
+                capture.set_placeholder("Press a shortcut".into(), cx);
+                capture
+            }),
         }
     }
 
@@ -187,6 +194,7 @@ impl ComponentGallery {
             .child(self.profile_panel(pal, cx))
             .child(self.preset_panel(pal, cx))
             .child(Self::battery_panel(pal))
+            .child(self.shortcut_panel(pal))
     }
 
     fn choice_panel(&self, pal: Palette, cx: &mut Context<Self>) -> gpui::Div {
@@ -381,6 +389,15 @@ impl ComponentGallery {
                     BatteryLevel::Unknown,
                     BatteryStatus::Error,
                 ))),
+            pal,
+        )
+    }
+
+    fn shortcut_panel(&self, pal: Palette) -> gpui::Div {
+        gallery_panel(
+            "ShortcutCapture",
+            IconName::Settings,
+            v_flex().gap_2().w_full().child(self.shortcut.clone()),
             pal,
         )
     }

--- a/crates/openlogi-desktop/src/ui/mod.rs
+++ b/crates/openlogi-desktop/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod components;
 #[cfg(debug_assertions)]
 pub(crate) mod gallery;
 pub mod section;
+pub(crate) mod shortcut_capture;
 pub mod spacing;
 pub mod status;
 pub mod theme;

--- a/crates/openlogi-desktop/src/ui/shortcut_capture.rs
+++ b/crates/openlogi-desktop/src/ui/shortcut_capture.rs
@@ -1,0 +1,203 @@
+//! Keystroke recorder for custom keyboard shortcuts.
+//!
+//! A text field cannot tell Home from a cursor-motion, or AZERTY `-` (the 6
+//! key) from the minus key or the numpad. This control intercepts GPUI
+//! keystrokes before keymap bindings and maps them to [`KeyCombo`] HID usages.
+//! Numpad digits are distinguished from main-row digits by a vendored GPUI
+//! patch (`vendor/gpui/`) that keeps `kp*` key names.
+
+use gpui::{
+    App, Context, ElementId, EventEmitter, FocusHandle, Focusable, InteractiveElement, IntoElement,
+    Keystroke, KeystrokeEvent, ParentElement as _, Render, Role, SharedString,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, div, px, rgb,
+};
+use openlogi_core::binding::{CapturedKeystroke, KeyCombo};
+
+use super::theme::{self, ACCENT_BLUE, CONTROL_H, Typography as _};
+
+/// Focusable control that records one keyboard chord.
+pub(crate) struct ShortcutCapture {
+    focus_handle: FocusHandle,
+    id: ElementId,
+    placeholder: SharedString,
+    combo: Option<KeyCombo>,
+    _intercept: Subscription,
+}
+
+impl ShortcutCapture {
+    pub(crate) fn new(id: impl Into<ElementId>, cx: &mut Context<Self>) -> Self {
+        let focus_handle = cx.focus_handle();
+        let listener = cx.listener(|this, event: &KeystrokeEvent, window, cx| {
+            if !this.focus_handle.is_focused(window) {
+                return;
+            }
+            this.record(&event.keystroke, window, cx);
+        });
+        let intercept = cx.intercept_keystrokes(listener);
+        Self {
+            focus_handle,
+            id: id.into(),
+            placeholder: SharedString::default(),
+            combo: None,
+            _intercept: intercept,
+        }
+    }
+
+    pub(crate) fn set_placeholder(&mut self, placeholder: SharedString, cx: &mut Context<Self>) {
+        if self.placeholder != placeholder {
+            self.placeholder = placeholder;
+            cx.notify();
+        }
+    }
+
+    fn record(&mut self, keystroke: &Keystroke, window: &mut Window, cx: &mut Context<Self>) {
+        cx.stop_propagation();
+        window.prevent_default();
+        let Some(combo) = KeyCombo::from_captured(
+            CapturedKeystroke::new(&keystroke.key, cx.keyboard_layout().name())
+                .command(keystroke.modifiers.platform)
+                .shift(keystroke.modifiers.shift)
+                .control(keystroke.modifiers.control)
+                .option(keystroke.modifiers.alt),
+        ) else {
+            return;
+        };
+        self.combo = Some(combo.clone());
+        cx.emit(combo);
+        cx.notify();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn combo(&self) -> Option<&KeyCombo> {
+        self.combo.as_ref()
+    }
+}
+
+impl EventEmitter<KeyCombo> for ShortcutCapture {}
+
+impl Focusable for ShortcutCapture {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for ShortcutCapture {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        let focused = self.focus_handle.is_focused(window);
+        let (label, muted) = self.combo.as_ref().map_or_else(
+            || (self.placeholder.to_string(), true),
+            |combo| (combo.rendered_label(), false),
+        );
+        div()
+            .id(self.id.clone())
+            .track_focus(&self.focus_handle)
+            .tab_index(0)
+            .role(Role::TextInput)
+            .flex()
+            .w_full()
+            .min_w_0()
+            .h(px(CONTROL_H))
+            .min_h(px(CONTROL_H))
+            .px_2()
+            .items_center()
+            .rounded(pal.control_radius)
+            .border_1()
+            .border_color(if focused {
+                rgb(ACCENT_BLUE).into()
+            } else {
+                pal.border
+            })
+            .bg(pal.control)
+            .hover(move |style| style.bg(pal.control_hover))
+            .on_click(cx.listener(|this, _, window, cx| {
+                this.focus_handle.focus(window, cx);
+            }))
+            .child(
+                div()
+                    .w_full()
+                    .min_w_0()
+                    .overflow_hidden()
+                    .text_body()
+                    .text_color(if muted {
+                        pal.text_muted
+                    } else {
+                        pal.text_primary
+                    })
+                    .child(label),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::{
+        AppContext as _, Context, KeyDownEvent, Keystroke, Render, TestAppContext, Window, div, px,
+    };
+
+    use super::*;
+
+    struct Harness {
+        capture: gpui::Entity<ShortcutCapture>,
+    }
+
+    impl Render for Harness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .id("shortcut-capture-harness")
+                .tab_group()
+                .size(px(200.))
+                .child(self.capture.clone())
+        }
+    }
+
+    #[gpui::test]
+    fn home_and_keypad_minus_are_recorded_as_named_keys(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let (view, cx) = cx.add_window_view(|_, cx| Harness {
+            capture: cx.new(|cx| ShortcutCapture::new("test-shortcut-capture", cx)),
+        });
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+        });
+        cx.update(|window, cx| {
+            view.read(cx).capture.focus_handle(cx).focus(window, cx);
+        });
+        cx.update(|window, cx| {
+            assert!(
+                window.focused(cx).is_some(),
+                "shortcut capture must be focused to intercept keys"
+            );
+        });
+
+        let home = Keystroke::parse("home").expect("GPUI names Home");
+        cx.simulate_event(KeyDownEvent {
+            keystroke: home,
+            is_held: false,
+            prefer_character_input: false,
+        });
+        view.update(cx, |view, cx| {
+            assert_eq!(
+                view.capture.read(cx).combo().map(KeyCombo::rendered_label),
+                Some("Home".to_string())
+            );
+        });
+
+        let subtract = Keystroke::parse("subtract").expect("GPUI names keypad minus");
+        cx.simulate_event(KeyDownEvent {
+            keystroke: subtract,
+            is_held: false,
+            prefer_character_input: false,
+        });
+        view.update(cx, |view, cx| {
+            assert_eq!(
+                view.capture.read(cx).combo().map(KeyCombo::rendered_label),
+                Some("KpMinus".to_string())
+            );
+        });
+
+        drop(view);
+        cx.update(|window, _| window.remove_window());
+        cx.run_until_parked();
+    }
+}

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -511,6 +511,16 @@ fn hid_usage_to_windows(usage: u8) -> Option<u16> {
     }
 }
 
+/// Whether a HID keyboard usage needs `KEYEVENTF_EXTENDEDKEY` on Windows.
+#[cfg_attr(
+    not(target_os = "windows"),
+    expect(clippy::allow_attributes, reason = "see hid_usage_to_windows"),
+    allow(dead_code, reason = "called only by the Windows backend")
+)]
+fn hid_usage_extended_key(usage: u8) -> bool {
+    usage == 0x58
+}
+
 #[cfg(test)]
 mod tests {
     use openlogi_core::scroll::ScrollDelta;
@@ -687,7 +697,7 @@ mod tests {
 
     #[test]
     fn hid_usages_map_across_windows_key_categories() {
-        use super::hid_usage_to_windows;
+        use super::{hid_usage_extended_key, hid_usage_to_windows};
 
         assert_eq!(hid_usage_to_windows(0x04), Some(0x41)); // A
         assert_eq!(hid_usage_to_windows(0x1e), Some(0x31)); // 1
@@ -698,6 +708,8 @@ mod tests {
         assert_eq!(hid_usage_to_windows(0x33), Some(0xba)); // Semicolon
         assert_eq!(hid_usage_to_windows(0x49), Some(0x2d)); // Insert
         assert_eq!(hid_usage_to_windows(0x56), Some(0x6d)); // Numpad subtract
+        assert!(!hid_usage_extended_key(0x28)); // Main Enter
+        assert!(hid_usage_extended_key(0x58)); // Numpad Enter
         assert_eq!(hid_usage_to_windows(0xff), None);
     }
 }

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -468,13 +468,13 @@ fn hid_usage_to_windows(usage: u8) -> Option<u16> {
         0x27 => Some(u16::from(b'0')),
         0x3a..=0x45 => Some(0x70 + u16::from(usage - 0x3a)),
         0x68..=0x6f => Some(0x7c + u16::from(usage - 0x68)),
-        0x28 => Some(0x0d),
+        0x28 | 0x58 => Some(0x0d),
         0x29 => Some(0x1b),
         0x2a => Some(0x08),
         0x2b => Some(0x09),
         0x2c => Some(0x20),
         0x2d => Some(0xbd),
-        0x2e => Some(0xbb),
+        0x2e | 0x67 => Some(0xbb),
         0x2f => Some(0xdb),
         0x30 => Some(0xdd),
         0x31 => Some(0xdc),
@@ -484,6 +484,11 @@ fn hid_usage_to_windows(usage: u8) -> Option<u16> {
         0x36 => Some(0xbc),
         0x37 => Some(0xbe),
         0x38 => Some(0xbf),
+        0x39 => Some(0x14),
+        0x46 => Some(0x2c),
+        0x47 => Some(0x91),
+        0x48 => Some(0x13),
+        0x49 => Some(0x2d),
         0x4a => Some(0x24),
         0x4b => Some(0x21),
         0x4c => Some(0x2e),
@@ -493,6 +498,15 @@ fn hid_usage_to_windows(usage: u8) -> Option<u16> {
         0x50 => Some(0x25),
         0x51 => Some(0x28),
         0x52 => Some(0x26),
+        0x53 => Some(0x90),
+        0x54 => Some(0x6f),
+        0x55 => Some(0x6a),
+        0x56 => Some(0x6d),
+        0x57 => Some(0x6b),
+        0x59..=0x61 => Some(0x61 + u16::from(usage - 0x59)),
+        0x62 => Some(0x60),
+        0x63 => Some(0x6e),
+        0x65 => Some(0x5d),
         _ => None,
     }
 }
@@ -682,6 +696,8 @@ mod tests {
         assert_eq!(hid_usage_to_windows(0x50), Some(0x25)); // Left
         assert_eq!(hid_usage_to_windows(0x2c), Some(0x20)); // Space
         assert_eq!(hid_usage_to_windows(0x33), Some(0xba)); // Semicolon
+        assert_eq!(hid_usage_to_windows(0x49), Some(0x2d)); // Insert
+        assert_eq!(hid_usage_to_windows(0x56), Some(0x6d)); // Numpad subtract
         assert_eq!(hid_usage_to_windows(0xff), None);
     }
 }

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -493,6 +493,10 @@ fn held_keycode(key: HeldKey) -> Option<KeyCode> {
 
 /// Map a platform-neutral USB HID keyboard usage to evdev.
 fn hid_usage_to_linux(usage: u8) -> Option<KeyCode> {
+    hid_linux_letter_digit_fn(usage).or_else(|| hid_linux_named(usage))
+}
+
+fn hid_linux_letter_digit_fn(usage: u8) -> Option<KeyCode> {
     const LETTERS: [KeyCode; 26] = [
         KeyCode::KEY_A,
         KeyCode::KEY_B,
@@ -560,6 +564,23 @@ fn hid_usage_to_linux(usage: u8) -> Option<KeyCode> {
         0x1e..=0x27 => DIGITS.get(usize::from(usage - 0x1e)).copied(),
         0x3a..=0x45 => FUNCTIONS.get(usize::from(usage - 0x3a)).copied(),
         0x68..=0x6f => FUNCTIONS.get(usize::from(usage - 0x68 + 12)).copied(),
+        _ => None,
+    }
+}
+
+fn hid_linux_named(usage: u8) -> Option<KeyCode> {
+    const KEYPAD_1_9: [KeyCode; 9] = [
+        KeyCode::KEY_KP1,
+        KeyCode::KEY_KP2,
+        KeyCode::KEY_KP3,
+        KeyCode::KEY_KP4,
+        KeyCode::KEY_KP5,
+        KeyCode::KEY_KP6,
+        KeyCode::KEY_KP7,
+        KeyCode::KEY_KP8,
+        KeyCode::KEY_KP9,
+    ];
+    match usage {
         0x28 => Some(KeyCode::KEY_ENTER),
         0x29 => Some(KeyCode::KEY_ESC),
         0x2a => Some(KeyCode::KEY_BACKSPACE),
@@ -576,6 +597,11 @@ fn hid_usage_to_linux(usage: u8) -> Option<KeyCode> {
         0x36 => Some(KeyCode::KEY_COMMA),
         0x37 => Some(KeyCode::KEY_DOT),
         0x38 => Some(KeyCode::KEY_SLASH),
+        0x39 => Some(KeyCode::KEY_CAPSLOCK),
+        0x46 => Some(KeyCode::KEY_SYSRQ),
+        0x47 => Some(KeyCode::KEY_SCROLLLOCK),
+        0x48 => Some(KeyCode::KEY_PAUSE),
+        0x49 => Some(KeyCode::KEY_INSERT),
         0x4a => Some(KeyCode::KEY_HOME),
         0x4b => Some(KeyCode::KEY_PAGEUP),
         0x4c => Some(KeyCode::KEY_DELETE),
@@ -585,6 +611,17 @@ fn hid_usage_to_linux(usage: u8) -> Option<KeyCode> {
         0x50 => Some(KeyCode::KEY_LEFT),
         0x51 => Some(KeyCode::KEY_DOWN),
         0x52 => Some(KeyCode::KEY_UP),
+        0x53 => Some(KeyCode::KEY_NUMLOCK),
+        0x54 => Some(KeyCode::KEY_KPSLASH),
+        0x55 => Some(KeyCode::KEY_KPASTERISK),
+        0x56 => Some(KeyCode::KEY_KPMINUS),
+        0x57 => Some(KeyCode::KEY_KPPLUS),
+        0x58 => Some(KeyCode::KEY_KPENTER),
+        0x59..=0x61 => KEYPAD_1_9.get(usize::from(usage - 0x59)).copied(),
+        0x62 => Some(KeyCode::KEY_KP0),
+        0x63 => Some(KeyCode::KEY_KPDOT),
+        0x65 => Some(KeyCode::KEY_MENU),
+        0x67 => Some(KeyCode::KEY_KPEQUAL),
         _ => None,
     }
 }
@@ -760,6 +797,8 @@ mod tests {
         assert_eq!(hid_usage_to_linux(0x50), Some(KeyCode::KEY_LEFT));
         assert_eq!(hid_usage_to_linux(0x3a), Some(KeyCode::KEY_F1));
         assert_eq!(hid_usage_to_linux(0x6f), Some(KeyCode::KEY_F20));
+        assert_eq!(hid_usage_to_linux(0x49), Some(KeyCode::KEY_INSERT));
+        assert_eq!(hid_usage_to_linux(0x56), Some(KeyCode::KEY_KPMINUS));
         assert_eq!(hid_usage_to_linux(0xff), None);
     }
 

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -415,6 +415,8 @@ fn hid_usage_to_macos(usage: u8) -> Option<u16> {
         0x36 => Some(0x2b),
         0x37 => Some(0x2f),
         0x38 => Some(0x2c),
+        0x39 => Some(0x39),
+        0x49 => Some(0x72),
         0x4a => Some(0x73),
         0x4b => Some(0x74),
         0x4c => Some(0x75),
@@ -424,6 +426,19 @@ fn hid_usage_to_macos(usage: u8) -> Option<u16> {
         0x50 => Some(0x7b),
         0x51 => Some(0x7d),
         0x52 => Some(0x7e),
+        0x53 => Some(0x47),
+        0x54 => Some(0x4b),
+        0x55 => Some(0x43),
+        0x56 => Some(0x4e),
+        0x57 => Some(0x45),
+        0x58 => Some(0x4c),
+        0x59..=0x61 => {
+            const KEYPAD_1_9: [u16; 9] = [0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5b, 0x5c];
+            KEYPAD_1_9.get(usize::from(usage - 0x59)).copied()
+        }
+        0x62 => Some(0x52),
+        0x63 => Some(0x41),
+        0x67 => Some(0x51),
         _ => None,
     }
 }
@@ -443,6 +458,8 @@ mod tests {
         assert_eq!(hid_usage_to_macos(0x50), Some(0x7b));
         assert_eq!(hid_usage_to_macos(0x3a), Some(0x7a));
         assert_eq!(hid_usage_to_macos(0x6f), Some(0x5a));
+        assert_eq!(hid_usage_to_macos(0x49), Some(0x72));
+        assert_eq!(hid_usage_to_macos(0x56), Some(0x4e));
         assert_eq!(hid_usage_to_macos(0xff), None);
     }
 

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -5,10 +5,10 @@ use std::mem::size_of;
 use std::sync::{LazyLock, Mutex};
 
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
-    INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_KEYUP, MOUSEEVENTF_HWHEEL,
-    MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP,
-    MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL, MOUSEEVENTF_XDOWN,
-    MOUSEEVENTF_XUP, MOUSEINPUT, SendInput,
+    INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP,
+    MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN,
+    MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL,
+    MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, MOUSEINPUT, SendInput,
 };
 
 use openlogi_core::binding::{
@@ -120,7 +120,7 @@ fn parse_shortcut(text: &str) -> KeyCombo {
 fn press_shortcut(shortcut: Shortcut) {
     match combo(shortcut) {
         Ok(combo) => post_custom_shortcut(&combo),
-        Err(vk) => post_key(vk, &[]),
+        Err(vk) => post_key(vk, &[], false),
     }
 }
 
@@ -129,16 +129,16 @@ fn press_shortcut(shortcut: Shortcut) {
 /// synthesis (see the comment below) and is skipped.
 fn dispatch_native(native: NativeAction) {
     match native {
-        NativeAction::MissionControl | NativeAction::AppExpose => post_key(VK_TAB, &[VK_LWIN]),
-        NativeAction::PreviousDesktop => post_key(VK_LEFT, &[VK_LWIN, VK_CONTROL]),
-        NativeAction::NextDesktop => post_key(VK_RIGHT, &[VK_LWIN, VK_CONTROL]),
-        NativeAction::ShowDesktop => post_key(VK_D, &[VK_LWIN]),
-        NativeAction::LaunchpadShow => post_key(VK_LWIN, &[]),
-        NativeAction::LockScreen => post_key(VK_L, &[VK_LWIN]),
+        NativeAction::MissionControl | NativeAction::AppExpose => post_key(VK_TAB, &[VK_LWIN], false),
+        NativeAction::PreviousDesktop => post_key(VK_LEFT, &[VK_LWIN, VK_CONTROL], false),
+        NativeAction::NextDesktop => post_key(VK_RIGHT, &[VK_LWIN, VK_CONTROL], false),
+        NativeAction::ShowDesktop => post_key(VK_D, &[VK_LWIN], false),
+        NativeAction::LaunchpadShow => post_key(VK_LWIN, &[], false),
+        NativeAction::LockScreen => post_key(VK_L, &[VK_LWIN], false),
         // Win+Shift+S opens the snip overlay, which serves both full-screen
         // and region capture on Windows.
         NativeAction::Screenshot | NativeAction::CaptureRegion => {
-            post_key(VK_S, &[VK_LWIN, VK_SHIFT]);
+            post_key(VK_S, &[VK_LWIN, VK_SHIFT], false);
         }
         // Suspending reliably needs `SetSuspendState` (powrprof.dll), which
         // hibernates instead when hibernation is enabled — no clean win from
@@ -151,12 +151,12 @@ fn dispatch_native(native: NativeAction) {
 
 fn dispatch_media(key: MediaKey) {
     match key {
-        MediaKey::PlayPause => post_key(VK_MEDIA_PLAY_PAUSE, &[]),
-        MediaKey::NextTrack => post_key(VK_MEDIA_NEXT_TRACK, &[]),
-        MediaKey::PrevTrack => post_key(VK_MEDIA_PREV_TRACK, &[]),
-        MediaKey::VolumeUp => post_key(VK_VOLUME_UP, &[]),
-        MediaKey::VolumeDown => post_key(VK_VOLUME_DOWN, &[]),
-        MediaKey::Mute => post_key(VK_VOLUME_MUTE, &[]),
+        MediaKey::PlayPause => post_key(VK_MEDIA_PLAY_PAUSE, &[], false),
+        MediaKey::NextTrack => post_key(VK_MEDIA_NEXT_TRACK, &[], false),
+        MediaKey::PrevTrack => post_key(VK_MEDIA_PREV_TRACK, &[], false),
+        MediaKey::VolumeUp => post_key(VK_VOLUME_UP, &[], false),
+        MediaKey::VolumeDown => post_key(VK_VOLUME_DOWN, &[], false),
+        MediaKey::Mute => post_key(VK_VOLUME_MUTE, &[], false),
     }
 }
 
@@ -215,15 +215,15 @@ fn post_click(button: MouseButton) {
     send_inputs(&[mouse_input(down, data), mouse_input(up, data)]);
 }
 
-fn post_key(vk: u16, modifiers: &[u16]) {
+fn post_key(vk: u16, modifiers: &[u16], extended: bool) {
     let mut inputs = Vec::with_capacity(modifiers.len() * 2 + 2);
     for modifier in modifiers {
-        inputs.push(key_input(*modifier, false));
+        inputs.push(key_input(*modifier, false, false));
     }
-    inputs.push(key_input(vk, false));
-    inputs.push(key_input(vk, true));
+    inputs.push(key_input(vk, false, extended));
+    inputs.push(key_input(vk, true, extended));
     for modifier in modifiers.iter().rev() {
-        inputs.push(key_input(*modifier, true));
+        inputs.push(key_input(*modifier, true, false));
     }
     send_inputs(&inputs);
 }
@@ -269,16 +269,21 @@ pub(super) fn post_scroll(delta: ScrollDelta) {
 }
 
 fn post_custom_shortcut(combo: &KeyCombo) {
-    let Some(vk) = super::hid_usage_to_windows(combo.key().code()) else {
+    let usage = combo.key().code();
+    let Some(vk) = super::hid_usage_to_windows(usage) else {
         tracing::warn!(
-            usage = combo.key().code(),
+            usage,
             chord = %combo.rendered_label(),
             "CustomShortcut key has no Windows mapping yet; press ignored"
         );
         return;
     };
 
-    post_key(vk, &combo_modifiers(combo));
+    post_key(
+        vk,
+        &combo_modifiers(combo),
+        super::hid_usage_extended_key(usage),
+    );
 }
 
 fn combo_modifiers(combo: &KeyCombo) -> Vec<u16> {
@@ -305,27 +310,42 @@ pub(super) fn hold_keys(keys: &[HeldKey], phase: KeyPhase) {
         .filter_map(|key| held_virtual_key(*key))
         .collect();
     let key_up = phase == KeyPhase::Up;
-    let mut inputs: Vec<_> = keys.iter().map(|key| key_input(*key, key_up)).collect();
+    let mut inputs: Vec<_> = keys
+        .iter()
+        .map(|key| key_input(key.vk, key_up, key.extended))
+        .collect();
     if key_up {
         inputs.reverse();
     }
     send_inputs(&inputs);
 }
 
-fn held_virtual_key(key: HeldKey) -> Option<u16> {
+struct VirtualKey {
+    vk: u16,
+    extended: bool,
+}
+
+fn held_virtual_key(key: HeldKey) -> Option<VirtualKey> {
     match key {
-        HeldKey::Control => Some(VK_CONTROL),
-        HeldKey::Shift => Some(VK_SHIFT),
-        HeldKey::Alt => Some(VK_MENU),
+        HeldKey::Control => Some(VirtualKey {
+            vk: VK_CONTROL,
+            extended: false,
+        }),
+        HeldKey::Shift => Some(VirtualKey {
+            vk: VK_SHIFT,
+            extended: false,
+        }),
+        HeldKey::Alt => Some(VirtualKey {
+            vk: VK_MENU,
+            extended: false,
+        }),
         HeldKey::Key(usage) => {
-            let key = super::hid_usage_to_windows(usage.code());
-            if key.is_none() {
-                tracing::warn!(
-                    usage = usage.code(),
-                    "held shortcut usage has no Windows mapping — edge ignored"
-                );
-            }
-            key
+            let code = usage.code();
+            let vk = super::hid_usage_to_windows(code)?;
+            Some(VirtualKey {
+                vk,
+                extended: super::hid_usage_extended_key(code),
+            })
         }
     }
 }
@@ -353,10 +373,13 @@ fn send_inputs(inputs: &[INPUT]) {
     }
 }
 
-fn key_input(vk: u16, key_up: bool) -> INPUT {
+fn key_input(vk: u16, key_up: bool, extended: bool) -> INPUT {
     let mut flags = 0;
     if key_up {
         flags |= KEYEVENTF_KEYUP;
+    }
+    if extended {
+        flags |= KEYEVENTF_EXTENDEDKEY;
     }
     INPUT {
         r#type: INPUT_KEYBOARD,

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Farvepalet"
 "Book": "Bog"
 "Custom shortcut": "Brugerdefineret genvej"
-"Shortcut, e.g. Cmd+Shift+P": "Genvej, f.eks. Cmd+Shift+P"
+"Press a shortcut": "Tryk på en genvej"
 "Application, folder path, or URL": "Program, mappesti eller URL"
 "Open application or folder": "Åbn program eller mappe"
 

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Farbpalette"
 "Book": "Buch"
 "Custom shortcut": "Benutzerdefinierter Kurzbefehl"
-"Shortcut, e.g. Cmd+Shift+P": "Tastenkürzel, z. B. Cmd+Shift+P"
+"Press a shortcut": "Tastenkürzel drücken"
 "Application, folder path, or URL": "Anwendung, Ordnerpfad oder URL"
 "Open application or folder": "Anwendung oder Ordner öffnen"
 

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Παλέτα"
 "Book": "Βιβλίο"
 "Custom shortcut": "Προσαρμοσμένη συντόμευση"
-"Shortcut, e.g. Cmd+Shift+P": "Συντόμευση, π.χ. Cmd+Shift+P"
+"Press a shortcut": "Πατήστε μια συντόμευση"
 "Application, folder path, or URL": "Εφαρμογή, διαδρομή φακέλου ή URL"
 "Open application or folder": "Άνοιγμα εφαρμογής ή φακέλου"
 

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Palette"
 "Book": "Book"
 "Custom shortcut": "Custom shortcut"
-"Shortcut, e.g. Cmd+Shift+P": "Shortcut, e.g. Cmd+Shift+P"
+"Press a shortcut": "Press a shortcut"
 "Application, folder path, or URL": "Application, folder path, or URL"
 "Open application or folder": "Open application or folder"
 

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Libro"
 "Custom shortcut": "Atajo personalizado"
-"Shortcut, e.g. Cmd+Shift+P": "Atajo, p. ej. Cmd+Shift+P"
+"Press a shortcut": "Pulse un atajo"
 "Application, folder path, or URL": "Aplicación, ruta de carpeta o URL"
 "Open application or folder": "Abrir aplicación o carpeta"
 

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Väripaletti"
 "Book": "Kirja"
 "Custom shortcut": "Mukautettu pikanäppäin"
-"Shortcut, e.g. Cmd+Shift+P": "Pikanäppäin, esim. Cmd+Shift+P"
+"Press a shortcut": "Paina pikanäppäintä"
 "Application, folder path, or URL": "Sovellus, kansiopolku tai URL"
 "Open application or folder": "Avaa sovellus tai kansio"
 

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Palette"
 "Book": "Livre"
 "Custom shortcut": "Raccourci personnalisé"
-"Shortcut, e.g. Cmd+Shift+P": "Raccourci, p. ex. Cmd+Shift+P"
+"Press a shortcut": "Appuyez sur un raccourci"
 "Application, folder path, or URL": "Application, chemin de dossier ou URL"
 "Open application or folder": "Ouvrir une application ou un dossier"
 

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Tavolozza"
 "Book": "Libro"
 "Custom shortcut": "Scorciatoia personalizzata"
-"Shortcut, e.g. Cmd+Shift+P": "Scorciatoia, ad es. Cmd+Shift+P"
+"Press a shortcut": "Premi una scorciatoia"
 "Application, folder path, or URL": "Applicazione, percorso cartella o URL"
 "Open application or folder": "Apri applicazione o cartella"
 

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "パレット"
 "Book": "本"
 "Custom shortcut": "カスタムショートカット"
-"Shortcut, e.g. Cmd+Shift+P": "ショートカット（例: Cmd+Shift+P）"
+"Press a shortcut": "ショートカットを押してください"
 "Application, folder path, or URL": "アプリ、フォルダのパス、またはURL"
 "Open application or folder": "アプリまたはフォルダを開く"
 

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "팔레트"
 "Book": "책"
 "Custom shortcut": "사용자 지정 단축키"
-"Shortcut, e.g. Cmd+Shift+P": "단축키(예: Cmd+Shift+P)"
+"Press a shortcut": "단축키를 누르세요"
 "Application, folder path, or URL": "앱, 폴더 경로 또는 URL"
 "Open application or folder": "앱 또는 폴더 열기"
 

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Palett"
 "Book": "Bok"
 "Custom shortcut": "Egendefinert snarvei"
-"Shortcut, e.g. Cmd+Shift+P": "Snarvei, f.eks. Cmd+Shift+P"
+"Press a shortcut": "Trykk på en snarvei"
 "Application, folder path, or URL": "Program, mappebane eller URL"
 "Open application or folder": "Åpne program eller mappe"
 

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Palet"
 "Book": "Boek"
 "Custom shortcut": "Aangepaste sneltoets"
-"Shortcut, e.g. Cmd+Shift+P": "Sneltoets, bijv. Cmd+Shift+P"
+"Press a shortcut": "Druk op een sneltoets"
 "Application, folder path, or URL": "Toepassing, mappad of URL"
 "Open application or folder": "Toepassing of map openen"
 

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Książka"
 "Custom shortcut": "Własny skrót"
-"Shortcut, e.g. Cmd+Shift+P": "Skrót, np. Cmd+Shift+P"
+"Press a shortcut": "Naciśnij skrót"
 "Application, folder path, or URL": "Aplikacja, ścieżka folderu lub URL"
 "Open application or folder": "Otwórz aplikację lub folder"
 

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Livro"
 "Custom shortcut": "Atalho personalizado"
-"Shortcut, e.g. Cmd+Shift+P": "Atalho, por exemplo, Cmd+Shift+P"
+"Press a shortcut": "Pressione um atalho"
 "Application, folder path, or URL": "Aplicativo, caminho de pasta ou URL"
 "Open application or folder": "Abrir aplicativo ou pasta"
 

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Livro"
 "Custom shortcut": "Atalho personalizado"
-"Shortcut, e.g. Cmd+Shift+P": "Atalho, por exemplo, Cmd+Shift+P"
+"Press a shortcut": "Prima um atalho"
 "Application, folder path, or URL": "Aplicação, caminho de pasta ou URL"
 "Open application or folder": "Abrir aplicação ou pasta"
 

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Палитра"
 "Book": "Книга"
 "Custom shortcut": "Пользовательское сочетание клавиш"
-"Shortcut, e.g. Cmd+Shift+P": "Сочетание, например Cmd+Shift+P"
+"Press a shortcut": "Нажмите сочетание клавиш"
 "Application, folder path, or URL": "Приложение, путь к папке или URL"
 "Open application or folder": "Открыть приложение или папку"
 

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Palett"
 "Book": "Bok"
 "Custom shortcut": "Anpassat kortkommando"
-"Shortcut, e.g. Cmd+Shift+P": "Kortkommando, t.ex. Cmd+Shift+P"
+"Press a shortcut": "Tryck på ett kortkommando"
 "Application, folder path, or URL": "Program, mappsökväg eller URL"
 "Open application or folder": "Öppna program eller mapp"
 

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -437,7 +437,7 @@ _version: 1
 "Palette": "Palet"
 "Book": "Kitap"
 "Custom shortcut": "Özel kısayol"
-"Shortcut, e.g. Cmd+Shift+P": "Kısayol, örn. Cmd+Shift+P"
+"Press a shortcut": "Bir kısayola basın"
 "Application, folder path, or URL": "Uygulama, klasör yolu veya URL"
 "Open application or folder": "Uygulama veya klasör aç"
 "%{app} overrides %{count} buttons. Others inherit Default.": "%{app} %{count} düğmeyi geçersiz kılıyor. Diğerleri Varsayılan'dan devralır."

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "Палітра"
 "Book": "Книга"
 "Custom shortcut": "Власне сполучення клавіш"
-"Shortcut, e.g. Cmd+Shift+P": "Сполучення клавіш, напр. Cmd+Shift+P"
+"Press a shortcut": "Натисніть сполучення клавіш"
 "Application, folder path, or URL": "Програма, шлях до папки або URL"
 "Open application or folder": "Відкрити програму або папку"
 

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "调色板"
 "Book": "书籍"
 "Custom shortcut": "自定义快捷键"
-"Shortcut, e.g. Cmd+Shift+P": "快捷键，例如 Cmd+Shift+P"
+"Press a shortcut": "按下快捷键"
 "Application, folder path, or URL": "应用、文件夹路径或 URL"
 "Open application or folder": "打开应用或文件夹"
 

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "調色盤"
 "Book": "書籍"
 "Custom shortcut": "自訂快速鍵"
-"Shortcut, e.g. Cmd+Shift+P": "快速鍵，例如 Cmd+Shift+P"
+"Press a shortcut": "按下快速鍵"
 "Application, folder path, or URL": "應用程式、資料夾路徑或 URL"
 "Open application or folder": "開啟應用程式或資料夾"
 

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -438,7 +438,7 @@ _version: 1
 "Palette": "調色盤"
 "Book": "書籍"
 "Custom shortcut": "自訂快速鍵"
-"Shortcut, e.g. Cmd+Shift+P": "快速鍵，例如 Cmd+Shift+P"
+"Press a shortcut": "按下快速鍵"
 "Application, folder path, or URL": "應用程式、資料夾路徑或 URL"
 "Open application or folder": "開啟應用程式或資料夾"
 

--- a/packaging/linux/udev/70-openlogi.rules
+++ b/packaging/linux/udev/70-openlogi.rules
@@ -33,8 +33,7 @@ KERNEL=="uinput", TAG+="uaccess", OPTIONS+="static_node=uinput"
 # seat, so those rules never tag it and its event node stays root:input 0660.
 #
 # Scoped to event nodes the kernel classifies as a mouse (ID_INPUT_MOUSE, set by
-# the input_id builtin in 60-input-id.rules, which runs before this file): a
-# Logitech keyboard's keystrokes must never become readable session-wide. The
+# the input_id builtin in 60-input-id.rules, which runs before this file). The
 # two matchers cover the same two transports as the hidraw block above.
 SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", ATTRS{idVendor}=="046d", TAG+="uaccess"
 SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", KERNELS=="*:046D:*", TAG+="uaccess"

--- a/vendor/gpui/README.md
+++ b/vendor/gpui/README.md
@@ -1,0 +1,23 @@
+# GPUI numpad patch (fork)
+
+OpenLogi patches three Zed GPUI platform crates so numpad digits keep their
+physical identity in `Keystroke.key` (`kp6` instead of `6`).
+
+The patch lives on a dedicated branch of a Zed fork — not in this directory
+anymore:
+
+**https://github.com/tournierjc/zed/tree/openlogi/numpad-digit-keys**
+
+Root `Cargo.toml` `[patch."https://github.com/zed-industries/zed"]` and
+`[patch.crates-io]` redirect `gpui`, `gpui_platform`, and the three platform
+crates to that branch.
+
+## Bumping GPUI
+
+1. Rebase or cherry-pick `openlogi/numpad-digit-keys` onto the new zed commit
+   OpenLogi pins in `Cargo.lock`.
+2. `cargo update -p gpui --precise <rev>` (or the usual lock bump flow).
+3. `cargo check -p openlogi-desktop`
+
+Consider upstreaming to [zed-industries/zed](https://github.com/zed-industries/zed)
+or [gpui-ce/gpui-ce](https://github.com/gpui-ce/gpui-ce) so the fork can go away.


### PR DESCRIPTION
## Summary

Record custom keyboard shortcuts from GPUI keystrokes in the button inspector, mapping numpad digits to distinct HID usages (`kp0`–`kp9`).

## GPUI dependency

Numpad identity requires a GPUI platform fix upstream in Zed:

- **Issue:** [zed-industries/zed#11948](https://github.com/zed-industries/zed/issues/11948) — numpad keys collapse into main-row digits in `Keystroke.key`
- **PR:** [zed-industries/zed#63402](https://github.com/zed-industries/zed/pull/63402) — emit `kp0`–`kp9` on Linux/macOS/Windows

This PR patches GPUI from `tournierjc/zed` branch `openlogi/numpad-digit-keys` until #63402 lands.

## Relation to OpenLogi#971

[AprilNEA/OpenLogi#971](https://github.com/AprilNEA/OpenLogi/pull/971) proposes agent-backed shortcut **recording** (Fixes #573). This PR uses **GPUI keystroke capture** in the desktop UI instead — an alternative approach worth comparing before both land.

## Testing

```sh
cargo check -p openlogi-desktop -p openlogi-core
```

Verify numpad digits record as `kp0`–`kp9` on Linux after the GPUI patch.

Made with [Cursor](https://cursor.com)