### PR TITLE
perf(agent): replace capture polling with events

### DIFF
--- a/.claude/rules/objc-ffi.md
+++ b/.claude/rules/objc-ffi.md
@@ -202,9 +202,10 @@ under a `SAFETY` comment. Where it currently lives on macOS:
   `addObserver:selector:name:object:`, and the `NSWorkspace*Notification` name
   statics.
 - `hook/macos.rs` — the whole tap (Core Graphics / Core Foundation C APIs),
-  `AXIsProcessTrusted[WithOptions]` and the two extern statics they need
-  (`kAXTrustedCheckOptionPrompt`, `kCFBooleanTrue`), and `NSString::to_str(pool)`
-  (the borrow is tied to the pool).
+  the `NSWorkspace` activation-observer registration and typed notification
+  payload, `AXIsProcessTrusted[WithOptions]` and the two extern statics they
+  need (`kAXTrustedCheckOptionPrompt`, `kCFBooleanTrue`), and
+  `NSString::to_str(pool)` (the borrow is tied to the pool).
 - `permissions/macos.rs` — the CoreBluetooth force-link and the `CBManager`
   class-method send. `IOHIDCheckAccess` needs none: `objc2-io-kit` exposes it as
   a safe fn, in `openlogi-permissions` and `openlogi-hid` alike.
@@ -235,9 +236,11 @@ code on a bare thread does, because the framework still autoreleases internal
 temporaries. The three places that keep an explicit `objc2::rc::autoreleasepool`,
 and the only ones that should:
 
