### PR TITLE
fix(gui): Linux compositor titlebar and i18n layout polish

### DIFF
--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -456,11 +456,9 @@ fn request_accessibility(cx: &mut App) {
 }
 
 /// Client-side main-window titlebar: window controls (minimize / maximize /
-/// close on Linux + Windows), the drag region, and the app name centred.
-/// Replaces the native titlebar so Linux — where the compositor declines
-/// server-side decorations and gpui falls back to client-side ones it doesn't
-/// paint — still gets a titlebar and window controls. On macOS the widget
-/// reserves the traffic-light space.
+/// close), the drag region, and the app name centred. Painted only when
+/// [`crate::windows::paints_client_titlebar`] is true (Linux CSD). On macOS the
+/// widget reserves the traffic-light space.
 fn app_title_bar(cx: &App) -> impl IntoElement {
     let pal = theme::palette(cx);
     TitleBar::new().child(
@@ -497,11 +495,9 @@ impl Render for AppView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            // Linux only: a client-side titlebar (window controls + drag region)
-            // as the first row of every frame — including the pre-connection and
-            // error frames — so the chrome is present from the first frame on.
-            // macOS / Windows keep their native titlebar.
-            .when(cfg!(target_os = "linux"), |this| {
+            // Client-side titlebar only when the compositor did not already
+            // draw one. KDE/KWin SSD plus this row is the double-chrome bug.
+            .when(crate::windows::paints_client_titlebar(window), |this| {
                 this.child(app_title_bar(cx))
             });
         let root = Self::with_back_navigation(root, cx);

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -2,7 +2,7 @@
 //! section bodies (Buttons, Keys, Pointer, Lighting, Camera, Device).
 
 use gpui::{
-    Context, InteractiveElement, IntoElement, ParentElement, Rems, Role,
+    Axis, Context, InteractiveElement, IntoElement, ParentElement, Rems, Role,
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rems,
 };
 use gpui_base::Button as BaseButton;
@@ -180,6 +180,7 @@ fn detail_navigation(
         .w(px(DETAIL_RAIL_W))
         .h_full()
         .flex_shrink_0()
+        .overflow_x_hidden()
         .gap_1()
         .border_r_1()
         .border_color(pal.border)
@@ -227,7 +228,13 @@ fn detail_navigation(
                         .size_4()
                         .flex_none(),
                 )
-                .child(tab.label())
+                .child(
+                    // A flex item's default min-content width is the full
+                    // label, which is how longer locales painted across the
+                    // divider. Bound it to the leftover rail and wrap at two
+                    // lines before ellipsizing.
+                    div().flex_1().min_w_0().line_clamp(2).child(tab.label()),
+                )
                 .on_click(cx.listener(move |this, _, _, cx| {
                     this.active_tab = tab;
                     cx.notify();
@@ -409,10 +416,12 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
     };
     let inversion_row = h_flex()
         .justify_between()
-        .items_center()
+        .items_start()
         .gap_4()
         .child(
             v_flex()
+                .min_w_0()
+                .flex_1()
                 .child(
                     div()
                         .text_body()
@@ -427,19 +436,21 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
                 ),
         )
         .child(
-            Toggle::new("invert-scroll-toggle")
-                .selected(inverted)
-                .disabled(!inversion_supported)
-                .label((!inversion_supported).then(|| tr!("Unavailable")))
-                .on_change(|inverted, _window, cx| {
-                    AppState::update(cx, |state, cx| {
-                        let key = state.current_record().map(DeviceRecord::device_key);
-                        state.commit_invert_scroll(*inverted);
-                        if let Some(key) = key {
-                            cx.emit(StateEvent::DeviceConfigChanged(key));
-                        }
-                    });
-                }),
+            div().flex_shrink_0().child(
+                Toggle::new("invert-scroll-toggle")
+                    .selected(inverted)
+                    .disabled(!inversion_supported)
+                    .label((!inversion_supported).then(|| tr!("Unavailable")))
+                    .on_change(|inverted, _window, cx| {
+                        AppState::update(cx, |state, cx| {
+                            let key = state.current_record().map(DeviceRecord::device_key);
+                            state.commit_invert_scroll(*inverted);
+                            if let Some(key) = key {
+                                cx.emit(StateEvent::DeviceConfigChanged(key));
+                            }
+                        });
+                    }),
+            ),
         );
     let resolution_description = match hires {
         HiresWheel::Here => match resolution {
@@ -489,24 +500,25 @@ fn wheel_resolution_control(selected: Option<ScrollResolution>, enabled: bool) -
         Some(ScrollResolution::High),
     ];
     ButtonGroup::new("wheel-resolution")
+        .layout(Axis::Vertical)
         .w_full()
         .outline()
         .disabled(!enabled)
         .child(
             Button::new("wheel-resolution-default")
-                .flex_1()
+                .w_full()
                 .label(tr!("Device default"))
                 .selected(selected.is_none()),
         )
         .child(
             Button::new("wheel-resolution-low")
-                .flex_1()
+                .w_full()
                 .label(tr!("Standard"))
                 .selected(selected == Some(ScrollResolution::Low)),
         )
         .child(
             Button::new("wheel-resolution-high")
-                .flex_1()
+                .w_full()
                 .label(tr!("High resolution"))
                 .selected(selected == Some(ScrollResolution::High)),
         )

--- a/crates/openlogi-desktop/src/ui/gallery.rs
+++ b/crates/openlogi-desktop/src/ui/gallery.rs
@@ -46,6 +46,7 @@ pub(crate) fn run() {
             window_min_size: Some(Size::new(px(760.), px(600.))),
             app_id: Some(APP_ID.into()),
             titlebar: Some(crate::windows::titlebar_options(TITLE)),
+            window_decorations: crate::windows::linux_window_decorations(),
             ..WindowOptions::default()
         };
         let opened = cx.open_window(options, |window, cx| {

--- a/crates/openlogi-desktop/src/ui/theme.rs
+++ b/crates/openlogi-desktop/src/ui/theme.rs
@@ -39,7 +39,10 @@ pub const STATUS_DISABLED: u32 = 0x00ef_4444;
 /// Sizes that several components need to agree on.
 pub const HEADER_H: f32 = 64.;
 pub const FOOTER_H: f32 = 40.;
-pub const DETAIL_RAIL_W: f32 = 168.;
+/// Width of the device-detail section rail. Matches the Settings sidebar so
+/// localized section labels fit beside their icon instead of overflowing
+/// the content divider.
+pub const DETAIL_RAIL_W: f32 = 210.;
 /// Height of standalone form controls: buttons, text inputs, tabs.
 /// gpui-component's `.small()` maps to a 24 px `h_6`, which reads undersized
 /// against this 30 px control rhythm — small controls pin the height

--- a/crates/openlogi-desktop/src/windows.rs
+++ b/crates/openlogi-desktop/src/windows.rs
@@ -18,7 +18,7 @@ use crate::ui::theme::Typography as _;
 use gpui::{
     App, AppContext as _, Bounds, Context, Decorations, Global, IntoElement, ParentElement as _,
     Pixels, Render, SharedString, Size, Styled as _, Subscription, TitlebarOptions, Window,
-    WindowBounds, WindowHandle, WindowOptions, div,
+    WindowBounds, WindowDecorations, WindowHandle, WindowOptions, div,
 };
 use gpui_component::{ActiveTheme as _, Root, TitleBar};
 use openlogi_core::brand::APP_ID;
@@ -39,13 +39,21 @@ pub struct WindowRegistry {
 
 impl Global for WindowRegistry {}
 
+/// Linux window-decoration request passed to GPUI at open time.
+///
+/// OpenLogi asks for client-side decorations so the compositor drops its own
+/// chrome and the in-app [`TitleBar`] can own minimize / maximize / close.
+/// Compositors may still ignore the request; [`paints_client_titlebar`] gates
+/// the in-app bar so a refused request does not stack two titlebars.
+pub fn linux_window_decorations() -> Option<WindowDecorations> {
+    cfg!(target_os = "linux").then_some(WindowDecorations::Client)
+}
+
 /// Titlebar options for an app window.
 ///
 /// On Linux this returns transparent options so the view can draw a client-side
-/// [`TitleBar`] when the compositor actually granted CSD (see
-/// [`paints_client_titlebar`]). The native title is still stamped so KDE/KWin
-/// (and any other compositor that keeps SSD) has a string to show. On macOS /
-/// Windows it keeps the native titlebar carrying `title`, unchanged.
+/// [`TitleBar`] when the compositor granted CSD (see [`paints_client_titlebar`]).
+/// On macOS / Windows it keeps the native titlebar carrying `title`, unchanged.
 pub fn titlebar_options(title: impl Into<SharedString>) -> TitlebarOptions {
     let title = title.into();
     if cfg!(target_os = "linux") {
@@ -64,20 +72,18 @@ pub fn titlebar_options(title: impl Into<SharedString>) -> TitlebarOptions {
 
 /// Whether this window should draw gpui-component's in-app [`TitleBar`].
 ///
-/// GPUI defaults to requesting server-side decorations. GNOME/Mutter typically
-/// has no `xdg-decoration` manager and falls back to unpainted CSD, so Linux
-/// windows paint a [`TitleBar`]. KDE/KWin honors the SSD request and draws its
-/// own chrome — painting a [`TitleBar`] there stacks a second set of window
-/// controls. macOS / Windows always use the native titlebar.
+/// Linux windows request CSD via [`linux_window_decorations`]; this is true
+/// only when the compositor actually granted it. If a compositor keeps SSD
+/// despite the request, the in-app bar stays hidden so controls are not
+/// doubled. macOS / Windows always use the native titlebar.
 pub fn paints_client_titlebar(window: &Window) -> bool {
     cfg!(target_os = "linux") && matches!(window.window_decorations(), Decorations::Client { .. })
 }
 
 /// Client-side window titlebar for auxiliary windows: window controls
 /// (minimize / maximize / close), the drag region, and the window `title`
-/// centred. Callers must gate this on [`paints_client_titlebar`] so KDE (SSD)
-/// keeps only the native chrome. On macOS the widget reserves the traffic-light
-/// space.
+/// centred. Callers must gate this on [`paints_client_titlebar`]. On macOS the
+/// widget reserves the traffic-light space.
 pub fn aux_title_bar(title: impl Into<SharedString>, cx: &App) -> impl IntoElement {
     let title = title.into();
     TitleBar::new().child(
@@ -157,6 +163,7 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
         // own `gnome_shell` frontmost backend.
         app_id: Some(APP_ID.into()),
         titlebar: Some(titlebar_options(title.clone())),
+        window_decorations: linux_window_decorations(),
         ..WindowOptions::default()
     };
 

--- a/crates/openlogi-desktop/src/windows.rs
+++ b/crates/openlogi-desktop/src/windows.rs
@@ -16,9 +16,9 @@ pub mod update_consent;
 
 use crate::ui::theme::Typography as _;
 use gpui::{
-    App, AppContext as _, Bounds, Context, Global, IntoElement, ParentElement as _, Pixels, Render,
-    SharedString, Size, Styled as _, Subscription, TitlebarOptions, WindowBounds, WindowHandle,
-    WindowOptions, div,
+    App, AppContext as _, Bounds, Context, Decorations, Global, IntoElement, ParentElement as _,
+    Pixels, Render, SharedString, Size, Styled as _, Subscription, TitlebarOptions, Window,
+    WindowBounds, WindowHandle, WindowOptions, div,
 };
 use gpui_component::{ActiveTheme as _, Root, TitleBar};
 use openlogi_core::brand::APP_ID;
@@ -42,28 +42,42 @@ impl Global for WindowRegistry {}
 /// Titlebar options for an app window.
 ///
 /// On Linux this returns transparent options so the view can draw a client-side
-/// [`TitleBar`] (see [`aux_title_bar`]); the compositor declines server-side
-/// decorations there and gpui's client-side fallback is otherwise unpainted,
-/// leaving the window with no titlebar or controls. On macOS / Windows it keeps
-/// the native titlebar carrying `title`, unchanged.
+/// [`TitleBar`] when the compositor actually granted CSD (see
+/// [`paints_client_titlebar`]). The native title is still stamped so KDE/KWin
+/// (and any other compositor that keeps SSD) has a string to show. On macOS /
+/// Windows it keeps the native titlebar carrying `title`, unchanged.
 pub fn titlebar_options(title: impl Into<SharedString>) -> TitlebarOptions {
+    let title = title.into();
     if cfg!(target_os = "linux") {
-        TitleBar::title_bar_options()
+        TitlebarOptions {
+            title: Some(title),
+            ..TitleBar::title_bar_options()
+        }
     } else {
         TitlebarOptions {
-            title: Some(title.into()),
+            title: Some(title),
             appears_transparent: false,
             traffic_light_position: None,
         }
     }
 }
 
+/// Whether this window should draw gpui-component's in-app [`TitleBar`].
+///
+/// GPUI defaults to requesting server-side decorations. GNOME/Mutter typically
+/// has no `xdg-decoration` manager and falls back to unpainted CSD, so Linux
+/// windows paint a [`TitleBar`]. KDE/KWin honors the SSD request and draws its
+/// own chrome — painting a [`TitleBar`] there stacks a second set of window
+/// controls. macOS / Windows always use the native titlebar.
+pub fn paints_client_titlebar(window: &Window) -> bool {
+    cfg!(target_os = "linux") && matches!(window.window_decorations(), Decorations::Client { .. })
+}
+
 /// Client-side window titlebar for auxiliary windows: window controls
-/// (minimize / maximize / close on Linux + Windows), the drag region, and the
-/// window `title` centred. Each auxiliary view renders this as the top of its
-/// layout so the window has a titlebar and controls on Linux, where the
-/// compositor declines server-side decorations and gpui's client-side fallback
-/// is otherwise unpainted. On macOS the widget reserves the traffic-light space.
+/// (minimize / maximize / close), the drag region, and the window `title`
+/// centred. Callers must gate this on [`paints_client_titlebar`] so KDE (SSD)
+/// keeps only the native chrome. On macOS the widget reserves the traffic-light
+/// space.
 pub fn aux_title_bar(title: impl Into<SharedString>, cx: &App) -> impl IntoElement {
     let title = title.into();
     TitleBar::new().child(

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -200,10 +200,9 @@ impl Render for AddDeviceView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            // Linux only: a client-side titlebar at the top of the window; the
-            // padded content sits in the flex-column below it. macOS / Windows
-            // keep their native titlebar.
-            .when(cfg!(target_os = "linux"), |this| {
+            // Client-side titlebar only when the compositor did not already
+            // draw one. KDE/KWin SSD plus this row is the double-chrome bug.
+            .when(windows::paints_client_titlebar(window), |this| {
                 this.child(windows::aux_title_bar(tr!("Add Device"), cx))
             })
             .child(

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -200,8 +200,7 @@ impl Render for AddDeviceView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            // Client-side titlebar only when the compositor did not already
-            // draw one. KDE/KWin SSD plus this row is the double-chrome bug.
+            // In-app titlebar when Linux CSD was granted.
             .when(windows::paints_client_titlebar(window), |this| {
                 this.child(windows::aux_title_bar(tr!("Add Device"), cx))
             })

--- a/crates/openlogi-desktop/src/windows/main_window.rs
+++ b/crates/openlogi-desktop/src/windows/main_window.rs
@@ -32,8 +32,9 @@ fn window_options(cx: &mut App) -> WindowOptions {
         // overlap; below this the model can't shrink further without crowding.
         window_min_size: Some(Size::new(px(720.), px(680.))),
         // Linux: transparent chrome so `AppView::render` can draw a client-side
-        // `TitleBar` (the compositor declines server-side decorations and gpui's
-        // fallback is unpainted). macOS/Windows keep their native titlebar.
+        // `TitleBar` when the compositor granted CSD. Compositors that keep SSD
+        // (KWin) still get a native titlebar from the stamped title.
+        // macOS/Windows keep their native titlebar.
         titlebar: Some(titlebar_options("OpenLogi")),
         ..WindowOptions::default()
     }

--- a/crates/openlogi-desktop/src/windows/main_window.rs
+++ b/crates/openlogi-desktop/src/windows/main_window.rs
@@ -14,7 +14,7 @@ use tracing::warn;
 
 use crate::app::AppView;
 use crate::ui::theme;
-use crate::windows::{WindowRegistry, titlebar_options};
+use crate::windows::{WindowRegistry, linux_window_decorations, titlebar_options};
 
 fn window_options(cx: &mut App) -> WindowOptions {
     let bounds = Bounds::centered(None, Size::new(px(1280.), px(820.)), cx);
@@ -31,11 +31,10 @@ fn window_options(cx: &mut App) -> WindowOptions {
         // (`MODEL_MIN_H` + the chrome/padding reserve) so its side labels never
         // overlap; below this the model can't shrink further without crowding.
         window_min_size: Some(Size::new(px(720.), px(680.))),
-        // Linux: transparent chrome so `AppView::render` can draw a client-side
-        // `TitleBar` when the compositor granted CSD. Compositors that keep SSD
-        // (KWin) still get a native titlebar from the stamped title.
+        // Linux: request CSD so `AppView::render` can draw the in-app `TitleBar`.
         // macOS/Windows keep their native titlebar.
         titlebar: Some(titlebar_options("OpenLogi")),
+        window_decorations: linux_window_decorations(),
         ..WindowOptions::default()
     }
 }

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -533,7 +533,7 @@ impl Render for SettingsView {
             // Client-side titlebar as an absolute overlay (with matching top
             // padding) rather than a flex-column row — the `Settings` sidebar
             // uses `h_resizable` percentage sizing, which a flex column would
-            // break. Only when the compositor did not already draw chrome.
+            // In-app titlebar when Linux CSD was granted.
             .when(windows::paints_client_titlebar(window), |this| {
                 this.pt(TITLE_BAR_HEIGHT).child(
                     div()

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -530,11 +530,11 @@ impl Render for SettingsView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            // Linux only: a client-side titlebar as an absolute overlay (with
-            // matching top padding) rather than a flex-column row — the
-            // `Settings` sidebar uses `h_resizable` percentage sizing, which a
-            // flex column would break. macOS / Windows keep their native titlebar.
-            .when(cfg!(target_os = "linux"), |this| {
+            // Client-side titlebar as an absolute overlay (with matching top
+            // padding) rather than a flex-column row — the `Settings` sidebar
+            // uses `h_resizable` percentage sizing, which a flex column would
+            // break. Only when the compositor did not already draw chrome.
+            .when(windows::paints_client_titlebar(window), |this| {
                 this.pt(TITLE_BAR_HEIGHT).child(
                     div()
                         .absolute()

--- a/crates/openlogi-desktop/src/windows/update_consent.rs
+++ b/crates/openlogi-desktop/src/windows/update_consent.rs
@@ -81,10 +81,9 @@ impl Render for UpdateConsentView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            // Linux only: a client-side titlebar at the top of the window; the
-            // centred content sits in the flex-column below it. macOS / Windows
-            // keep their native titlebar.
-            .when(cfg!(target_os = "linux"), |this| {
+            // Client-side titlebar only when the compositor did not already
+            // draw one. KDE/KWin SSD plus this row is the double-chrome bug.
+            .when(windows::paints_client_titlebar(window), |this| {
                 this.child(windows::aux_title_bar(tr!("OpenLogi"), cx))
             })
             .child(

--- a/crates/openlogi-desktop/src/windows/update_consent.rs
+++ b/crates/openlogi-desktop/src/windows/update_consent.rs
@@ -81,8 +81,7 @@ impl Render for UpdateConsentView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            // Client-side titlebar only when the compositor did not already
-            // draw one. KDE/KWin SSD plus this row is the double-chrome bug.
+            // In-app titlebar when Linux CSD was granted.
             .when(windows::paints_client_titlebar(window), |this| {
                 this.child(windows::aux_title_bar(tr!("OpenLogi"), cx))
             })


### PR DESCRIPTION
## Summary

- Draw the client-side titlebar only when GPUI negotiated CSD (`paints_client_titlebar`), fixing double chrome on KDE/Wayland ([#890](https://github.com/AprilNEA/OpenLogi/issues/890)).
- **Request client-side decorations at window open** (`linux_window_decorations`) so KDE/KWin drops native SSD when it honors the CSD request and OpenLogi paints its own `TitleBar`; still gated on `paints_client_titlebar` so a refused request does not stack two titlebars.
- Keep localized device-rail labels inside the sidebar (overflow + two-line clamp).
- Align scrolling-card controls for long locale strings.

## Overlap with #945

[AprilNEA/OpenLogi#945](https://github.com/AprilNEA/OpenLogi/pull/945) addresses the **same titlebar root cause** with the same `paints_client_titlebar` / `window_decorations()` approach.

Recommend merging one titlebar fix and folding any unique hunks from the other. The sidebar label and scrolling-card alignment changes here are **not** covered by #945.

## Testing

Visual check on KDE Plasma Wayland (single in-app titlebar when CSD granted; native-only fallback when compositor keeps SSD). GNOME: CSD still drawn when compositor declines SSD.

Made with [Cursor](https://cursor.com)