-- `openlogi-hook`'s `frontmost_application` — a watcher thread with no run loop,
-  and `to_str` borrows its UTF-8 view from the pool (both the bundle id and the
-  localized name).
+- `openlogi-hook`'s frontmost-application reads and activation observer — the
+  watcher and notification callback may run on threads with no run loop, and
+  `to_str` borrows its UTF-8 view from the pool (both the bundle id and the
+  localized name). Registration and removal use the same boundary so AppKit's
+  internal autoreleased temporaries are drained as well.
 - `openlogi-inject`'s `post_media_key` — the hook/gesture dispatch threads, where
   both the `NSEvent` creation and the `CGEvent` getter autorelease temporaries.
 - `openlogi-camera`'s device enumeration — every `AVCaptureDevice` string is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5636,6 +5636,7 @@ dependencies = [
 name = "openlogi-hook"
 version = "0.8.1"
 dependencies = [
+ "block2 0.6.2",
  "core-foundation 0.10.0",
  "core-graphics 0.25.0",
  "ctrlc",
@@ -5646,6 +5647,7 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-application-services",
  "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "openlogi-core",
  "openlogi-inject",
  "thiserror 2.0.18",

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -9,7 +9,7 @@
 //! map.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use openlogi_core::binding::{Action, Binding, ButtonId, GestureDirection, default_binding};
 use openlogi_core::bindings::{button_bindings_for, hidpp_gesture_maps_for, oshook_gestures_for};
@@ -19,6 +19,7 @@ use openlogi_hid::DeviceRoute;
 use openlogi_hid::session::gesture::{
     CaptureSpec, DIVERTABLE_STANDARD_BUTTONS, GESTURE_SOURCE_BUTTONS,
 };
+use tokio::sync::watch;
 
 /// Hardware identity of one HID++ capture session.
 ///
@@ -73,8 +74,8 @@ pub struct DeviceCapturePlan {
     pub dispatch: DispatchPlan,
 }
 
-/// Shared plan list, rewritten by the orchestrator and read by the watcher.
-pub type SharedCapturePlans = Arc<RwLock<Vec<DeviceCapturePlan>>>;
+/// Read-only, lossless, coalescing view of the latest capture-plan snapshot.
+pub type SharedCapturePlans = watch::Receiver<Arc<Vec<DeviceCapturePlan>>>;
 
 /// Back/Forward gesture maps that macOS must own through device-specific HID++
 /// capture because Bluetooth-direct CGEvents may carry no sender identity.

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -27,7 +27,7 @@ use openlogi_hid::{
     KEYBOARD_KEY_CIDS,
 };
 use openlogi_ipc::InventoryHealth;
-use tokio::sync::Notify;
+use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
 use crate::action_ring::ActionRingSessionSpec;
@@ -66,9 +66,9 @@ struct AgentDevice {
     online: bool,
 }
 
-/// The shared runtime handed to the hook and the gesture watcher. Every field
-/// is an `Arc`, so cloning is cheap; the orchestrator rewrites the inner values
-/// on each rebuild and the background threads observe them on their next read.
+/// Cheaply cloneable runtime handles handed to hooks and background managers.
+/// The orchestrator remains the sole producer for its watch-backed projections;
+/// consumers receive only read capabilities through this type.
 #[derive(Clone)]
 pub struct SharedRuntime {
     /// The OS-hook callback's single-action + gesture maps, behind one lock so a
@@ -86,9 +86,6 @@ pub struct SharedRuntime {
     /// dispatch, keyed by the device the events arrive on. Carries each
     /// device's effective thumb-wheel sensitivity.
     pub capture_plans: SharedCapturePlans,
-    /// Wakes the capture manager when a published plan needs immediate
-    /// reconciliation; periodic polling remains the failure-recovery path.
-    pub capture_plan_changed: Arc<Notify>,
     pub capture_channel: CaptureChannel,
     /// Exact-route channels owned and published by the inventory enumerator.
     pub channel_registry: ChannelRegistry,
@@ -175,6 +172,11 @@ pub struct Orchestrator {
     /// broader mouse-remapping path is available so losing the hook leaves the
     /// side buttons native.
     os_mouse_hook_available: bool,
+    /// Private producer halves for the read-only runtime projections in
+    /// `shared`, keeping the orchestrator's single-writer contract structural.
+    capture_plans_tx: watch::Sender<Arc<Vec<DeviceCapturePlan>>>,
+    keyboard_spec_tx: watch::Sender<Option<Arc<KeyboardSpec>>>,
+    host_switch_links_tx: watch::Sender<Arc<Vec<HostSwitchLink>>>,
     shared: SharedRuntime,
     /// The state the GUI observes. Every mutator below that changes one of its
     /// facts republishes here, so the cell cannot go stale behind a new code
@@ -197,14 +199,17 @@ enum InventoryState {
 }
 
 impl Orchestrator {
-    /// Build from a loaded config. Creates the shared `Arc`s and seeds them
-    /// from the config with no devices yet; the first inventory tick fills in
-    /// the routes and presets.
+    /// Build from a loaded config. Creates the shared runtime handles and seeds
+    /// them from the config with no devices yet; the first inventory tick fills
+    /// in the routes and presets.
     ///
     /// `observable` is the cell the IPC server answers from; the config facts
     /// it carries are seeded here.
     #[must_use]
     pub fn new(config: Config, observable: Arc<ObservableState>) -> Self {
+        let (capture_plans_tx, capture_plans) = watch::channel(Arc::new(Vec::new()));
+        let (keyboard_spec_tx, keyboard_spec) = watch::channel(None);
+        let (host_switch_links_tx, host_switch_links) = watch::channel(Arc::new(Vec::new()));
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(config.keyboard.bindings.clone())),
@@ -213,16 +218,15 @@ impl Orchestrator {
                 config.app_settings.vertical_scroll_sensitivity,
             )),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
-            capture_plans: Arc::new(RwLock::new(Vec::new())),
-            capture_plan_changed: Arc::new(Notify::new()),
+            capture_plans,
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: ChannelRegistry::default(),
             channel_pool: openlogi_hid::host::channel_pool(),
-            keyboard_spec: Arc::new(RwLock::new(None)),
+            keyboard_spec,
             keyboard_channel: Arc::new(RwLock::new(None)),
             capture_rearm_generation: Arc::new(AtomicU64::new(0)),
             receiver_access: ReceiverAccess::default(),
-            host_switch_links: Arc::new(RwLock::new(Vec::new())),
+            host_switch_links,
         };
         let orch = Self {
             config,
@@ -236,6 +240,9 @@ impl Orchestrator {
             camera_active: None,
             manual_light_overrides: BTreeMap::new(),
             os_mouse_hook_available: false,
+            capture_plans_tx,
+            keyboard_spec_tx,
+            host_switch_links_tx,
             shared,
             observable,
         };
@@ -355,25 +362,15 @@ impl Orchestrator {
             self.config.keyboard.bindings.clone(),
             "keyboard_bindings",
         );
-        write_value(
-            &self.shared.host_switch_links,
+        publish_arc_if_changed(
+            &self.host_switch_links_tx,
             host_switch_links(&self.config, &self.devices),
-            "host_switch_links",
         );
-        write_value(
-            &self.shared.keyboard_spec,
-            self.keyboard_spec_for(),
-            "keyboard_spec",
-        );
+        publish_optional_arc_if_changed(&self.keyboard_spec_tx, self.keyboard_spec_for());
     }
 
     fn publish_capture_plans(&self) {
-        write_value(
-            &self.shared.capture_plans,
-            self.capture_plans_for(),
-            "capture_plans",
-        );
-        self.shared.capture_plan_changed.notify_one();
+        publish_arc_if_changed(&self.capture_plans_tx, self.capture_plans_for());
     }
 
     /// Rewrite the per-device DPI-cycle map for every online device,
@@ -1150,6 +1147,30 @@ fn write_value<T>(lock: &RwLock<T>, value: T, name: &str) {
         Ok(mut guard) => *guard = value,
         Err(e) => warn!(error = %e, lock = name, "lock poisoned — keeping stale value"),
     }
+}
+
+/// Publish a fresh immutable snapshot only when its projected value changed.
+fn publish_arc_if_changed<T: PartialEq>(publication: &watch::Sender<Arc<T>>, value: T) {
+    publication.send_if_modified(|current| {
+        if current.as_ref() == &value {
+            return false;
+        }
+        *current = Arc::new(value);
+        true
+    });
+}
+
+fn publish_optional_arc_if_changed<T: PartialEq>(
+    publication: &watch::Sender<Option<Arc<T>>>,
+    value: Option<T>,
+) {
+    publication.send_if_modified(|current| {
+        if current.as_deref() == value.as_ref() {
+            return false;
+        }
+        *current = value.map(Arc::new);
+        true
+    });
 }
 
 #[cfg(test)]

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -18,7 +18,6 @@ use openlogi_core::device_order::{DeviceIdentity, DeviceStableId};
 use openlogi_core::hid::Dpi;
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::observable::ObservableState;
 
@@ -870,13 +869,12 @@ fn config_reload_clears_override_when_camera_mode_changes() {
 
 /// The published capture plan's Back binding for the first device, if any.
 fn published_back_binding(orch: &Orchestrator) -> Option<Action> {
-    orch.shared.capture_plans.read().ok().and_then(|plans| {
-        plans.first().and_then(|plan| {
-            plan.dispatch
-                .bindings
-                .get(&ButtonId::Back)
-                .map(Binding::click_action)
-        })
+    let plans = orch.shared.capture_plans.borrow();
+    plans.first().and_then(|plan| {
+        plan.dispatch
+            .bindings
+            .get(&ButtonId::Back)
+            .map(Binding::click_action)
     })
 }
 
@@ -905,23 +903,18 @@ fn app_switch_republishes_capture_plans() {
     assert_eq!(published_back_binding(&orch), Some(Action::Undo));
 }
 
-#[tokio::test]
-async fn macos_side_gesture_capture_follows_mouse_hook_availability() {
+#[test]
+fn macos_side_gesture_capture_follows_mouse_hook_availability() {
     let mut config = Config::default();
     config.set_gesture_mode("a", ButtonId::Forward, true);
     let mut orch = orchestrator(config);
     orch.devices = vec![dev("a", 1, true)];
     orch.rebuild();
-    let capture_plan_changed = Arc::clone(&orch.shared.capture_plan_changed);
-    tokio::time::timeout(Duration::from_millis(100), capture_plan_changed.notified())
-        .await
-        .expect("initial capture-plan notification should be pending");
+    let mut capture_plans = orch.shared.capture_plans.clone();
+    let _ = capture_plans.borrow_and_update();
 
     let side_gesture_is_armed = |orch: &Orchestrator| {
-        orch.shared
-            .capture_plans
-            .read()
-            .expect("capture plans should not be poisoned")[0]
+        orch.shared.capture_plans.borrow()[0]
             .target
             .spec
             .divert_gesture_buttons
@@ -934,9 +927,14 @@ async fn macos_side_gesture_capture_follows_mouse_hook_availability() {
     );
 
     orch.set_os_mouse_hook_available(true);
-    tokio::time::timeout(Duration::from_millis(100), capture_plan_changed.notified())
-        .await
-        .expect("hook installation should wake capture reconciliation");
+    assert_eq!(
+        capture_plans
+            .has_changed()
+            .expect("publication remains open"),
+        cfg!(target_os = "macos"),
+        "only a semantic capture-plan change should wake reconciliation"
+    );
+    let _ = capture_plans.borrow_and_update();
     if cfg!(target_os = "macos") {
         let hook_maps = orch
             .shared
@@ -956,13 +954,47 @@ async fn macos_side_gesture_capture_follows_mouse_hook_availability() {
         assert!(!side_gesture_is_armed(&orch));
     }
 
-    let revoked = capture_plan_changed.notified();
     orch.set_os_mouse_hook_available(false);
-    tokio::time::timeout(Duration::from_millis(100), revoked)
-        .await
-        .expect("hook revocation should wake capture reconciliation");
+    assert_eq!(
+        capture_plans
+            .has_changed()
+            .expect("publication remains open"),
+        cfg!(target_os = "macos"),
+        "only a semantic capture-plan change should wake reconciliation"
+    );
     assert!(
         !side_gesture_is_armed(&orch),
         "revoking the movement hook must restore native HID++ controls"
+    );
+}
+
+#[test]
+fn equal_runtime_projection_does_not_wake_managers() {
+    let mut orch = orchestrator(Config::default());
+    orch.devices = vec![dev("a", 1, true)];
+    orch.rebuild();
+    let mut capture_plans = orch.shared.capture_plans.clone();
+    let mut keyboard_spec = orch.shared.keyboard_spec.clone();
+    let mut host_switch_links = orch.shared.host_switch_links.clone();
+    let _ = capture_plans.borrow_and_update();
+    let _ = keyboard_spec.borrow_and_update();
+    let _ = host_switch_links.borrow_and_update();
+
+    orch.publish_device_runtime();
+
+    assert!(
+        !capture_plans
+            .has_changed()
+            .expect("publication remains open")
+    );
+    assert!(
+        !keyboard_spec
+            .has_changed()
+            .expect("publication remains open")
+    );
+    assert!(
+        !host_switch_links
+            .has_changed()
+            .expect("publication remains open")
     );
 }

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -5,27 +5,25 @@
 //! sessions stop, then wait for an exclusive write lease.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
-use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, watch};
 
 /// Coordinates exclusive access to the receiver HID node.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ReceiverAccess {
     inner: Arc<ReceiverAccessInner>,
 }
 
-#[derive(Default)]
 struct ReceiverAccessInner {
     lease: Arc<RwLock<()>>,
-    exclusive_requests: Arc<ExclusiveRequests>,
+    requests: watch::Sender<ReceiverRequestState>,
 }
 
-#[derive(Default)]
-struct ExclusiveRequests {
-    total: AtomicUsize,
-    pairing: AtomicUsize,
-    host_transition: AtomicUsize,
+/// Authoritative count of queued or active exclusive receiver requests.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReceiverRequestState {
+    pairing: usize,
+    host_transition: usize,
 }
 
 /// Operation requiring sole ownership of a receiver transport.
@@ -38,21 +36,28 @@ pub enum ExclusiveAccessReason {
 }
 
 impl ExclusiveAccessReason {
-    fn counter(self, requests: &ExclusiveRequests) -> &AtomicUsize {
+    fn count_mut(self, requests: &mut ReceiverRequestState) -> &mut usize {
         match self {
-            Self::Pairing => &requests.pairing,
-            Self::HostTransition => &requests.host_transition,
+            Self::Pairing => &mut requests.pairing,
+            Self::HostTransition => &mut requests.host_transition,
         }
     }
 }
 
-impl ExclusiveRequests {
-    fn any(&self) -> bool {
-        self.total.load(Ordering::Acquire) != 0
+impl ReceiverRequestState {
+    /// Whether any exclusive operation is queued or active.
+    #[must_use]
+    pub fn any(self) -> bool {
+        self.pairing != 0 || self.host_transition != 0
     }
 
-    fn requested(&self, reason: ExclusiveAccessReason) -> bool {
-        reason.counter(self).load(Ordering::Acquire) != 0
+    /// Whether an operation for `reason` is queued or active.
+    #[must_use]
+    pub fn requested(self, reason: ExclusiveAccessReason) -> bool {
+        match reason {
+            ExclusiveAccessReason::Pairing => self.pairing != 0,
+            ExclusiveAccessReason::HostTransition => self.host_transition != 0,
+        }
     }
 }
 
@@ -67,23 +72,41 @@ pub struct ExclusiveReceiverLease {
     _request: ExclusiveRequest,
 }
 
+impl Default for ReceiverAccess {
+    fn default() -> Self {
+        let (requests, _) = watch::channel(ReceiverRequestState::default());
+        Self {
+            inner: Arc::new(ReceiverAccessInner {
+                lease: Arc::new(RwLock::new(())),
+                requests,
+            }),
+        }
+    }
+}
+
 impl ReceiverAccess {
     /// Whether any exclusive operation is waiting for or holding receiver access.
     #[must_use]
     pub fn exclusive_requested(&self) -> bool {
-        self.inner.exclusive_requests.any()
+        self.request_state().any()
     }
 
     /// Whether `reason` is waiting for or holding receiver access.
     #[must_use]
     pub fn requested(&self, reason: ExclusiveAccessReason) -> bool {
-        self.inner.exclusive_requests.requested(reason)
+        self.request_state().requested(reason)
+    }
+
+    /// Subscribe to requested-state changes, starting with the current counts.
+    #[must_use]
+    pub fn subscribe_requests(&self) -> watch::Receiver<ReceiverRequestState> {
+        self.inner.requests.subscribe()
     }
 
     /// Try to acquire receiver access for a pooled HID++ session.
     ///
     /// Capture is opportunistic: if pairing is waiting or active, capture should
-    /// stay idle and retry on its next management tick.
+    /// stay idle until the next requested-state reconciliation.
     #[must_use]
     pub fn try_acquire_for_session(&self) -> Option<SessionReceiverLease> {
         if self.exclusive_requested() {
@@ -111,34 +134,43 @@ impl ReceiverAccess {
     /// If the returned future is cancelled while waiting, the pairing request is
     /// withdrawn automatically so capture can resume.
     pub async fn acquire_exclusive(&self, reason: ExclusiveAccessReason) -> ExclusiveReceiverLease {
-        let request = ExclusiveRequest::new(Arc::clone(&self.inner.exclusive_requests), reason);
+        let request = ExclusiveRequest::new(self.inner.requests.clone(), reason);
         let guard = Arc::clone(&self.inner.lease).write_owned().await;
         ExclusiveReceiverLease {
             _guard: guard,
             _request: request,
         }
     }
+
+    fn request_state(&self) -> ReceiverRequestState {
+        *self.inner.requests.borrow()
+    }
 }
 
 struct ExclusiveRequest {
-    requests: Arc<ExclusiveRequests>,
+    requests: watch::Sender<ReceiverRequestState>,
     reason: ExclusiveAccessReason,
 }
 
 impl ExclusiveRequest {
-    fn new(requests: Arc<ExclusiveRequests>, reason: ExclusiveAccessReason) -> Self {
-        requests.total.fetch_add(1, Ordering::AcqRel);
-        reason.counter(&requests).fetch_add(1, Ordering::AcqRel);
+    fn new(requests: watch::Sender<ReceiverRequestState>, reason: ExclusiveAccessReason) -> Self {
+        requests.send_if_modified(|state| {
+            let count = reason.count_mut(state);
+            *count += 1;
+            true
+        });
         Self { requests, reason }
     }
 }
 
 impl Drop for ExclusiveRequest {
     fn drop(&mut self) {
-        self.reason
-            .counter(&self.requests)
-            .fetch_sub(1, Ordering::AcqRel);
-        self.requests.total.fetch_sub(1, Ordering::AcqRel);
+        self.requests.send_if_modified(|state| {
+            let count = self.reason.count_mut(state);
+            debug_assert!(*count != 0, "every request drop has a matching begin");
+            *count -= 1;
+            true
+        });
     }
 }
 
@@ -207,11 +239,11 @@ mod tests {
     fn same_reason_overlap_stays_requested_until_every_request_drops() {
         let access = ReceiverAccess::default();
         let first = ExclusiveRequest::new(
-            Arc::clone(&access.inner.exclusive_requests),
+            access.inner.requests.clone(),
             ExclusiveAccessReason::Pairing,
         );
         let second = ExclusiveRequest::new(
-            Arc::clone(&access.inner.exclusive_requests),
+            access.inner.requests.clone(),
             ExclusiveAccessReason::Pairing,
         );
 
@@ -221,6 +253,33 @@ mod tests {
 
         drop(second);
         assert!(!access.exclusive_requested());
+    }
+
+    #[tokio::test]
+    async fn request_begin_and_end_publish_immediately() {
+        let access = ReceiverAccess::default();
+        let mut requests = access.subscribe_requests();
+
+        let request = ExclusiveRequest::new(
+            access.inner.requests.clone(),
+            ExclusiveAccessReason::Pairing,
+        );
+        requests
+            .changed()
+            .await
+            .expect("request publication should remain open");
+        assert!(
+            requests
+                .borrow_and_update()
+                .requested(ExclusiveAccessReason::Pairing)
+        );
+
+        drop(request);
+        requests
+            .changed()
+            .await
+            .expect("request publication should remain open");
+        assert!(!requests.borrow_and_update().any());
     }
 
     #[tokio::test]

--- a/crates/openlogi-agent-core/src/watchers/foreground_app.rs
+++ b/crates/openlogi-agent-core/src/watchers/foreground_app.rs
@@ -1,11 +1,25 @@
-//! Foreground application polling watcher.
+//! Foreground application watcher.
 
 use std::time::Duration;
 
 use openlogi_core::app::ForegroundApp;
 use tokio::sync::mpsc;
 
-use super::poll::{self, Poll};
+use super::poll;
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+use super::poll::Poll;
+
+#[cfg(target_os = "macos")]
+use std::sync::mpsc::RecvTimeoutError;
+#[cfg(target_os = "macos")]
+use std::thread;
+#[cfg(target_os = "macos")]
+use std::time::Instant;
+#[cfg(target_os = "macos")]
+use tracing::{debug, warn};
+
+#[cfg(target_os = "macos")]
+const MACOS_RECONCILE_PERIOD: Duration = Duration::from_secs(30);
 
 /// Channel item: `Some(app)` when an app is frontmost; `None` for "no
 /// foreground app" (rare on macOS — Finder is usually frontmost even when
@@ -13,6 +27,11 @@ use super::poll::{self, Poll};
 pub type ForegroundUpdate = Option<ForegroundApp>;
 
 /// Watch foreground application changes.
+///
+/// macOS uses native activation notifications plus a slow recovery read. Linux
+/// and Windows keep their platform-specific readers on the supplied polling
+/// cadence.
+#[must_use]
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     if !cfg!(any(
         target_os = "macos",
@@ -22,10 +41,157 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
         // No way to read the frontmost app, so per-app profiles never switch.
         return poll::never();
     }
-    Poll {
-        name: "openlogi-app-watcher",
-        period,
-        degrades: "per-app profiles are disabled",
+
+    #[cfg(target_os = "macos")]
+    {
+        let _ = period;
+        spawn_macos()
     }
-    .on_change(openlogi_hook::frontmost_application)
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        Poll {
+            name: "openlogi-app-watcher",
+            period,
+            degrades: "per-app profiles are disabled",
+        }
+        .on_change(openlogi_hook::frontmost_application)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        unreachable!("unsupported platforms returned above")
+    }
+}
+
+/// The last value published to the orchestrator, used only to suppress
+/// duplicate snapshots. `NSWorkspace`, not this adapter, remains the source of
+/// truth for the current application.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Default)]
+struct ForegroundChanges {
+    published: Option<ForegroundUpdate>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl ForegroundChanges {
+    fn observe(&mut self, current: &ForegroundUpdate) -> bool {
+        if self.published.as_ref() == Some(current) {
+            return false;
+        }
+        self.published = Some(current.clone());
+        true
+    }
+}
+
+/// Observe native app activations from each notification's application payload.
+/// A slow authoritative reconciliation read recovers from any notification the
+/// OS failed to deliver and notices a dropped consumer without a separate poll.
+#[cfg(target_os = "macos")]
+fn spawn_macos() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let spawned = thread::Builder::new()
+        .name("openlogi-app-watcher".into())
+        .spawn(move || {
+            let (activation_tx, activation_rx) = std::sync::mpsc::channel();
+            let _observer =
+                openlogi_hook::watch_frontmost_application_activations(move |activation| {
+                    let _ = activation_tx.send(activation);
+                });
+            let mut changes = ForegroundChanges::default();
+
+            // Register first so an activation racing this initial snapshot is
+            // either reflected by the read or queued for the loop below.
+            if !publish_current(&tx, &mut changes) {
+                return;
+            }
+            let mut next_reconcile = Instant::now() + MACOS_RECONCILE_PERIOD;
+
+            loop {
+                let timeout = next_reconcile.saturating_duration_since(Instant::now());
+                match activation_rx.recv_timeout(timeout) {
+                    Ok(mut activation) => {
+                        // Coalesce a burst to its latest authoritative AppKit
+                        // payload; intermediate activations were never stable
+                        // foreground state for the consumer.
+                        while let Ok(next) = activation_rx.try_recv() {
+                            activation = next;
+                        }
+                        if !publish(&tx, &mut changes, activation) {
+                            return;
+                        }
+                        next_reconcile = Instant::now() + MACOS_RECONCILE_PERIOD;
+                    }
+                    Err(RecvTimeoutError::Timeout) => {
+                        if tx.is_closed() {
+                            debug!("foreground-app watcher receiver dropped — exiting");
+                            return;
+                        }
+                        if Instant::now() >= next_reconcile {
+                            if !publish_current(&tx, &mut changes) {
+                                return;
+                            }
+                            next_reconcile = Instant::now() + MACOS_RECONCILE_PERIOD;
+                        }
+                    }
+                    Err(RecvTimeoutError::Disconnected) => {
+                        warn!(
+                            "foreground-app activation observer stopped — per-app profiles are disabled"
+                        );
+                        return;
+                    }
+                }
+            }
+        });
+    if let Err(error) = spawned {
+        warn!(error = %error, "could not spawn foreground-app watcher — per-app profiles are disabled");
+    }
+    rx
+}
+
+#[cfg(target_os = "macos")]
+fn publish_current(
+    tx: &mpsc::UnboundedSender<ForegroundUpdate>,
+    changes: &mut ForegroundChanges,
+) -> bool {
+    publish(tx, changes, openlogi_hook::frontmost_application())
+}
+
+#[cfg(target_os = "macos")]
+fn publish(
+    tx: &mpsc::UnboundedSender<ForegroundUpdate>,
+    changes: &mut ForegroundChanges,
+    current: ForegroundUpdate,
+) -> bool {
+    if !changes.observe(&current) {
+        return true;
+    }
+    debug!(value = ?current, "foreground application changed");
+    if tx.send(current).is_err() {
+        debug!("foreground-app watcher receiver dropped — exiting");
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app(id: &str) -> ForegroundApp {
+        ForegroundApp::unnamed(id.to_owned())
+    }
+
+    #[test]
+    fn first_snapshot_and_only_changes_are_published() {
+        let mut changes = ForegroundChanges::default();
+
+        // `None` is a real foreground snapshot, distinct from "not published".
+        assert!(changes.observe(&None));
+        assert!(!changes.observe(&None));
+        assert!(changes.observe(&Some(app("com.example.One"))));
+        assert!(!changes.observe(&Some(app("com.example.One"))));
+        assert!(changes.observe(&Some(app("com.example.Two"))));
+        assert!(changes.observe(&None));
+    }
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -33,19 +33,18 @@ use openlogi_hid::{
     CaptureChannel, CaptureSessionOutcome, CapturedInput, PendingCaptureRestore,
     run_capture_session_with_registry_spec,
 };
-use tokio::sync::{Notify, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::time::Instant;
 use tracing::{debug, warn};
 
 use self::dispatch::InputDispatcher;
 use super::capture_session::{CaptureSession, CompletionAction, ReconcileAction};
 use crate::capture_plan::{CaptureTarget, DeviceCapturePlan, DispatchPlan, SharedCapturePlans};
-use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
+use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
 use crate::runtime::scroll::ScrollInputHandle;
 use crate::runtime::{ActionDispatcher, HidppSessionId};
 
-/// Fallback interval for reconciling a missed plan notification and pacing the
-/// respawn of a session that ended on its own (see `manage`).
-const TARGET_POLL: Duration = Duration::from_secs(1);
+const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Output capabilities shared by every HID++ gesture capture session.
 #[derive(Clone)]
@@ -79,13 +78,14 @@ impl GestureOutputs {
 /// keeps one capture session pointed at the active device and dispatches each
 /// captured input.
 pub fn spawn(
-    capture_plans: SharedCapturePlans,
-    capture_plan_changed: Arc<Notify>,
+    capture_plans: &SharedCapturePlans,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
     channel_registry: openlogi_hid::ChannelRegistry,
     outputs: GestureOutputs,
 ) {
+    let plans = capture_plans.clone();
+    let receiver_requests = receiver_access.subscribe_requests();
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -98,10 +98,10 @@ pub fn spawn(
             }
         };
         runtime.block_on(manage(
-            capture_plans,
-            capture_plan_changed,
+            plans,
             capture_channel,
             receiver_access,
+            receiver_requests,
             channel_registry,
             outputs,
         ));
@@ -125,6 +125,19 @@ struct SessionDone {
 enum SessionEvent {
     Input(CapturedEvent),
     Done(SessionDone),
+}
+
+struct PendingRestore {
+    token: PendingCaptureRestore,
+    retry_at: Instant,
+}
+
+struct GestureManagerState {
+    sessions: HashMap<PhysicalDeviceKey, RunningSession>,
+    pending_restores: HashMap<PhysicalDeviceKey, PendingRestore>,
+    restart_after: HashMap<PhysicalDeviceKey, Instant>,
+    input_dispatcher: InputDispatcher,
+    lease: std::sync::Weak<SessionReceiverLease>,
 }
 
 #[derive(Clone)]
@@ -178,25 +191,18 @@ fn dispatch_context_for<'a>(
         .map(|session| (session.id(), session.dispatch()))
 }
 
-/// Snapshot the sessions that should be armed on this tick. Pairing owns the
-/// receiver exclusively, so its request temporarily makes the wanted set
-/// empty and lets the normal teardown path restore every control.
+/// Snapshot the sessions that should be armed. An exclusive request
+/// temporarily makes the wanted set empty so normal teardown restores every
+/// control.
+#[cfg(test)]
 fn wanted_sessions(
-    receiver_access: &ReceiverAccess,
-    capture_plans: &SharedCapturePlans,
-) -> HashMap<PhysicalDeviceKey, DeviceCapturePlan> {
-    if receiver_access.exclusive_requested() {
-        return HashMap::new();
+    requests: ReceiverRequestState,
+    capture_plans: &watch::Receiver<Arc<Vec<DeviceCapturePlan>>>,
+) -> Arc<Vec<DeviceCapturePlan>> {
+    if requests.any() {
+        return Arc::new(Vec::new());
     }
-    capture_plans
-        .read()
-        .map(|plans| {
-            plans
-                .iter()
-                .map(|plan| (plan.target.physical_key.clone(), plan.clone()))
-                .collect()
-        })
-        .unwrap_or_default()
+    Arc::clone(&capture_plans.borrow())
 }
 
 fn reconcile_session(
@@ -212,36 +218,43 @@ fn reconcile_session(
 }
 
 /// Reconcile one tracked slot directly against the latest publication. Input
-/// calls this before dispatch so an event cannot slip through the interval
-/// between publishing a hot action update and processing its notification.
+/// calls this before dispatch so an event cannot slip between publishing a hot
+/// action update and processing its notification.
 fn reconcile_published_session(
     key: &PhysicalDeviceKey,
     session: &mut RunningSession,
-    receiver_access: &ReceiverAccess,
-    capture_plans: &SharedCapturePlans,
+    receiver_requests: &watch::Receiver<ReceiverRequestState>,
+    capture_plans: &watch::Receiver<Arc<Vec<DeviceCapturePlan>>>,
     dispatcher: &mut InputDispatcher,
 ) {
-    if receiver_access.exclusive_requested() {
+    if receiver_requests.borrow().any() {
         reconcile_session(session, None, dispatcher);
     } else {
-        match capture_plans.read() {
-            Ok(plans) => {
-                let wanted = plans
-                    .iter()
-                    .find(|plan| plan.target.physical_key == *key)
-                    .map(|plan| (&plan.target, &plan.dispatch));
-                reconcile_session(session, wanted, dispatcher);
-            }
-            Err(_) => reconcile_session(session, None, dispatcher),
-        }
+        let plans = capture_plans.borrow();
+        let wanted = plans
+            .iter()
+            .find(|plan| plan.target.physical_key == *key)
+            .map(|plan| (&plan.target, &plan.dispatch));
+        reconcile_session(session, wanted, dispatcher);
     }
 }
 
-async fn wait_for_reconcile(ticker: &mut tokio::time::Interval, changed: &Notify) {
-    tokio::select! {
-        _ = ticker.tick() => {}
-        () = changed.notified() => {}
+async fn wait_for_deadline(deadline: Option<Instant>) {
+    if let Some(deadline) = deadline {
+        tokio::time::sleep_until(deadline).await;
+    } else {
+        std::future::pending::<()>().await;
     }
+}
+
+async fn wait_for_registry_change(
+    changes: &mut watch::Receiver<()>,
+    has_pending_restore: bool,
+) -> bool {
+    if !has_pending_restore {
+        return std::future::pending().await;
+    }
+    changes.changed().await.is_ok()
 }
 
 fn acquire_session_lease(
@@ -257,16 +270,134 @@ fn acquire_session_lease(
 }
 
 async fn retry_pending_restores(
-    pending_restores: &mut HashMap<PhysicalDeviceKey, PendingCaptureRestore>,
+    pending_restores: &mut HashMap<PhysicalDeviceKey, PendingRestore>,
     registry: &openlogi_hid::ChannelRegistry,
+    now: Instant,
 ) {
-    let keys: Vec<_> = pending_restores.keys().cloned().collect();
+    let keys: Vec<_> = pending_restores
+        .iter()
+        .filter(|(_, pending)| pending.retry_at <= now)
+        .map(|(key, _)| key.clone())
+        .collect();
     for key in keys {
         let Some(pending) = pending_restores.remove(&key) else {
             continue;
         };
-        if let CaptureSessionOutcome::RestorePending(pending) = pending.retry(registry).await {
-            pending_restores.insert(key, pending);
+        if let CaptureSessionOutcome::RestorePending(token) = pending.token.retry(registry).await {
+            pending_restores.insert(
+                key,
+                PendingRestore {
+                    token,
+                    retry_at: Instant::now() + RETRY_DELAY,
+                },
+            );
+        }
+    }
+}
+
+fn next_deadline(
+    requests: ReceiverRequestState,
+    pending_restores: &HashMap<PhysicalDeviceKey, PendingRestore>,
+    restart_after: &HashMap<PhysicalDeviceKey, Instant>,
+) -> Option<Instant> {
+    if requests.any() {
+        return None;
+    }
+    pending_restores
+        .values()
+        .map(|pending| pending.retry_at)
+        .chain(restart_after.values().copied())
+        .min()
+}
+
+fn restart_deadline(unexpected: bool, now: Instant) -> Option<Instant> {
+    unexpected.then_some(now + RETRY_DELAY)
+}
+
+impl GestureManagerState {
+    fn new(outputs: GestureOutputs) -> Self {
+        Self {
+            sessions: HashMap::new(),
+            pending_restores: HashMap::new(),
+            restart_after: HashMap::new(),
+            input_dispatcher: InputDispatcher::new(outputs),
+            lease: std::sync::Weak::new(),
+        }
+    }
+
+    fn deadline(&self, requests: ReceiverRequestState) -> Option<Instant> {
+        next_deadline(requests, &self.pending_restores, &self.restart_after)
+    }
+
+    fn expedite_pending_restores(&mut self) {
+        let now = Instant::now();
+        for pending in self.pending_restores.values_mut() {
+            pending.retry_at = now;
+        }
+    }
+
+    async fn reconcile(
+        &mut self,
+        requests: ReceiverRequestState,
+        published: &Arc<Vec<DeviceCapturePlan>>,
+        receiver_access: &ReceiverAccess,
+        channels: &SessionChannels,
+    ) {
+        let now = Instant::now();
+        let wanted = if requests.any() {
+            &[][..]
+        } else {
+            published.as_slice()
+        };
+        for (key, session) in &mut self.sessions {
+            let wanted = wanted
+                .iter()
+                .find(|plan| plan.target.physical_key == *key)
+                .map(|plan| (&plan.target, &plan.dispatch));
+            reconcile_session(session, wanted, &mut self.input_dispatcher);
+        }
+        self.restart_after.retain(|key, _| {
+            published
+                .iter()
+                .any(|plan| plan.target.physical_key == *key)
+        });
+
+        // Firmware ownership outlives the desired plan. Keep the strong lease
+        // through successor spawning so restore→rearm is uninterrupted.
+        let due_restore = self
+            .pending_restores
+            .values()
+            .any(|pending| pending.retry_at <= now);
+        let restore_lease = if due_restore {
+            acquire_session_lease(receiver_access, &mut self.lease)
+        } else {
+            None
+        };
+        if restore_lease.is_some() {
+            retry_pending_restores(&mut self.pending_restores, &channels.registry, now).await;
+        }
+
+        for plan in wanted {
+            let key = &plan.target.physical_key;
+            if self.sessions.contains_key(key) || self.pending_restores.contains_key(key) {
+                continue;
+            }
+            if self
+                .restart_after
+                .get(key)
+                .is_some_and(|deadline| *deadline > now)
+            {
+                continue;
+            }
+            self.restart_after.remove(key);
+            let Some(session_lease) = acquire_session_lease(receiver_access, &mut self.lease)
+            else {
+                self.restart_after.insert(key.clone(), now + RETRY_DELAY);
+                continue;
+            };
+            let id = HidppSessionId::new(&plan.dispatch.config_key);
+            let session = spawn_session(id, plan.clone(), session_lease, channels);
+            self.sessions.insert(key.clone(), session);
         }
     }
 }
@@ -275,23 +406,20 @@ async fn retry_pending_restores(
 /// its device's plan changes, and dispatch incoming inputs against the plan of
 /// the device they arrived on. Runs for the lifetime of the process.
 async fn manage(
-    capture_plans: SharedCapturePlans,
-    capture_plan_changed: Arc<Notify>,
+    mut capture_plans: watch::Receiver<Arc<Vec<DeviceCapturePlan>>>,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
+    mut receiver_requests: watch::Receiver<ReceiverRequestState>,
     channel_registry: openlogi_hid::ChannelRegistry,
     outputs: GestureOutputs,
 ) {
     let (events, mut event_rx) = mpsc::unbounded_channel::<SessionEvent>();
-    let mut sessions: HashMap<PhysicalDeviceKey, RunningSession> = HashMap::new();
-    let mut pending_restores: HashMap<PhysicalDeviceKey, PendingCaptureRestore> = HashMap::new();
-    let mut ticker = tokio::time::interval(TARGET_POLL);
-    let mut input_dispatcher = InputDispatcher::new(outputs);
+    let mut registry_changes = channel_registry.subscribe();
     // Capture sessions run as detached tasks, so an unexpected exit (a transient
     // HID++ read error, a sleep-wake glitch, brief radio loss) would otherwise go
     // unnoticed. Each session reports its completion here, tagged with its device
     // key and the epoch it started under: a dead *current* session re-arms on the
-    // next tick, a deliberately stopped one merely frees its key for the
+    // retry deadline, a deliberately stopped one immediately frees its key for the
     // replacement once its teardown has drained, and stale completions are
     // ignored by the shared capture-session lifecycle.
     let channels = SessionChannels {
@@ -299,32 +427,46 @@ async fn manage(
         capture: capture_channel,
         registry: channel_registry,
     };
-    // The capture-vs-pairing arbiter hands out one exclusive lease. All session
-    // tasks share it through an `Arc`; the manager keeps only a `Weak` so the
-    // lease frees itself when the last session exits (letting pairing proceed).
-    let mut lease: std::sync::Weak<SessionReceiverLease> = std::sync::Weak::new();
+    let mut state = GestureManagerState::new(outputs);
+    let mut reconcile = true;
 
     loop {
+        if reconcile {
+            reconcile = false;
+            let requests = *receiver_requests.borrow_and_update();
+            let published = Arc::clone(&capture_plans.borrow_and_update());
+            state
+                .reconcile(requests, &published, &receiver_access, &channels)
+                .await;
+        }
+
+        let requests = *receiver_requests.borrow();
+        let deadline = state.deadline(requests);
+        if deadline.is_some_and(|deadline| deadline <= Instant::now()) {
+            reconcile = true;
+            continue;
+        }
+
         tokio::select! {
             Some(event) = event_rx.recv() => {
                 match event {
                     SessionEvent::Input(event) => {
                         let key = &event.physical_key;
-                        if let Some(session) = sessions.get_mut(key) {
+                        if let Some(session) = state.sessions.get_mut(key) {
                             reconcile_published_session(
                                 key,
                                 session,
-                                &receiver_access,
+                                &receiver_requests,
                                 &capture_plans,
-                                &mut input_dispatcher,
+                                &mut state.input_dispatcher,
                             );
                         }
-                        let live = sessions.get(key);
+                        let live = state.sessions.get(key);
                         let dispatch_context = dispatch_context_for(&event.session, live);
                         if let Some((session, plan)) = dispatch_context {
-                            input_dispatcher.dispatch(session, plan, event.input);
+                            state.input_dispatcher.dispatch(session, plan, event.input);
                         } else {
-                            input_dispatcher.cancel_session(&event.session);
+                            state.input_dispatcher.cancel_session(&event.session);
                             debug!(key = key.as_str(), epoch = event.session.epoch(), "input from a stale capture session — ignored");
                         }
                     }
@@ -334,79 +476,50 @@ async fn manage(
                         // accepted during restoration, so cancellation cannot
                         // overtake the last diverted edge.
                         if let Some((CompletionAction::Remove { unexpected }, dispatch_session)) =
-                            sessions.get(key).map(|session| {
+                            state.sessions.get(key).map(|session| {
                                 (session.completion(&done.session), session.id().clone())
                             })
                         {
                             if let Some(pending) = done.pending_restore {
-                                pending_restores.insert(key.clone(), pending);
+                                state.pending_restores.insert(
+                                    key.clone(),
+                                    PendingRestore {
+                                        token: pending,
+                                        retry_at: Instant::now() + RETRY_DELAY,
+                                    },
+                                );
                             }
-                            input_dispatcher.cancel_session(&dispatch_session);
-                            if unexpected {
-                                warn!(key = key.as_str(), "capture session ended unexpectedly, re-arming");
+                            state.input_dispatcher.cancel_session(&dispatch_session);
+                            if let Some(deadline) = restart_deadline(unexpected, Instant::now()) {
+                                state.restart_after.insert(key.clone(), deadline);
+                                warn!(key = key.as_str(), "capture session ended unexpectedly, delaying re-arm");
                             }
-                            sessions.remove(key);
+                            state.sessions.remove(key);
+                            reconcile = true;
                         }
                     }
                 }
             }
-            () = wait_for_reconcile(&mut ticker, &capture_plan_changed) => {
-                // While pairing is waiting or active, release every capture
-                // session so run_pairing can own the receiver's HID node (one
-                // process can't read it through two channels).
-                let want = wanted_sessions(&receiver_access, &capture_plans);
-                // Stop sessions whose device disappeared or whose plan changed.
-                // Sending on the oneshot lets the session restore its controls.
-                // A stopped session stays tracked in the draining phase until
-                // its task reports completion below, and a tracked key is never
-                // re-armed: arming the replacement while the old task may still
-                // be mid-restore could interleave its divert writes with the
-                // restore writes on the same device, leaving a control
-                // un-diverted while the new session believes it owns it,
-                // however many ticks the restore takes. Its lifecycle stays
-                // live until completion so already-diverted edges can settle
-                // against the retiring plan during teardown.
-                for (key, session) in &mut sessions {
-                    let wanted = want.get(key).map(|plan| (&plan.target, &plan.dispatch));
-                    reconcile_session(session, wanted, &mut input_dispatcher);
+            result = capture_plans.changed() => match result {
+                Ok(()) => reconcile = true,
+                Err(_) => return,
+            },
+            result = receiver_requests.changed() => match result {
+                Ok(()) => reconcile = true,
+                Err(_) => return,
+            },
+            open = wait_for_registry_change(
+                &mut registry_changes,
+                !state.pending_restores.is_empty(),
+            ) => {
+                if !open {
+                    return;
                 }
-                // Firmware ownership outlives the desired plan. Retry every
-                // pending restore even when the device was disabled or its
-                // plan disappeared, and consume/reinsert the typed token so a
-                // successful attempt cannot accidentally be retried.
-                // Keep the strong lease through successor spawning below: the
-                // restore→rearm transition is one uninterrupted shared-access
-                // interval from pairing's perspective.
-                let restore_lease = if pending_restores.is_empty() {
-                    None
-                } else {
-                    let Some(restore_lease) = acquire_session_lease(
-                        &receiver_access,
-                        &mut lease,
-                    ) else {
-                        continue;
-                    };
-                    Some(restore_lease)
-                };
-                if restore_lease.is_some() {
-                    retry_pending_restores(&mut pending_restores, &channels.registry).await;
-                }
-                for (key, plan) in want {
-                    if sessions.contains_key(&key) || pending_restores.contains_key(&key) {
-                        continue;
-                    }
-                    // Restoration and capture both touch the receiver channel,
-                    // so acquire the shared session lease before either. This
-                    // closes the window where pairing could acquire exclusive
-                    // access between a pending restore and successor arming.
-                    let Some(session_lease) = acquire_session_lease(&receiver_access, &mut lease)
-                    else {
-                        continue;
-                    };
-                    let id = HidppSessionId::new(&plan.dispatch.config_key);
-                    let session = spawn_session(id, plan, session_lease, &channels);
-                    sessions.insert(key, session);
-                }
+                state.expedite_pending_restores();
+                reconcile = true;
+            }
+            () = wait_for_deadline(deadline) => {
+                reconcile = true;
             }
         }
     }

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -45,6 +45,59 @@ fn draining_session_with_epoch(epoch: u64) -> RunningSession {
     session
 }
 
+#[tokio::test(start_paused = true)]
+async fn planned_done_allows_an_immediate_successor_but_unexpected_done_is_paced() {
+    let planned = draining_session_with_epoch(7);
+    let CompletionAction::Remove {
+        unexpected: planned_unexpected,
+    } = planned.completion(&session_id(7))
+    else {
+        panic!("the tracked planned completion should remove its session");
+    };
+    assert!(
+        restart_deadline(planned_unexpected, Instant::now()).is_none(),
+        "ordered Done after planned retirement must reconcile its successor immediately"
+    );
+
+    let unexpected = live_session_with_epoch(8);
+    let CompletionAction::Remove { unexpected: failed } = unexpected.completion(&session_id(8))
+    else {
+        panic!("the tracked unexpected completion should remove its session");
+    };
+    let retry_at =
+        restart_deadline(failed, Instant::now()).expect("an unexpected completion must be paced");
+    assert_eq!(retry_at, Instant::now() + RETRY_DELAY);
+}
+
+#[tokio::test(start_paused = true)]
+async fn retry_deadline_is_not_postponed_by_ready_input() {
+    let retry_at = Instant::now() + RETRY_DELAY;
+    let (input_tx, mut input_rx) = mpsc::unbounded_channel();
+    let waiter = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = wait_for_deadline(Some(retry_at)) => return Instant::now(),
+                Some(()) = input_rx.recv() => {}
+            }
+        }
+    });
+
+    for _ in 0..10 {
+        input_tx
+            .send(())
+            .expect("the deadline waiter should remain alive");
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(100)).await;
+    }
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        waiter.await.expect("deadline waiter should finish"),
+        retry_at,
+        "recreating an absolute sleep after unrelated input must not postpone it"
+    );
+}
+
 #[tokio::test]
 async fn input_accepted_during_restoration_precedes_session_done() {
     let id = session_id(7);
@@ -130,8 +183,10 @@ async fn exclusive_request_retires_capture_without_rejecting_owned_input() {
     .await
     .expect("pairing should announce its exclusive request");
 
-    let plans = Arc::new(std::sync::RwLock::new(vec![plan()]));
-    assert!(wanted_sessions(&access, &plans).is_empty());
+    let (plans, _) = tokio::sync::watch::channel(Arc::new(vec![plan()]));
+    let plans = plans.subscribe();
+    let requests = access.subscribe_requests();
+    assert!(wanted_sessions(*requests.borrow(), &plans).is_empty());
 
     let mut session = live_session_with_epoch(7);
     assert_eq!(session.reconcile(None), ReconcileAction::Retiring);

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -1,19 +1,19 @@
 //! Keep configured keyboard → pointing-device host-switch links armed.
 
-use std::sync::{Arc, RwLock};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use openlogi_hid::{
     ChannelPool, DeviceRoute, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::time::Instant;
 use tracing::{debug, warn};
 
-use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess};
+use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess, ReceiverRequestState};
 
 const DEPARTURE_TIMEOUT: Duration = Duration::from_secs(10);
-const DEPARTURE_POLL: Duration = Duration::from_millis(100);
+const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// One resolved link. Config keys are converted to live routes by the
 /// orchestrator so the transport watcher never needs to understand inventory.
@@ -25,11 +25,13 @@ pub struct HostSwitchLink {
     pub targets: Vec<DeviceRoute>,
 }
 
-/// Shared resolved links, refreshed with config and inventory.
-pub type HostSwitchLinks = Arc<RwLock<Vec<HostSwitchLink>>>;
+/// Read-only, lossless, coalescing view of resolved links.
+pub type HostSwitchLinks = watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>;
 
 /// Spawn the host switch session manager.
-pub fn spawn(links: HostSwitchLinks, channel_pool: ChannelPool, receiver_access: ReceiverAccess) {
+pub fn spawn(links: &HostSwitchLinks, channel_pool: ChannelPool, receiver_access: ReceiverAccess) {
+    let links = links.clone();
+    let receiver_requests = receiver_access.subscribe_requests();
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -41,85 +43,190 @@ pub fn spawn(links: HostSwitchLinks, channel_pool: ChannelPool, receiver_access:
                 return;
             }
         };
-        runtime.block_on(manage(links, channel_pool, receiver_access));
+        runtime.block_on(manage(
+            links,
+            channel_pool,
+            receiver_access,
+            receiver_requests,
+        ));
     });
 }
 
+struct HostSwitchManagerState {
+    sessions: Vec<RunningSession>,
+    next_generation: u64,
+    restart_after: Vec<(HostSwitchLink, Instant)>,
+}
+
+impl HostSwitchManagerState {
+    fn new() -> Self {
+        Self {
+            sessions: Vec::new(),
+            next_generation: 0,
+            restart_after: Vec::new(),
+        }
+    }
+
+    fn deadline(&self, requests: ReceiverRequestState) -> Option<Instant> {
+        if requests.any() {
+            return None;
+        }
+        self.restart_after
+            .iter()
+            .map(|(_, deadline)| *deadline)
+            .min()
+    }
+
+    async fn reconcile(
+        &mut self,
+        requests: ReceiverRequestState,
+        published: &std::sync::Arc<Vec<HostSwitchLink>>,
+        receiver_access: &ReceiverAccess,
+        channel_pool: &ChannelPool,
+        done: &mpsc::UnboundedSender<SessionCompletion>,
+    ) {
+        let now = Instant::now();
+        let wanted = if requests.any() {
+            &[][..]
+        } else {
+            published.as_slice()
+        };
+        stop_unwanted(&mut self.sessions, wanted).await;
+        self.restart_after
+            .retain(|(link, _)| published.contains(link));
+        for link in wanted {
+            if self.sessions.iter().any(|session| session.link == *link)
+                || self
+                    .restart_after
+                    .iter()
+                    .any(|(delayed, deadline)| delayed == link && *deadline > now)
+            {
+                continue;
+            }
+            self.restart_after.retain(|(delayed, _)| delayed != link);
+            let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
+                self.restart_after.push((link.clone(), now + RETRY_DELAY));
+                break;
+            };
+            self.next_generation = self.next_generation.wrapping_add(1);
+            self.sessions.push(spawn_session(
+                link.clone(),
+                self.next_generation,
+                receiver_lease,
+                channel_pool.clone(),
+                done.clone(),
+            ));
+        }
+    }
+}
+
 async fn manage(
-    links: HostSwitchLinks,
+    mut links: watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
     channel_pool: ChannelPool,
     receiver_access: ReceiverAccess,
+    mut receiver_requests: watch::Receiver<ReceiverRequestState>,
 ) {
-    let mut sessions = Vec::new();
     let (done_tx, mut done_rx) = mpsc::unbounded_channel::<SessionCompletion>();
-    let mut next_generation = 0_u64;
-    let mut ticker = tokio::time::interval(Duration::from_secs(1));
+    let mut state = HostSwitchManagerState::new();
+    let mut reconcile = true;
 
     loop {
+        if reconcile {
+            reconcile = false;
+            let requests = *receiver_requests.borrow_and_update();
+            let published = std::sync::Arc::clone(&links.borrow_and_update());
+            state
+                .reconcile(
+                    requests,
+                    &published,
+                    &receiver_access,
+                    &channel_pool,
+                    &done_tx,
+                )
+                .await;
+        }
+
+        let requests = *receiver_requests.borrow();
+        let deadline = state.deadline(requests);
+        if deadline.is_some_and(|deadline| deadline <= Instant::now()) {
+            reconcile = true;
+            continue;
+        }
+
         tokio::select! {
-            _ = ticker.tick() => {
-                let wanted = if receiver_access.exclusive_requested() {
-                    Vec::new()
-                } else {
-                    links.read().map_or_else(|_| Vec::new(), |guard| guard.clone())
-                };
-                stop_unwanted(&mut sessions, &wanted).await;
-                for link in wanted {
-                    if sessions.iter().any(|session| session.link == link) {
-                        continue;
-                    }
-                    let (stop_tx, stop_rx) = oneshot::channel();
-                    let done = done_tx.clone();
-                    let pool = channel_pool.clone();
-                    let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
-                        break;
-                    };
-                    next_generation = next_generation.wrapping_add(1);
-                    let session_generation = next_generation;
-                    let session_link = link.clone();
-                    let task = tokio::spawn(async move {
-                        let _receiver_lease = receiver_lease;
-                        let keyboard = link.keyboard.clone();
-                        let request = match run_host_switch_session(
-                            link.keyboard.clone(),
-                            stop_rx,
-                            pool,
-                        )
-                        .await
-                        {
-                            Ok(host) => host.map(|host| (link, host)),
-                            Err(error) => {
-                                debug!(%error, route = %keyboard, "host switch session ended");
-                                None
-                            }
-                        };
-                        let _ = done.send(SessionCompletion {
-                            generation: session_generation,
-                            request,
-                        });
-                    });
-                    sessions.push(RunningSession {
-                        link: session_link,
-                        generation: session_generation,
-                        stop: stop_tx,
-                        task,
-                    });
-                }
-            }
             Some(completion) = done_rx.recv() => {
-                if let Some(index) = sessions
+                if let Some(index) = state.sessions
                     .iter()
                     .position(|session| session.generation == completion.generation)
                 {
-                    let completed = sessions.remove(index);
+                    let completed = state.sessions.remove(index);
                     let _ = completed.task.await;
                     if let Some((link, host)) = completion.request {
-                        stop_all(&mut sessions, HostSwitchStopReason::Graceful).await;
-                        run_transition(&links, &channel_pool, &receiver_access, link, host).await;
+                        stop_all(&mut state.sessions, HostSwitchStopReason::Graceful).await;
+                        run_transition(&mut links, &channel_pool, &receiver_access, link, host).await;
+                    } else {
+                        state.restart_after.push((completed.link, Instant::now() + RETRY_DELAY));
                     }
+                    reconcile = true;
                 }
             }
+            result = links.changed() => {
+                if result.is_err() {
+                    return;
+                }
+                reconcile = true;
+            }
+            result = receiver_requests.changed() => {
+                if result.is_err() {
+                    return;
+                }
+                reconcile = true;
+            }
+            () = wait_for_deadline(deadline) => {
+                reconcile = true;
+            }
         }
+    }
+}
+
+async fn wait_for_deadline(deadline: Option<Instant>) {
+    if let Some(deadline) = deadline {
+        tokio::time::sleep_until(deadline).await;
+    } else {
+        std::future::pending::<()>().await;
+    }
+}
+
+fn spawn_session(
+    link: HostSwitchLink,
+    generation: u64,
+    receiver_lease: crate::receiver_access::SessionReceiverLease,
+    pool: ChannelPool,
+    done: mpsc::UnboundedSender<SessionCompletion>,
+) -> RunningSession {
+    let (stop, stop_rx) = oneshot::channel();
+    let session_link = link.clone();
+    let task = tokio::spawn(async move {
+        let _receiver_lease = receiver_lease;
+        let keyboard = session_link.keyboard.clone();
+        let request =
+            match run_host_switch_session(session_link.keyboard.clone(), stop_rx, pool).await {
+                Ok(host) => host.map(|host| (session_link, host)),
+                Err(error) => {
+                    debug!(%error, route = %keyboard, "host switch session ended");
+                    None
+                }
+            };
+        let _ = done.send(SessionCompletion {
+            generation,
+            request,
+        });
+    });
+    RunningSession {
+        link,
+        generation,
+        stop,
+        task,
     }
 }
 
@@ -161,7 +268,7 @@ async fn stop_unwanted(sessions: &mut Vec<RunningSession>, wanted: &[HostSwitchL
 }
 
 async fn run_transition(
-    links: &HostSwitchLinks,
+    links: &mut watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
     channel_pool: &ChannelPool,
     receiver_access: &ReceiverAccess,
     link: HostSwitchLink,
@@ -179,16 +286,67 @@ async fn run_transition(
     }
 }
 
-async fn wait_for_departure(links: &HostSwitchLinks, keyboard: &DeviceRoute) {
-    let deadline = Instant::now() + DEPARTURE_TIMEOUT;
-    while Instant::now() < deadline {
-        let departed = links.read().map_or(true, |current| {
-            !current.iter().any(|link| link.keyboard == *keyboard)
-        });
+async fn wait_for_departure(
+    links: &mut watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>,
+    keyboard: &DeviceRoute,
+) {
+    let deadline = tokio::time::sleep(DEPARTURE_TIMEOUT);
+    tokio::pin!(deadline);
+    loop {
+        let departed = !links
+            .borrow_and_update()
+            .iter()
+            .any(|link| link.keyboard == *keyboard);
         if departed {
             return;
         }
-        tokio::time::sleep(DEPARTURE_POLL).await;
+        tokio::select! {
+            result = links.changed() => {
+                if result.is_err() {
+                    return;
+                }
+            }
+            () = &mut deadline => {
+                warn!(route = %keyboard, "host transition departure was not observed");
+                return;
+            }
+        }
     }
-    warn!(route = %keyboard, "host transition departure was not observed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn route(slot: u8) -> DeviceRoute {
+        DeviceRoute::Bolt {
+            receiver_uid: "cafe".to_owned(),
+            slot,
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn departure_publication_finishes_wait_without_advancing_time() {
+        let keyboard = route(1);
+        let link = HostSwitchLink {
+            keyboard: keyboard.clone(),
+            targets: vec![route(2)],
+        };
+        let (links, mut published) = watch::channel(std::sync::Arc::new(vec![link]));
+        let started = Instant::now();
+        let waiting = tokio::spawn(async move {
+            wait_for_departure(&mut published, &keyboard).await;
+            Instant::now()
+        });
+        tokio::task::yield_now().await;
+
+        links.send_replace(std::sync::Arc::new(Vec::new()));
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            waiting.await.expect("departure waiter should finish"),
+            started,
+            "the link publication should reconcile departure immediately"
+        );
+    }
 }

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -12,7 +12,7 @@
 //! permission — the key events arrive over HID++.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -21,18 +21,18 @@ use openlogi_hid::{
     CaptureChannel, CaptureSessionOutcome, CapturedInput, ChannelRegistry, DeviceRoute,
     PendingCaptureRestore, run_keyboard_capture_session_with_registry,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, info, warn};
 
 use super::capture_session::{CaptureSession, CompletionAction, ReconcileAction};
-use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
+use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
 use crate::runtime::{ActionDispatcher, HidppSessionId};
 
 /// Everything the watcher needs to capture one keyboard: where it is, which
 /// `0x1b04` controls to divert (only keys carrying a real binding), and the
 /// per-key action map presses dispatch through. Rebuilt by the orchestrator on
 /// config / inventory / foreground-app changes.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyboardSpec {
     /// Current config namespace for actions from this keyboard. Settings
     /// adoption may change it without cycling an unchanged hardware target.
@@ -45,9 +45,8 @@ pub struct KeyboardSpec {
     pub bindings: BTreeMap<ButtonId, Binding>,
 }
 
-/// Shared keyboard-capture spec, `None` when no online keyboard has bound
-/// keys. Written by the orchestrator, read by the watcher.
-pub type SharedKeyboardSpec = Arc<RwLock<Option<KeyboardSpec>>>;
+/// Read-only, lossless, coalescing view of the keyboard-capture spec.
+pub type SharedKeyboardSpec = watch::Receiver<Option<Arc<KeyboardSpec>>>;
 
 /// Capture identity excluding bindings, which may change without requiring a
 /// hardware session restart when the diverted key set stays the same.
@@ -88,20 +87,38 @@ enum KeyboardSessionEvent {
     Done(KeyboardDone),
 }
 
-/// How often to re-read the spec so a config edit, per-app overlay change, or
-/// keyboard reconnect re-points the capture session.
-const TARGET_POLL: Duration = Duration::from_secs(1);
+struct PendingRestore {
+    token: PendingCaptureRestore,
+    retry_at: tokio::time::Instant,
+}
+
+struct KeyboardManagerState {
+    current: Option<RunningKeyboardSession>,
+    pending_restore: Option<PendingRestore>,
+    restart_at: Option<tokio::time::Instant>,
+    dispatcher: ActionDispatcher,
+}
+
+struct KeyboardSessionChannels {
+    capture: CaptureChannel,
+    registry: ChannelRegistry,
+    events: mpsc::UnboundedSender<KeyboardSessionEvent>,
+}
+
+const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Spawn the keyboard-capture manager thread. It owns a current-thread tokio
 /// runtime that keeps one capture session pointed at the bound keyboard and
 /// dispatches each captured key press.
 pub fn spawn(
-    spec: SharedKeyboardSpec,
+    spec: &SharedKeyboardSpec,
     keyboard_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
     registry: ChannelRegistry,
     dispatcher: ActionDispatcher,
 ) {
+    let spec = spec.clone();
+    let receiver_requests = receiver_access.subscribe_requests();
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -117,6 +134,7 @@ pub fn spawn(
             spec,
             keyboard_channel,
             receiver_access,
+            receiver_requests,
             registry,
             dispatcher,
         ));
@@ -153,24 +171,29 @@ fn dispatch_input(
 /// Snapshot the keyboard capture target and dispatch plan unless pairing
 /// currently owns capture.
 fn wanted_session(
-    receiver_access: &ReceiverAccess,
-    spec: &SharedKeyboardSpec,
+    requests: ReceiverRequestState,
+    spec: &watch::Receiver<Option<Arc<KeyboardSpec>>>,
 ) -> Option<(KeyboardTarget, KeyboardDispatchPlan)> {
-    if receiver_access.exclusive_requested() {
+    let published = spec.borrow();
+    wanted_session_for(requests, published.as_deref())
+}
+
+fn wanted_session_for(
+    requests: ReceiverRequestState,
+    spec: Option<&KeyboardSpec>,
+) -> Option<(KeyboardTarget, KeyboardDispatchPlan)> {
+    if requests.any() {
         return None;
     }
-    spec.read()
-        .ok()
-        .and_then(|guard| guard.clone())
-        .map(|spec| {
-            (
-                KeyboardTarget::for_spec(&spec),
-                KeyboardDispatchPlan {
-                    config_key: spec.config_key,
-                    bindings: spec.bindings,
-                },
-            )
-        })
+    spec.map(|spec| {
+        (
+            KeyboardTarget::for_spec(spec),
+            KeyboardDispatchPlan {
+                config_key: spec.config_key.clone(),
+                bindings: spec.bindings.clone(),
+            },
+        )
+    })
 }
 
 fn reconcile_session(
@@ -189,36 +212,150 @@ fn reconcile_session(
     }
 }
 
+impl KeyboardManagerState {
+    fn new(dispatcher: ActionDispatcher) -> Self {
+        Self {
+            current: None,
+            pending_restore: None,
+            restart_at: None,
+            dispatcher,
+        }
+    }
+
+    fn deadline(&self, requests: ReceiverRequestState) -> Option<tokio::time::Instant> {
+        if requests.any() {
+            return None;
+        }
+        self.pending_restore
+            .as_ref()
+            .map(|pending| pending.retry_at)
+            .into_iter()
+            .chain(self.restart_at)
+            .min()
+    }
+
+    fn expedite_pending_restore(&mut self) {
+        if let Some(pending) = self.pending_restore.as_mut() {
+            pending.retry_at = tokio::time::Instant::now();
+        }
+    }
+
+    async fn reconcile(
+        &mut self,
+        requests: ReceiverRequestState,
+        published: bool,
+        wanted: Option<(KeyboardTarget, KeyboardDispatchPlan)>,
+        receiver_access: &ReceiverAccess,
+        channels: &KeyboardSessionChannels,
+    ) {
+        let now = tokio::time::Instant::now();
+        if !published {
+            self.restart_at = None;
+        }
+        if let Some(running) = self.current.as_mut() {
+            reconcile_session(running, wanted.as_ref(), &self.dispatcher);
+            return;
+        }
+        if requests.any() {
+            return;
+        }
+
+        // Restoration remains mandatory when the spec disappears. A due
+        // retry hands its lease directly to a successor.
+        let mut handoff_lease = None;
+        if self
+            .pending_restore
+            .as_ref()
+            .is_some_and(|pending| pending.retry_at <= now)
+            && let Some(lease) = receiver_access.try_acquire_for_session()
+            && let Some(pending) = self.pending_restore.take()
+        {
+            handoff_lease = Some(lease);
+            if let CaptureSessionOutcome::RestorePending(token) =
+                pending.token.retry(&channels.registry).await
+            {
+                self.pending_restore = Some(PendingRestore {
+                    token,
+                    retry_at: tokio::time::Instant::now() + RETRY_DELAY,
+                });
+            }
+        }
+        if self.pending_restore.is_some() || self.restart_at.is_some_and(|deadline| deadline > now)
+        {
+            return;
+        }
+        let Some((target, dispatch)) = wanted else {
+            return;
+        };
+        let receiver_lease = handoff_lease.or_else(|| receiver_access.try_acquire_for_session());
+        if let Some(receiver_lease) = receiver_lease {
+            self.restart_at = None;
+            self.current = Some(spawn_session(target, dispatch, receiver_lease, channels));
+        } else {
+            self.restart_at = Some(now + RETRY_DELAY);
+        }
+    }
+}
+
 /// Keep one keyboard capture session alive for the published spec, restarting
 /// it when the keyboard or its bound-key set changes, and dispatch incoming
 /// presses. Runs for the lifetime of the process.
 async fn manage(
-    spec: SharedKeyboardSpec,
+    mut spec: watch::Receiver<Option<Arc<KeyboardSpec>>>,
     keyboard_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
+    mut receiver_requests: watch::Receiver<ReceiverRequestState>,
     registry: ChannelRegistry,
     dispatcher: ActionDispatcher,
 ) {
     let (events, mut event_rx) = mpsc::unbounded_channel::<KeyboardSessionEvent>();
-    let mut current: Option<RunningKeyboardSession> = None;
-    let mut pending_restore: Option<PendingCaptureRestore> = None;
-    let mut ticker = tokio::time::interval(TARGET_POLL);
+    let mut registry_changes = registry.subscribe();
+    let channels = KeyboardSessionChannels {
+        capture: keyboard_channel,
+        registry,
+        events,
+    };
+    let mut state = KeyboardManagerState::new(dispatcher);
+    let mut reconcile = true;
 
     loop {
+        if reconcile {
+            reconcile = false;
+            let requests = *receiver_requests.borrow_and_update();
+            let published = spec.borrow_and_update().clone();
+            let want = wanted_session_for(requests, published.as_deref());
+            state
+                .reconcile(
+                    requests,
+                    published.is_some(),
+                    want,
+                    &receiver_access,
+                    &channels,
+                )
+                .await;
+        }
+
+        let requests = *receiver_requests.borrow();
+        let deadline = state.deadline(requests);
+        if deadline.is_some_and(|deadline| deadline <= tokio::time::Instant::now()) {
+            reconcile = true;
+            continue;
+        }
+
         tokio::select! {
             Some(event) = event_rx.recv() => {
                 match event {
                     KeyboardSessionEvent::Input(input) => {
-                        let want = wanted_session(&receiver_access, &spec);
-                        if let Some(running) = current.as_mut() {
-                            reconcile_session(running, want.as_ref(), &dispatcher);
+                        let want = wanted_session(*receiver_requests.borrow(), &spec);
+                        if let Some(running) = state.current.as_mut() {
+                            reconcile_session(running, want.as_ref(), &state.dispatcher);
                         }
 
-                        let Some(running) = current
+                        let Some(running) = state.current
                             .as_ref()
                             .filter(|running| running.owns(&input.session))
                         else {
-                            dispatcher.cancel_hidpp_session(&input.session);
+                            state.dispatcher.cancel_hidpp_session(&input.session);
                             debug!(epoch = input.session.epoch(), "input from a stale keyboard session — ignored");
                             continue;
                         };
@@ -226,7 +363,7 @@ async fn manage(
                             running.id(),
                             input.input,
                             running.dispatch(),
-                            &dispatcher,
+                            &state.dispatcher,
                         );
                     }
                     KeyboardSessionEvent::Done(done) => {
@@ -235,84 +372,80 @@ async fn manage(
                         // draining session therefore remains the sole input
                         // owner until firmware restoration is complete.
                         if let Some((CompletionAction::Remove { unexpected }, dispatch_session)) =
-                            current.as_ref().map(|running| {
+                            state.current.as_ref().map(|running| {
                                 (running.completion(&done.session), running.id().clone())
                             })
                         {
-                            dispatcher.cancel_hidpp_session(&dispatch_session);
-                            pending_restore = done.pending_restore;
+                            state.dispatcher.cancel_hidpp_session(&dispatch_session);
+                            state.pending_restore = done.pending_restore.map(|token| PendingRestore {
+                                token,
+                                retry_at: tokio::time::Instant::now() + RETRY_DELAY,
+                            });
                             if unexpected {
-                                warn!("keyboard capture session ended unexpectedly, re-arming");
+                                state.restart_at = Some(tokio::time::Instant::now() + RETRY_DELAY);
+                                warn!("keyboard capture session ended unexpectedly, delaying re-arm");
                             }
-                            current = None;
+                            state.current = None;
+                            reconcile = true;
                         }
                     }
                 }
             }
-            _ = ticker.tick() => {
-                // While pairing is waiting or active, release the capture
-                // session so run_pairing can own the receiver's HID node.
-                let want = wanted_session(&receiver_access, &spec);
-                if let Some(running) = current.as_mut() {
-                    reconcile_session(running, want.as_ref(), &dispatcher);
-                    continue;
+            result = spec.changed() => match result {
+                Ok(()) => reconcile = true,
+                Err(_) => return,
+            },
+            result = receiver_requests.changed() => match result {
+                Ok(()) => reconcile = true,
+                Err(_) => return,
+            },
+            open = wait_for_registry_change(
+                &mut registry_changes,
+                state.pending_restore.is_some(),
+            ) => {
+                if !open {
+                    return;
                 }
-                // Restoration remains mandatory when the spec disappears
-                // (for example, after disabling the keyboard). Retry the
-                // consuming token before considering any successor. A
-                // successful restore hands the same lease into that successor
-                // so pairing cannot enter between restore and rearm.
-                let mut handoff_lease = None;
-                if let Some(pending) = pending_restore.take() {
-                    let Some(lease) = receiver_access.try_acquire_for_session() else {
-                        pending_restore = Some(pending);
-                        continue;
-                    };
-                    handoff_lease = Some(lease);
-                    if let CaptureSessionOutcome::RestorePending(pending) =
-                        pending.retry(&registry).await
-                    {
-                        pending_restore = Some(pending);
-                        continue;
-                    }
-                }
-                if let Some((target, dispatch)) = want {
-                    let receiver_lease = if let Some(lease) = handoff_lease {
-                        lease
-                    } else {
-                        let Some(lease) = receiver_access.try_acquire_for_session() else {
-                            continue;
-                        };
-                        lease
-                    };
-                    current = Some(spawn_session(
-                        target,
-                        dispatch,
-                        receiver_lease,
-                        &keyboard_channel,
-                        &registry,
-                        &events,
-                    ));
-                }
+                state.expedite_pending_restore();
+                reconcile = true;
+            }
+            () = wait_for_deadline(deadline) => {
+                reconcile = true;
             }
         }
     }
+}
+
+async fn wait_for_deadline(deadline: Option<tokio::time::Instant>) {
+    if let Some(deadline) = deadline {
+        tokio::time::sleep_until(deadline).await;
+    } else {
+        std::future::pending::<()>().await;
+    }
+}
+
+async fn wait_for_registry_change(
+    changes: &mut watch::Receiver<()>,
+    has_pending_restore: bool,
+) -> bool {
+    if !has_pending_restore {
+        return std::future::pending().await;
+    }
+    changes.changed().await.is_ok()
 }
 
 fn spawn_session(
     target: KeyboardTarget,
     dispatch: KeyboardDispatchPlan,
     receiver_lease: SessionReceiverLease,
-    keyboard_channel: &CaptureChannel,
-    registry: &ChannelRegistry,
-    events: &mpsc::UnboundedSender<KeyboardSessionEvent>,
+    channels: &KeyboardSessionChannels,
 ) -> RunningKeyboardSession {
     let (stop_tx, stop_rx) = oneshot::channel();
-    let slot = Arc::clone(keyboard_channel);
-    let session_registry = registry.clone();
+    let slot = Arc::clone(&channels.capture);
+    let session_registry = channels.registry.clone();
     let id = HidppSessionId::new(&dispatch.config_key);
     let (sink, mut session_rx) = mpsc::unbounded_channel();
-    let forward_events = events.clone();
+    let forward_events = channels.events.clone();
     let forward_id = id.clone();
     let forward = tokio::spawn(async move {
         while let Some(input) = session_rx.recv().await {
@@ -322,7 +455,7 @@ fn spawn_session(
             }));
         }
     });
-    let session_events = events.clone();
+    let session_events = channels.events.clone();
     let done_id = id.clone();
     let route = target.route.clone();
     let wanted = target.wanted.clone();
@@ -359,91 +492,4 @@ fn spawn_session(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use openlogi_core::binding::Action;
-
-    fn target() -> KeyboardTarget {
-        KeyboardTarget {
-            route: DeviceRoute::Direct {
-                vendor_id: 0x046d,
-                product_id: 0xc548,
-            },
-            wanted: BTreeMap::new(),
-        }
-    }
-
-    fn session_id(epoch: u64) -> HidppSessionId {
-        HidppSessionId::with_epoch("keyboard-a", epoch)
-    }
-
-    fn dispatch(action: Action) -> KeyboardDispatchPlan {
-        KeyboardDispatchPlan {
-            config_key: "keyboard-a".to_owned(),
-            bindings: BTreeMap::from([(ButtonId::KeySearch, Binding::Single(action))]),
-        }
-    }
-
-    fn live_session(epoch: u64) -> RunningKeyboardSession {
-        let (stop, _rx) = oneshot::channel();
-        CaptureSession::active(
-            session_id(epoch),
-            target(),
-            dispatch(Action::MissionControl),
-            stop,
-        )
-    }
-
-    fn draining_session(epoch: u64) -> RunningKeyboardSession {
-        let mut session = live_session(epoch);
-        assert_eq!(session.reconcile(None), ReconcileAction::Retiring);
-        session
-    }
-
-    #[test]
-    fn accepts_inputs_from_the_current_session_until_teardown_finishes() {
-        assert!(live_session(7).owns(&session_id(7)));
-        assert!(
-            !live_session(7).owns(&session_id(6)),
-            "a superseded session's queued input is stale"
-        );
-        assert!(
-            draining_session(7).owns(&session_id(7)),
-            "the draining keyboard remains the sole owner until restore and ordered Done"
-        );
-    }
-
-    #[test]
-    fn binding_changes_refresh_without_rearming_hardware() {
-        let mut session = live_session(7);
-        let current_target = session.target().clone();
-        let new_dispatch = dispatch(Action::ShowDesktop);
-
-        assert_eq!(
-            session.reconcile(Some((&current_target, &new_dispatch))),
-            ReconcileAction::DispatchChanged
-        );
-        assert!(session.is_active());
-        assert_eq!(session.dispatch(), &new_dispatch);
-    }
-
-    #[test]
-    fn target_changes_freeze_dispatch_until_teardown_finishes() {
-        let mut session = live_session(7);
-        let old_dispatch = session.dispatch().clone();
-        let mut replacement = target();
-        replacement.wanted.insert(0x00d4, ButtonId::KeySearch);
-        let new_dispatch = dispatch(Action::ShowDesktop);
-
-        assert!(
-            replacement != *session.target(),
-            "the test must require different firmware capture"
-        );
-        assert_eq!(
-            session.reconcile(Some((&replacement, &new_dispatch))),
-            ReconcileAction::Retiring
-        );
-        assert!(!session.is_active());
-        assert_eq!(session.dispatch(), &old_dispatch);
-    }
-}
+mod tests;

--- a/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
@@ -1,0 +1,130 @@
+use super::*;
+use openlogi_core::binding::Action;
+
+fn target() -> KeyboardTarget {
+    KeyboardTarget {
+        route: DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc548,
+        },
+        wanted: BTreeMap::new(),
+    }
+}
+
+fn session_id(epoch: u64) -> HidppSessionId {
+    HidppSessionId::with_epoch("keyboard-a", epoch)
+}
+
+fn dispatch(action: Action) -> KeyboardDispatchPlan {
+    KeyboardDispatchPlan {
+        config_key: "keyboard-a".to_owned(),
+        bindings: BTreeMap::from([(ButtonId::KeySearch, Binding::Single(action))]),
+    }
+}
+
+fn live_session(epoch: u64) -> RunningKeyboardSession {
+    let (stop, _rx) = oneshot::channel();
+    CaptureSession::active(
+        session_id(epoch),
+        target(),
+        dispatch(Action::MissionControl),
+        stop,
+    )
+}
+
+fn draining_session(epoch: u64) -> RunningKeyboardSession {
+    let mut session = live_session(epoch);
+    assert_eq!(session.reconcile(None), ReconcileAction::Retiring);
+    session
+}
+
+#[tokio::test]
+async fn publication_and_receiver_request_change_wanted_state_immediately() {
+    let (spec_tx, mut spec_rx) = watch::channel(None);
+    let access = ReceiverAccess::default();
+    let mut requests = access.subscribe_requests();
+    let published = KeyboardSpec {
+        config_key: "keyboard-a".to_owned(),
+        route: target().route,
+        wanted: target().wanted,
+        bindings: dispatch(Action::MissionControl).bindings,
+    };
+
+    spec_tx.send_replace(Some(Arc::new(published)));
+    spec_rx
+        .changed()
+        .await
+        .expect("spec publication should remain open");
+    assert!(wanted_session(*requests.borrow(), &spec_rx).is_some());
+
+    let session_lease = access
+        .try_acquire_for_session()
+        .expect("the test session should hold shared access");
+    let exclusive = tokio::spawn({
+        let access = access.clone();
+        async move {
+            access
+                .acquire_exclusive(crate::receiver_access::ExclusiveAccessReason::Pairing)
+                .await
+        }
+    });
+    requests
+        .changed()
+        .await
+        .expect("request publication should remain open");
+    assert!(
+        wanted_session(*requests.borrow(), &spec_rx).is_none(),
+        "a queued request should retire capture without waiting for a tick"
+    );
+
+    exclusive.abort();
+    let _ = exclusive.await;
+    drop(session_lease);
+}
+
+#[test]
+fn accepts_inputs_from_the_current_session_until_teardown_finishes() {
+    assert!(live_session(7).owns(&session_id(7)));
+    assert!(
+        !live_session(7).owns(&session_id(6)),
+        "a superseded session's queued input is stale"
+    );
+    assert!(
+        draining_session(7).owns(&session_id(7)),
+        "the draining keyboard remains the sole owner until restore and ordered Done"
+    );
+}
+
+#[test]
+fn binding_changes_refresh_without_rearming_hardware() {
+    let mut session = live_session(7);
+    let current_target = session.target().clone();
+    let new_dispatch = dispatch(Action::ShowDesktop);
+
+    assert_eq!(
+        session.reconcile(Some((&current_target, &new_dispatch))),
+        ReconcileAction::DispatchChanged
+    );
+    assert!(session.is_active());
+    assert_eq!(session.dispatch(), &new_dispatch);
+}
+
+#[test]
+fn target_changes_freeze_dispatch_until_teardown_finishes() {
+    let mut session = live_session(7);
+    let old_dispatch = session.dispatch().clone();
+    let mut replacement = target();
+    replacement.wanted.insert(0x00d4, ButtonId::KeySearch);
+    let new_dispatch = dispatch(Action::ShowDesktop);
+
+    assert!(
+        replacement != *session.target(),
+        "the test must require different firmware capture"
+    );
+    assert_eq!(
+        session.reconcile(Some((&replacement, &new_dispatch))),
+        ReconcileAction::Retiring
+    );
+    assert!(!session.is_active());
+    assert_eq!(session.dispatch(), &old_dispatch);
+}

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -397,6 +397,9 @@ mod tests {
     use openlogi_hid::PairingError;
 
     fn shared_runtime() -> SharedRuntime {
+        let (_, capture_plans) = tokio::sync::watch::channel(Arc::new(Vec::new()));
+        let (_, keyboard_spec) = tokio::sync::watch::channel(None);
+        let (_, host_switch_links) = tokio::sync::watch::channel(Arc::new(Vec::new()));
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
@@ -405,16 +408,15 @@ mod tests {
                 VerticalScrollSensitivity::DEFAULT,
             )),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
-            capture_plans: Arc::new(RwLock::new(Vec::new())),
-            capture_plan_changed: Arc::new(tokio::sync::Notify::new()),
+            capture_plans,
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: openlogi_hid::ChannelRegistry::default(),
             channel_pool: openlogi_hid::host::channel_pool(),
-            keyboard_spec: Arc::new(RwLock::new(None)),
+            keyboard_spec,
             keyboard_channel: Arc::new(RwLock::new(None)),
             capture_rearm_generation: Arc::new(0.into()),
             receiver_access: ReceiverAccess::default(),
-            host_switch_links: Arc::new(RwLock::new(Vec::new())),
+            host_switch_links,
         }
     }
 

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -170,20 +170,19 @@ impl InputServices {
 /// Start the HID++ background sessions that do not need Accessibility.
 pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputServices) {
     watchers::gesture::spawn(
-        shared.capture_plans.clone(),
-        Arc::clone(&shared.capture_plan_changed),
+        &shared.capture_plans,
         shared.capture_channel.clone(),
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
         GestureOutputs::new(inputs.dispatcher.clone(), inputs.scroll_input.clone()),
     );
     watchers::host_switch::spawn(
-        shared.host_switch_links.clone(),
+        &shared.host_switch_links,
         shared.channel_pool.clone(),
         shared.receiver_access.clone(),
     );
     watchers::keyboard::spawn(
-        shared.keyboard_spec.clone(),
+        &shared.keyboard_spec,
         shared.keyboard_channel.clone(),
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),

--- a/crates/openlogi-device/src/channel/registry.rs
+++ b/crates/openlogi-device/src/channel/registry.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, PoisonError, RwLock};
 
 use crate::backend::NodeId;
 use hidpp::channel::HidppChannel;
+use tokio::sync::watch;
 
 use crate::{DeviceRoute, SharedChannel};
 
@@ -36,16 +37,27 @@ impl<Node: Eq, Channel> NodeRegistry<Node, Channel> {
         node: Node,
         routes: impl IntoIterator<Item = DeviceRoute>,
         channel: Channel,
-    ) {
-        let routes = routes.into_iter().collect();
+        same_channel: fn(&Channel, &Channel) -> bool,
+    ) -> bool {
+        let routes: Vec<_> = routes.into_iter().collect();
         if let Some(publication) = self
             .publications
             .iter_mut()
             .find(|publication| publication.node == node)
         {
+            let same_routes = publication
+                .routes
+                .iter()
+                .all(|route| routes.contains(route))
+                && routes
+                    .iter()
+                    .all(|route| publication.routes.contains(route));
+            if same_routes && same_channel(&publication.channel, &channel) {
+                return false;
+            }
             publication.routes = routes;
             publication.channel = channel;
-            return;
+            return true;
         }
 
         let sequence = self.next_sequence;
@@ -56,11 +68,14 @@ impl<Node: Eq, Channel> NodeRegistry<Node, Channel> {
             routes,
             channel,
         });
+        true
     }
 
-    fn remove_node(&mut self, node: &Node) {
+    fn remove_node(&mut self, node: &Node) -> bool {
+        let previous_len = self.publications.len();
         self.publications
             .retain(|publication| publication.node != *node);
+        self.publications.len() != previous_len
     }
 
     fn lookup(&self, route: &DeviceRoute) -> Option<&Channel> {
@@ -84,29 +99,54 @@ impl<Node: Eq, Channel> NodeRegistry<Node, Channel> {
 }
 
 impl<Node: Eq + Hash, Channel> NodeRegistry<Node, Channel> {
-    fn retain_nodes(&mut self, nodes: &HashSet<Node>) {
+    fn retain_nodes(&mut self, nodes: &HashSet<Node>) -> bool {
+        let previous_len = self.publications.len();
         self.publications
             .retain(|publication| nodes.contains(&publication.node));
+        self.publications.len() != previous_len
     }
 }
 
 struct Registry<Node, Channel> {
     state: Arc<RwLock<NodeRegistry<Node, Channel>>>,
+    changes: watch::Sender<()>,
+    same_channel: fn(&Channel, &Channel) -> bool,
 }
 
 impl<Node, Channel> Clone for Registry<Node, Channel> {
     fn clone(&self) -> Self {
         Self {
             state: Arc::clone(&self.state),
+            changes: self.changes.clone(),
+            same_channel: self.same_channel,
         }
     }
 }
 
-impl<Node, Channel> Default for Registry<Node, Channel> {
+impl<Node, Channel: PartialEq> Default for Registry<Node, Channel> {
     fn default() -> Self {
+        Self::new(PartialEq::eq)
+    }
+}
+
+impl<Node, Channel> Registry<Node, Channel> {
+    fn new(same_channel: fn(&Channel, &Channel) -> bool) -> Self {
+        let (changes, _) = watch::channel(());
         Self {
             state: Arc::new(RwLock::new(NodeRegistry::default())),
+            changes,
+            same_channel,
         }
+    }
+
+    fn subscribe(&self) -> watch::Receiver<()> {
+        self.changes.subscribe()
+    }
+
+    fn notify_change(&self) {
+        // `watch` versions each send internally; the unit payload deliberately
+        // carries no registry state and means only "read the SSOT again".
+        self.changes.send_modify(|()| {});
     }
 }
 
@@ -117,26 +157,38 @@ impl<Node: Eq, Channel> Registry<Node, Channel> {
         routes: impl IntoIterator<Item = DeviceRoute>,
         channel: Channel,
     ) {
-        self.state
+        let changed = self
+            .state
             .write()
             .unwrap_or_else(PoisonError::into_inner)
-            .replace_node(node, routes, channel);
+            .replace_node(node, routes, channel, self.same_channel);
+        if changed {
+            self.notify_change();
+        }
     }
 
     fn remove_node(&self, node: &Node) {
-        self.state
+        let changed = self
+            .state
             .write()
             .unwrap_or_else(PoisonError::into_inner)
             .remove_node(node);
+        if changed {
+            self.notify_change();
+        }
     }
 }
 
 impl<Node: Eq + Hash, Channel> Registry<Node, Channel> {
     fn retain_nodes(&self, nodes: &HashSet<Node>) {
-        self.state
+        let changed = self
+            .state
             .write()
             .unwrap_or_else(PoisonError::into_inner)
             .retain_nodes(nodes);
+        if changed {
+            self.notify_change();
+        }
     }
 }
 
@@ -159,9 +211,17 @@ impl<Node: Eq, Channel> Registry<Node, Channel> {
 /// Publications are keyed by OS HID node internally and selected by exact
 /// [`DeviceRoute`]. When identical direct devices publish the same route, the
 /// oldest live node wins until it is removed.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ChannelRegistry {
     inner: Registry<NodeId, Arc<HidppChannel>>,
+}
+
+impl Default for ChannelRegistry {
+    fn default() -> Self {
+        Self {
+            inner: Registry::new(Arc::ptr_eq),
+        }
+    }
 }
 
 impl ChannelRegistry {
@@ -184,6 +244,17 @@ impl ChannelRegistry {
     /// Remove publications for nodes absent from the current OS enumeration.
     pub(crate) fn retain_nodes(&self, nodes: &HashSet<NodeId>) {
         self.inner.retain_nodes(nodes);
+    }
+
+    /// Subscribe to semantic publication changes.
+    ///
+    /// The receiver coalesces changes and carries no route data: after it
+    /// changes, read this registry again with [`Self::lookup`] or
+    /// [`Self::is_current`]. Re-publishing the same node, route set, and channel
+    /// does not wake subscribers.
+    #[must_use]
+    pub fn subscribe(&self) -> watch::Receiver<()> {
+        self.inner.subscribe()
     }
 
     /// Clone the current exact-route winner.
@@ -209,6 +280,7 @@ mod tests {
     use std::collections::HashSet;
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::sync::Arc;
+    use std::time::Duration;
 
     use crate::DeviceRoute;
 
@@ -312,6 +384,85 @@ mod tests {
 
         registry.remove_node(&1);
         assert_eq!(registry.lookup(&route), Some("b"));
+    }
+
+    #[test]
+    fn replacement_and_removal_wake_every_subscriber() {
+        let route = direct(0xb35b);
+        let first_channel = Arc::new(());
+        let replacement = Arc::new(());
+        let registry = Registry::<u8, Arc<()>>::new(Arc::ptr_eq);
+        registry.replace_node(1, [route.clone()], Arc::clone(&first_channel));
+        let mut first = registry.subscribe();
+        let mut second = registry.subscribe();
+
+        registry.replace_node(1, [route.clone()], Arc::clone(&replacement));
+
+        assert!(first.has_changed().expect("registry sender remains alive"));
+        assert!(second.has_changed().expect("registry sender remains alive"));
+        first.borrow_and_update();
+        second.borrow_and_update();
+        assert!(!registry.any_current(|candidate, channel| {
+            candidate == &route && Arc::ptr_eq(channel, &first_channel)
+        }));
+        assert!(registry.any_current(|candidate, channel| {
+            candidate == &route && Arc::ptr_eq(channel, &replacement)
+        }));
+
+        registry.remove_node(&1);
+
+        assert!(first.has_changed().expect("registry sender remains alive"));
+        assert!(second.has_changed().expect("registry sender remains alive"));
+        assert_eq!(registry.lookup(&route), None);
+    }
+
+    #[test]
+    fn no_op_publications_do_not_wake_subscribers() {
+        let first_route = bolt("AABB", 1);
+        let second_route = bolt("AABB", 2);
+        let channel = Arc::new(());
+        let registry = Registry::<u8, Arc<()>>::new(Arc::ptr_eq);
+        registry.replace_node(
+            1,
+            [first_route.clone(), second_route.clone()],
+            Arc::clone(&channel),
+        );
+        let changes = registry.subscribe();
+
+        registry.replace_node(1, [second_route, first_route], Arc::clone(&channel));
+        registry.remove_node(&2);
+        registry.retain_nodes(&HashSet::from([1]));
+
+        assert!(
+            !changes
+                .has_changed()
+                .expect("registry sender remains alive")
+        );
+    }
+
+    #[tokio::test]
+    async fn change_between_current_check_and_wait_is_not_missed() {
+        let route = direct(0xb35b);
+        let first_channel = Arc::new(());
+        let replacement = Arc::new(());
+        let registry = Registry::<u8, Arc<()>>::new(Arc::ptr_eq);
+        registry.replace_node(1, [route.clone()], Arc::clone(&first_channel));
+
+        // This is the ordering used by capture restore: subscribe, check the
+        // SSOT, then wait. Publishing in that final gap must remain visible.
+        let mut changes = registry.subscribe();
+        assert!(registry.any_current(|candidate, channel| {
+            candidate == &route && Arc::ptr_eq(channel, &first_channel)
+        }));
+        registry.replace_node(1, [route.clone()], Arc::clone(&replacement));
+
+        tokio::time::timeout(Duration::from_millis(100), changes.changed())
+            .await
+            .expect("a pre-wait publication must be observed")
+            .expect("registry sender remains alive");
+        assert!(registry.any_current(|candidate, channel| {
+            candidate == &route && Arc::ptr_eq(channel, &replacement)
+        }));
     }
 
     #[test]

--- a/crates/openlogi-device/src/session/capture_restore.rs
+++ b/crates/openlogi-device/src/session/capture_restore.rs
@@ -13,8 +13,6 @@ use crate::reprog_controls::{self, ReprogControlsV4};
 use crate::thumbwheel::Thumbwheel;
 use crate::{ChannelRegistry, DeviceRoute, SharedChannel};
 
-const REGISTRY_CURRENT_POLL: std::time::Duration = std::time::Duration::from_secs(1);
-
 /// Shared slot holding the active capture session's open channel, so bounded
 /// hardware writes can reuse it instead of opening a second connection.
 pub type CaptureChannel = Arc<RwLock<Option<SharedChannel>>>;
@@ -307,10 +305,16 @@ pub(crate) async fn wait_for_channel_change(
     let Some(registry) = registry else {
         return std::future::pending().await;
     };
+    let mut changes = registry.subscribe();
     loop {
-        tokio::time::sleep(REGISTRY_CURRENT_POLL).await;
         if !registry.is_current(retired) {
             return CaptureStop::ChannelChanged;
+        }
+        if changes.changed().await.is_err() {
+            // The borrowed registry owns the sender, so this is unreachable;
+            // preserve standalone-like pending semantics if that invariant is
+            // ever changed rather than inventing a channel transition.
+            return std::future::pending().await;
         }
     }
 }

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -28,6 +28,7 @@ ctrlc = "3"
 # CGEventTap stays on core-graphics/core-foundation (the freeze-hazard run-loop
 # machinery). The frontmost-app read uses objc2 (NSWorkspace) so no raw `objc`.
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = { workspace = true }
 core-graphics = { workspace = true }
 core-foundation = { workspace = true }
 # For `ForeignType::as_ptr` on `CGEvent` (to reach the raw `CGEventRef` for the
@@ -37,6 +38,13 @@ objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSWorkspace", "NSRunningApplication"] }
 objc2-application-services = { workspace = true, features = ["std", "HIServices", "AXUIElement"] }
 objc2-core-foundation = { workspace = true, features = ["std", "CFDictionary", "CFNumber"] }
+objc2-foundation = { workspace = true, features = [
+    "block2",
+    "NSDictionary",
+    "NSNotification",
+    "NSOperation",
+    "NSString",
+] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -523,11 +523,27 @@ impl Hook {
 /// `None` when no app is frontmost, when reading fails, or on an unsupported
 /// platform — including a pure-Wayland session with no backend (see
 /// `linux::detect_frontmost_source`). Costs one X11 round-trip on Linux and a
-/// handful of `objc_msgSend`s on macOS — well under a millisecond at the
-/// agent's 1 Hz polling cadence (`openlogi_agent_core::watchers::foreground_app`).
+/// handful of `objc_msgSend`s on macOS. macOS callers can use
+/// `watch_frontmost_application_activations` to drive reads from native
+/// activation notifications instead of polling.
 #[must_use]
 pub fn frontmost_application() -> Option<ForegroundApp> {
     Backend::frontmost_app()
+}
+
+#[cfg(target_os = "macos")]
+pub use macos::ForegroundApplicationObserver;
+
+/// Observe macOS foreground-application activations.
+///
+/// Each callback carries the application from AppKit's activation notification;
+/// it may run on any thread and must return quickly. Dropping the returned
+/// handle unregisters the native observer and releases its block.
+#[cfg(target_os = "macos")]
+pub fn watch_frontmost_application_activations(
+    on_activation: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
+) -> ForegroundApplicationObserver {
+    macos::watch_frontmost_application_activations(on_activation)
 }
 
 /// Return the current global cursor position without installing an input hook.

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -1,7 +1,7 @@
 //! macOS `CGEventTap` implementation of the OS-level mouse hook.
 #![expect(
     unsafe_code,
-    reason = "the event tap is built on Core Graphics / Core Foundation C APIs"
+    reason = "the event tap uses Core Graphics / Core Foundation C APIs, and workspace observation uses typed Objective-C notification APIs"
 )]
 
 mod watchdog;
@@ -9,11 +9,13 @@ mod watchdog;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::Duration;
 
+use block2::RcBlock;
 use core_foundation::base::{CFTypeRef, TCFType as _};
 use core_foundation::number::CFNumber;
 use core_foundation::runloop::{
@@ -26,7 +28,14 @@ use core_graphics::event::{
 };
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use foreign_types_shared::ForeignType as _;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, ProtocolObject};
+use objc2_app_kit::{
+    NSRunningApplication, NSWorkspace, NSWorkspaceApplicationKey,
+    NSWorkspaceDidActivateApplicationNotification,
+};
 use objc2_application_services::{AXIsProcessTrusted, AXIsProcessTrustedWithOptions};
+use objc2_foundation::{NSNotification, NSNotificationCenter, NSObjectProtocol};
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -57,6 +66,91 @@ pub(crate) struct HookInner {
 // documentation states that CFRunLoop objects can be passed between
 // threads; only CFRunLoopRun must be called on the owning thread.
 unsafe impl Send for HookInner {}
+
+/// Owner of an `NSWorkspace` activation observer.
+///
+/// The notification center retains the registration block. The returned token
+/// identifies that registration; removing it releases the center's block
+/// reference, and dropping the token releases the caller's final reference.
+#[must_use]
+pub struct ForegroundApplicationObserver {
+    center: Retained<NSNotificationCenter>,
+    token: Retained<ProtocolObject<dyn NSObjectProtocol>>,
+}
+
+impl Drop for ForegroundApplicationObserver {
+    fn drop(&mut self) {
+        objc2::rc::autoreleasepool(|_| {
+            // SAFETY: `token` came from this center's block-observer registration
+            // and is removed exactly once, before both retained objects are dropped.
+            unsafe { self.center.removeObserver(self.token.as_ref()) };
+        });
+    }
+}
+
+/// Register for `NSWorkspaceDidActivateApplicationNotification`.
+pub(crate) fn watch_frontmost_application_activations(
+    on_activation: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
+) -> ForegroundApplicationObserver {
+    objc2::rc::autoreleasepool(|_| {
+        let workspace = NSWorkspace::sharedWorkspace();
+        let center = workspace.notificationCenter();
+        let block: RcBlock<dyn Fn(NonNull<NSNotification>)> =
+            RcBlock::new(move |notification: NonNull<NSNotification>| {
+                // A panic must not unwind across the Objective-C block boundary.
+                let result = catch_unwind(AssertUnwindSafe(|| {
+                    let activation = objc2::rc::autoreleasepool(|pool| {
+                        // SAFETY: NotificationCenter passes a live, non-null
+                        // NSNotification to the block for the duration of this call.
+                        let notification = unsafe { notification.as_ref() };
+                        let info = notification.userInfo()?;
+                        // SAFETY: AppKit documents NSWorkspaceApplicationKey as this
+                        // notification's NSRunningApplication-valued user-info entry.
+                        let app = info
+                            .objectForKey(unsafe { NSWorkspaceApplicationKey } as &AnyObject)?
+                            .downcast::<NSRunningApplication>()
+                            .ok()?;
+                        foreground_app_from_running_application(&app, pool)
+                    });
+                    on_activation(activation);
+                }));
+                if result.is_err() {
+                    error!("foreground-application activation callback panicked");
+                }
+            });
+        // SAFETY: AppKit exports the name as an immutable process-lifetime
+        // constant. The block captures only `Send + Sync` state and accepts the
+        // exact `NSNotification` argument required by the API. A nil queue asks
+        // the center to invoke it synchronously on the notification-posting thread.
+        let token = unsafe {
+            center.addObserverForName_object_queue_usingBlock(
+                Some(NSWorkspaceDidActivateApplicationNotification),
+                Some(&workspace),
+                None,
+                &block,
+            )
+        };
+        ForegroundApplicationObserver { center, token }
+    })
+}
+
+fn foreground_app_from_running_application(
+    app: &NSRunningApplication,
+    pool: objc2::rc::AutoreleasePool<'_>,
+) -> Option<ForegroundApp> {
+    let bundle_id = app.bundleIdentifier()?;
+    let name = app.localizedName();
+    // SAFETY: Both UTF-8 views are copied into owned Strings before `pool`
+    // drains, so no borrowed Objective-C storage escapes.
+    let (id, name) = unsafe {
+        (
+            bundle_id.to_str(pool).to_owned(),
+            name.as_ref().map(|name| name.to_str(pool).to_owned()),
+        )
+    };
+    let display_name = name.unwrap_or_else(|| id.clone());
+    Some(ForegroundApp { id, display_name })
+}
 
 /// Opaque `IOHIDEventRef` — the HID event backing a `CGEvent`.
 type IOHIDEventRef = *mut std::ffi::c_void;
@@ -663,26 +757,10 @@ impl HookBackend for Backend {
     /// leaked the workspace/app/bundle-id objects: hundreds of MB across a workday.)
     fn frontmost_app() -> Option<ForegroundApp> {
         use objc2::rc::autoreleasepool;
-        use objc2_app_kit::NSWorkspace;
 
         autoreleasepool(|pool| {
             let app = NSWorkspace::sharedWorkspace().frontmostApplication()?;
-            let bundle_id = app.bundleIdentifier()?;
-            let name = app.localizedName();
-            // SAFETY: `to_str` yields a UTF-8 view valid for `pool`'s lifetime.
-            // Both are copied into owned `String`s here, before the pool — and
-            // the `NSString`s borrowing from it — drop, so neither view escapes.
-            let (id, name) = unsafe {
-                (
-                    bundle_id.to_str(pool).to_owned(),
-                    name.as_ref().map(|name| name.to_str(pool).to_owned()),
-                )
-            };
-            // An app with no localized name is possible (a bare bundle, a
-            // background helper that briefly activates); the identifier is the
-            // only thing guaranteed, so it doubles as the name.
-            let display_name = name.unwrap_or_else(|| id.clone());
-            Some(ForegroundApp { id, display_name })
+            foreground_app_from_running_application(&app, pool)
         })
     }
 


### PR DESCRIPTION
## Summary

Replace the capture-management polling loops with event-driven state publications and native lifecycle notifications. This is a follow-up to #722.

## Changes

- **agent-core**
  - publish capture plans, keyboard specs, host-switch links, and receiver-request state through coalescing watch channels
  - keep producer capabilities private to the orchestrator and expose read-only runtime views
  - reconcile gesture, keyboard, and host-switch sessions on state changes, completion events, and targeted retry deadlines
  - preserve ordered teardown, pending firmware restoration, receiver lease fairness, and unexpected-exit backoff
- **device**
  - publish semantic channel-registry changes and remove channel-replacement polling
  - suppress no-op registry publications
- **hook**
  - observe macOS foreground-app activations through `NSWorkspaceDidActivateApplicationNotification`
  - retain a low-frequency authoritative recovery read
  - document the new Objective-C observer ownership and autorelease-pool boundary

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo clippy -p openlogi-hook -p openlogi-agent-core --target x86_64-apple-darwin --all-targets -- -D warnings`
- `cargo clippy -p openlogi-agent-core -p openlogi-agent -p openlogi-hook --target x86_64-pc-windows-gnu --all-targets -- -D warnings`
- `cargo xtask ci wasm cargo-deny`
- Not runtime-tested on macOS hardware.
