### PR TITLE
perf(agent): replace lifecycle polling with native events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5642,6 +5642,7 @@ dependencies = [
  "ctrlc",
  "evdev",
  "foreign-types-shared",
+ "futures-lite",
  "libc",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5406,6 +5406,7 @@ dependencies = [
  "tracing-subscriber",
  "windows-sys 0.61.2",
  "winreg",
+ "zbus",
 ]
 
 [[package]]

--- a/crates/openlogi-agent-core/src/observable.rs
+++ b/crates/openlogi-agent-core/src/observable.rs
@@ -115,11 +115,11 @@ impl ObservableState {
     }
 
     /// Publish where enumeration stands together with the device set it
-    /// produced — and whether that tick failed to open HID++ nodes — so none
+    /// produced — and whether that pass failed to open HID++ nodes — so none
     /// of the three can be read from different generations.
     ///
-    /// The inventory watcher re-enumerates on a timer, so most calls carry the
-    /// same devices as the last one; those notify nobody.
+    /// Reconciliations often carry the same devices as the last one; those
+    /// notify nobody.
     pub fn set_inventory(
         &self,
         health: InventoryHealth,

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -157,8 +157,8 @@ pub struct Orchestrator {
     /// atomically with the inventory so no observation pairs a fresh device
     /// set with a stale flag.
     hid_open_failures: bool,
-    /// Config keys of devices first sighted (or wake-flagged) recently, with
-    /// remaining confirming re-apply budget: the first write can race the
+    /// Config keys of devices first sighted (or targeted after wake) recently,
+    /// with remaining confirming re-apply budget: the first write can race the
     /// device's own boot or reconnect and be lost.
     reapply_followup: HashMap<String, u8>,
     /// Last successful aggregate camera-use sample. `None` means the macOS
@@ -1066,7 +1066,7 @@ fn any_device_needs_capture_rearm(
     !reapply_targets(prev, next, reapply_all).is_empty()
 }
 
-/// How many explicit confirmation passes a first-sighted or wake-flagged
+/// How many explicit confirmation passes a first-sighted or wake-targeted
 /// device keeps re-applying its volatile settings after the initial write. A
 /// cold restart leaves a Bolt/Unifying mouse slow to enumerate — and a system
 /// wake can enumerate a receiver whose mouse link is still re-establishing —

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -153,7 +153,7 @@ pub struct Orchestrator {
     /// set/route/online state looks identical across the sleep gap, so the
     /// next refresh re-applies volatile settings to every online device.
     reapply_all_next_refresh: bool,
-    /// Whether the last enumeration tick failed to open HID++ nodes; published
+    /// Whether the last enumeration pass failed to open HID++ nodes; published
     /// atomically with the inventory so no observation pairs a fresh device
     /// set with a stale flag.
     hid_open_failures: bool,
@@ -452,7 +452,7 @@ impl Orchestrator {
     /// altering the device *set*), but only re-picks the selection and rebuilds
     /// the shared maps when the device set or runtime selection changed —
     /// `rebuild()` is driven by `config_key` + route and resets the live
-    /// DPI-cycle index, so running it every 2s tick on a steady selection
+    /// DPI-cycle index, so running it on every steady reconciliation
     /// would snap DPI back to `preset[0]` (and burn three `RwLock` writes)
     /// for nothing.
     pub fn refresh_inventory(
@@ -517,6 +517,13 @@ impl Orchestrator {
         self.devices = devices;
         self.current = next_current;
         self.rebuild();
+    }
+
+    /// Whether volatile-setting writes still need a delayed inventory pass to
+    /// confirm them after device boot or system resume.
+    #[must_use]
+    pub fn needs_reapply_confirmation(&self) -> bool {
+        !self.reapply_followup.is_empty()
     }
 
     /// Force a volatile-settings re-apply for every online device on the next
@@ -1059,13 +1066,13 @@ fn any_device_needs_capture_rearm(
     !reapply_targets(prev, next, reapply_all).is_empty()
 }
 
-/// How many inventory ticks a first-sighted or wake-flagged device keeps
-/// re-applying its volatile settings after the initial write. A cold restart
-/// leaves a Bolt/Unifying mouse slow to enumerate — and a system wake can
-/// enumerate a receiver whose mouse link is still re-establishing — so the
-/// first write (and a single confirm) can both time out against a
-/// still-booting device; retrying for ~8s at the 2s cadence lets the write
-/// land once it finishes booting.
+/// How many explicit confirmation passes a first-sighted or wake-flagged
+/// device keeps re-applying its volatile settings after the initial write. A
+/// cold restart leaves a Bolt/Unifying mouse slow to enumerate — and a system
+/// wake can enumerate a receiver whose mouse link is still re-establishing —
+/// so the first write (and a single confirm) can both time out against a
+/// still-booting device. Four confirmations are requested at two-second
+/// intervals; any intervening authoritative reconciliation satisfies one.
 const VOLATILE_REAPPLY_CONFIRM_RETRIES: u8 = 4;
 
 /// Plan this refresh's volatile-settings writes: the [`reapply_targets`] set

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -614,6 +614,23 @@ fn plan_reapply_skips_a_followup_that_went_offline() {
     assert!(followup.is_empty());
 }
 
+#[test]
+fn orchestrator_exposes_only_the_bounded_confirmation_run() {
+    let mut orchestrator = orchestrator(Config::default());
+    let inventory = direct_inventory(Some("serial-1"), [1, 2, 3, 4]);
+
+    orchestrator.refresh_inventory(std::slice::from_ref(&inventory), &[], false);
+    assert!(orchestrator.needs_reapply_confirmation());
+
+    for confirmations_left in (0..VOLATILE_REAPPLY_CONFIRM_RETRIES).rev() {
+        orchestrator.refresh_inventory(std::slice::from_ref(&inventory), &[], false);
+        assert_eq!(
+            orchestrator.needs_reapply_confirmation(),
+            confirmations_left > 0
+        );
+    }
+}
+
 /// An *empty* snapshot still flips the health to `Ready`: the watcher only
 /// forwards completed enumerations, so "checked and found nothing" must not
 /// be reported as "still scanning" — that's the whole distinction the

--- a/crates/openlogi-agent-core/src/watchers/foreground_app.rs
+++ b/crates/openlogi-agent-core/src/watchers/foreground_app.rs
@@ -13,13 +13,24 @@ use super::poll::Poll;
 use std::sync::mpsc::RecvTimeoutError;
 #[cfg(target_os = "macos")]
 use std::thread;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 use std::time::Instant;
 #[cfg(target_os = "macos")]
 use tracing::{debug, warn};
 
-#[cfg(target_os = "macos")]
-const MACOS_RECONCILE_PERIOD: Duration = Duration::from_secs(30);
+/// Long-stop recovery after the native activation path has been quiet.
+///
+/// This is deliberately not a foreground polling cadence: every delivered
+/// native activation defers it. It remains armed because AppKit can lose a
+/// notification or retain an observer that has silently stopped calling back;
+/// neither condition disconnects the callback channel.
+#[cfg(any(target_os = "macos", test))]
+const MACOS_IDLE_RECOVERY_INTERVAL: Duration = Duration::from_secs(30);
+
+#[cfg(any(target_os = "macos", test))]
+fn next_idle_recovery_deadline(now: Instant) -> Instant {
+    now + MACOS_IDLE_RECOVERY_INTERVAL
+}
 
 /// Channel item: `Some(app)` when an app is frontmost; `None` for "no
 /// foreground app" (rare on macOS — Finder is usually frontmost even when
@@ -85,8 +96,10 @@ impl ForegroundChanges {
 }
 
 /// Observe native app activations from each notification's application payload.
-/// A slow authoritative reconciliation read recovers from any notification the
-/// OS failed to deliver and notices a dropped consumer without a separate poll.
+/// After 30 seconds without a native activation, one authoritative read recovers
+/// from a notification the OS failed to deliver or from an observer that remains
+/// registered but has silently stopped delivering callbacks. Successful native
+/// delivery keeps deferring that deadline, so this is not periodic polling.
 #[cfg(target_os = "macos")]
 fn spawn_macos() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -105,10 +118,10 @@ fn spawn_macos() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
             if !publish_current(&tx, &mut changes) {
                 return;
             }
-            let mut next_reconcile = Instant::now() + MACOS_RECONCILE_PERIOD;
+            let mut idle_recovery_deadline = next_idle_recovery_deadline(Instant::now());
 
             loop {
-                let timeout = next_reconcile.saturating_duration_since(Instant::now());
+                let timeout = idle_recovery_deadline.saturating_duration_since(Instant::now());
                 match activation_rx.recv_timeout(timeout) {
                     Ok(mut activation) => {
                         // Coalesce a burst to its latest authoritative AppKit
@@ -120,21 +133,26 @@ fn spawn_macos() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
                         if !publish(&tx, &mut changes, activation) {
                             return;
                         }
-                        next_reconcile = Instant::now() + MACOS_RECONCILE_PERIOD;
+                        idle_recovery_deadline = next_idle_recovery_deadline(Instant::now());
                     }
                     Err(RecvTimeoutError::Timeout) => {
                         if tx.is_closed() {
                             debug!("foreground-app watcher receiver dropped — exiting");
                             return;
                         }
-                        if Instant::now() >= next_reconcile {
+                        if Instant::now() >= idle_recovery_deadline {
                             if !publish_current(&tx, &mut changes) {
                                 return;
                             }
-                            next_reconcile = Instant::now() + MACOS_RECONCILE_PERIOD;
+                            idle_recovery_deadline = next_idle_recovery_deadline(Instant::now());
                         }
                     }
                     Err(RecvTimeoutError::Disconnected) => {
+                        // `_observer` retains the callback and therefore its
+                        // sender for this loop's lifetime. Silence does not
+                        // disconnect it (the idle recovery above handles that),
+                        // so disconnection means the observer ownership
+                        // contract itself broke and there is no producer left.
                         warn!(
                             "foreground-app activation observer stopped — per-app profiles are disabled"
                         );
@@ -193,5 +211,23 @@ mod tests {
         assert!(!changes.observe(&Some(app("com.example.One"))));
         assert!(changes.observe(&Some(app("com.example.Two"))));
         assert!(changes.observe(&None));
+    }
+
+    #[test]
+    fn native_activity_defers_the_idle_recovery_read() {
+        let started = Instant::now();
+        let original = next_idle_recovery_deadline(started);
+        let activation = started + Duration::from_secs(12);
+        let deferred = next_idle_recovery_deadline(activation);
+
+        assert_eq!(
+            original.saturating_duration_since(started),
+            MACOS_IDLE_RECOVERY_INTERVAL
+        );
+        assert_eq!(
+            deferred.saturating_duration_since(activation),
+            MACOS_IDLE_RECOVERY_INTERVAL
+        );
+        assert!(deferred > original);
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/foreground_app.rs
+++ b/crates/openlogi-agent-core/src/watchers/foreground_app.rs
@@ -24,6 +24,29 @@ fn next_idle_recovery_deadline(now: Instant) -> Instant {
     now + IDLE_RECOVERY_INTERVAL
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IdleRecovery {
+    ReadCurrent,
+    RenewObserver,
+}
+
+enum ObserverExit {
+    RecoverAfterDrop,
+    RetryAfterFailure,
+}
+
+/// Linux's selected native source moves onto the observer worker, so reads
+/// while it is active intentionally return the latest publication. Renewing
+/// the observer returns that source to the synchronous reader before recovery;
+/// macOS and Windows can query their OS state independently.
+const fn idle_recovery() -> IdleRecovery {
+    if cfg!(target_os = "linux") {
+        IdleRecovery::RenewObserver
+    } else {
+        IdleRecovery::ReadCurrent
+    }
+}
+
 /// Channel item: `Some(app)` when an app is frontmost; `None` for "no
 /// foreground app" (rare on macOS — Finder is usually frontmost even when
 /// nothing else is).
@@ -32,7 +55,7 @@ pub type ForegroundUpdate = Option<ForegroundApp>;
 /// Watch foreground application changes.
 ///
 /// macOS, Linux, and Windows use native platform events plus a slow idle
-/// recovery read. Unsupported targets return a receiver that never yields.
+/// recovery pass. Unsupported targets return a receiver that never yields.
 #[must_use]
 pub fn spawn() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     if !cfg!(any(
@@ -56,8 +79,8 @@ pub fn spawn() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
 }
 
 /// The last value published to the orchestrator, used only to suppress
-/// duplicate snapshots. `NSWorkspace`, not this adapter, remains the source of
-/// truth for the current application.
+/// duplicate snapshots. The native platform source, not this adapter, remains
+/// the source of truth for the current application.
 #[derive(Default)]
 struct ForegroundChanges {
     published: Option<ForegroundUpdate>,
@@ -74,8 +97,10 @@ impl ForegroundChanges {
 }
 
 /// Treat native callbacks as invalidations, then read the hook crate's current
-/// application SSOT. After 30 seconds without an event, one authoritative read
-/// and health check recover from a missed event or silent observer failure.
+/// application SSOT. After 30 seconds without an event, a health check and
+/// authoritative read recover from a missed event or silent observer failure.
+/// Linux first renews its observer because its active source owns the native
+/// transport and serves reads from the last event publication.
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn spawn_native() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -113,7 +138,7 @@ fn spawn_native() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
                 };
                 recovery_deadline = next_idle_recovery_deadline(Instant::now());
 
-                loop {
+                let observer_exit = loop {
                     let timeout = recovery_deadline.saturating_duration_since(Instant::now());
                     match native_rx.recv_timeout(timeout) {
                         Ok(()) => {
@@ -130,7 +155,10 @@ fn spawn_native() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
                             }
                             if let Err(error) = observer.check_health() {
                                 warn!(%error, "native foreground-app observer stopped; restarting");
-                                break;
+                                break ObserverExit::RetryAfterFailure;
+                            }
+                            if idle_recovery() == IdleRecovery::RenewObserver {
+                                break ObserverExit::RecoverAfterDrop;
                             }
                             if !publish_current(&tx, &mut changes) {
                                 return;
@@ -139,17 +167,27 @@ fn spawn_native() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
                         }
                         Err(RecvTimeoutError::Disconnected) => {
                             warn!("native foreground-app observer disconnected; restarting");
-                            break;
+                            break ObserverExit::RetryAfterFailure;
                         }
                     }
-                }
+                };
 
+                // On Linux this synchronously returns the selected native
+                // source to `frontmost_application`, so the recovery read below
+                // cannot be satisfied by the stale observer publication.
                 drop(observer);
                 if tx.is_closed() {
                     debug!("foreground-app watcher receiver dropped — exiting");
                     return;
                 }
-                thread::sleep(OBSERVER_RETRY_INTERVAL);
+                match observer_exit {
+                    ObserverExit::RecoverAfterDrop => {
+                        if !publish_current(&tx, &mut changes) {
+                            return;
+                        }
+                    }
+                    ObserverExit::RetryAfterFailure => thread::sleep(OBSERVER_RETRY_INTERVAL),
+                }
             }
         });
     if let Err(error) = spawned {
@@ -218,5 +256,11 @@ mod tests {
             IDLE_RECOVERY_INTERVAL
         );
         assert!(deferred > original);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linux_idle_recovery_renews_the_observer_before_reading() {
+        assert_eq!(idle_recovery(), IdleRecovery::RenewObserver);
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/foreground_app.rs
+++ b/crates/openlogi-agent-core/src/watchers/foreground_app.rs
@@ -1,35 +1,27 @@
 //! Foreground application watcher.
 
-use std::time::Duration;
+use std::sync::mpsc::RecvTimeoutError;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use openlogi_core::app::ForegroundApp;
 use tokio::sync::mpsc;
-
-use super::poll;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
-use super::poll::Poll;
-
-#[cfg(target_os = "macos")]
-use std::sync::mpsc::RecvTimeoutError;
-#[cfg(target_os = "macos")]
-use std::thread;
-#[cfg(any(target_os = "macos", test))]
-use std::time::Instant;
-#[cfg(target_os = "macos")]
 use tracing::{debug, warn};
 
-/// Long-stop recovery after the native activation path has been quiet.
+use super::poll;
+
+/// Recovery after the native event path has been quiet.
 ///
 /// This is deliberately not a foreground polling cadence: every delivered
-/// native activation defers it. It remains armed because AppKit can lose a
-/// notification or retain an observer that has silently stopped calling back;
-/// neither condition disconnects the callback channel.
-#[cfg(any(target_os = "macos", test))]
-const MACOS_IDLE_RECOVERY_INTERVAL: Duration = Duration::from_secs(30);
+/// native event defers it. It remains armed because native observers and event
+/// transports can miss a change without disconnecting their callback.
+const IDLE_RECOVERY_INTERVAL: Duration = Duration::from_secs(30);
 
-#[cfg(any(target_os = "macos", test))]
+/// Retry cadence only while native observer setup or health is failing.
+const OBSERVER_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
 fn next_idle_recovery_deadline(now: Instant) -> Instant {
-    now + MACOS_IDLE_RECOVERY_INTERVAL
+    now + IDLE_RECOVERY_INTERVAL
 }
 
 /// Channel item: `Some(app)` when an app is frontmost; `None` for "no
@@ -39,11 +31,10 @@ pub type ForegroundUpdate = Option<ForegroundApp>;
 
 /// Watch foreground application changes.
 ///
-/// macOS uses native activation notifications plus a slow recovery read. Linux
-/// and Windows keep their platform-specific readers on the supplied polling
-/// cadence.
+/// macOS, Linux, and Windows use native platform events plus a slow idle
+/// recovery read. Unsupported targets return a receiver that never yields.
 #[must_use]
-pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
+pub fn spawn() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     if !cfg!(any(
         target_os = "macos",
         target_os = "linux",
@@ -53,20 +44,9 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
         return poll::never();
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     {
-        let _ = period;
-        spawn_macos()
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
-    {
-        Poll {
-            name: "openlogi-app-watcher",
-            period,
-            degrades: "per-app profiles are disabled",
-        }
-        .on_change(openlogi_hook::frontmost_application)
+        spawn_native()
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
@@ -78,13 +58,11 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
 /// The last value published to the orchestrator, used only to suppress
 /// duplicate snapshots. `NSWorkspace`, not this adapter, remains the source of
 /// truth for the current application.
-#[cfg(any(target_os = "macos", test))]
 #[derive(Default)]
 struct ForegroundChanges {
     published: Option<ForegroundUpdate>,
 }
 
-#[cfg(any(target_os = "macos", test))]
 impl ForegroundChanges {
     fn observe(&mut self, current: &ForegroundUpdate) -> bool {
         if self.published.as_ref() == Some(current) {
@@ -95,70 +73,83 @@ impl ForegroundChanges {
     }
 }
 
-/// Observe native app activations from each notification's application payload.
-/// After 30 seconds without a native activation, one authoritative read recovers
-/// from a notification the OS failed to deliver or from an observer that remains
-/// registered but has silently stopped delivering callbacks. Successful native
-/// delivery keeps deferring that deadline, so this is not periodic polling.
-#[cfg(target_os = "macos")]
-fn spawn_macos() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
+/// Treat native callbacks as invalidations, then read the hook crate's current
+/// application SSOT. After 30 seconds without an event, one authoritative read
+/// and health check recover from a missed event or silent observer failure.
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+fn spawn_native() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     let (tx, rx) = mpsc::unbounded_channel();
     let spawned = thread::Builder::new()
         .name("openlogi-app-watcher".into())
         .spawn(move || {
-            let (activation_tx, activation_rx) = std::sync::mpsc::channel();
-            let _observer =
-                openlogi_hook::watch_frontmost_application_activations(move |activation| {
-                    let _ = activation_tx.send(activation);
-                });
             let mut changes = ForegroundChanges::default();
-
-            // Register first so an activation racing this initial snapshot is
-            // either reflected by the read or queued for the loop below.
-            if !publish_current(&tx, &mut changes) {
-                return;
-            }
-            let mut idle_recovery_deadline = next_idle_recovery_deadline(Instant::now());
+            let mut recovery_deadline = Instant::now();
 
             loop {
-                let timeout = idle_recovery_deadline.saturating_duration_since(Instant::now());
-                match activation_rx.recv_timeout(timeout) {
-                    Ok(mut activation) => {
-                        // Coalesce a burst to its latest authoritative AppKit
-                        // payload; intermediate activations were never stable
-                        // foreground state for the consumer.
-                        while let Ok(next) = activation_rx.try_recv() {
-                            activation = next;
+                // Every callback means only "the authoritative value may have
+                // changed", so capacity one preserves all semantics while
+                // bounding native bursts before this worker can coalesce them.
+                let (native_tx, native_rx) = std::sync::mpsc::sync_channel(1);
+                let observer = match openlogi_hook::watch_frontmost_application_changes(move || {
+                    let _ = native_tx.try_send(());
+                }) {
+                    Ok(observer) => observer,
+                    Err(error) => {
+                        warn!(%error, "could not start native foreground-app observer; retrying");
+                        let now = Instant::now();
+                        if now >= recovery_deadline {
+                            if !publish_current(&tx, &mut changes) {
+                                return;
+                            }
+                            recovery_deadline = next_idle_recovery_deadline(now);
                         }
-                        if !publish(&tx, &mut changes, activation) {
-                            return;
-                        }
-                        idle_recovery_deadline = next_idle_recovery_deadline(Instant::now());
-                    }
-                    Err(RecvTimeoutError::Timeout) => {
+                        thread::sleep(OBSERVER_RETRY_INTERVAL);
                         if tx.is_closed() {
                             debug!("foreground-app watcher receiver dropped — exiting");
                             return;
                         }
-                        if Instant::now() >= idle_recovery_deadline {
+                        continue;
+                    }
+                };
+                recovery_deadline = next_idle_recovery_deadline(Instant::now());
+
+                loop {
+                    let timeout = recovery_deadline.saturating_duration_since(Instant::now());
+                    match native_rx.recv_timeout(timeout) {
+                        Ok(()) => {
+                            while native_rx.try_recv().is_ok() {}
                             if !publish_current(&tx, &mut changes) {
                                 return;
                             }
-                            idle_recovery_deadline = next_idle_recovery_deadline(Instant::now());
+                            recovery_deadline = next_idle_recovery_deadline(Instant::now());
+                        }
+                        Err(RecvTimeoutError::Timeout) => {
+                            if tx.is_closed() {
+                                debug!("foreground-app watcher receiver dropped — exiting");
+                                return;
+                            }
+                            if let Err(error) = observer.check_health() {
+                                warn!(%error, "native foreground-app observer stopped; restarting");
+                                break;
+                            }
+                            if !publish_current(&tx, &mut changes) {
+                                return;
+                            }
+                            recovery_deadline = next_idle_recovery_deadline(Instant::now());
+                        }
+                        Err(RecvTimeoutError::Disconnected) => {
+                            warn!("native foreground-app observer disconnected; restarting");
+                            break;
                         }
                     }
-                    Err(RecvTimeoutError::Disconnected) => {
-                        // `_observer` retains the callback and therefore its
-                        // sender for this loop's lifetime. Silence does not
-                        // disconnect it (the idle recovery above handles that),
-                        // so disconnection means the observer ownership
-                        // contract itself broke and there is no producer left.
-                        warn!(
-                            "foreground-app activation observer stopped — per-app profiles are disabled"
-                        );
-                        return;
-                    }
                 }
+
+                drop(observer);
+                if tx.is_closed() {
+                    debug!("foreground-app watcher receiver dropped — exiting");
+                    return;
+                }
+                thread::sleep(OBSERVER_RETRY_INTERVAL);
             }
         });
     if let Err(error) = spawned {
@@ -167,7 +158,6 @@ fn spawn_macos() -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     rx
 }
 
-#[cfg(target_os = "macos")]
 fn publish_current(
     tx: &mpsc::UnboundedSender<ForegroundUpdate>,
     changes: &mut ForegroundChanges,
@@ -175,7 +165,6 @@ fn publish_current(
     publish(tx, changes, openlogi_hook::frontmost_application())
 }
 
-#[cfg(target_os = "macos")]
 fn publish(
     tx: &mpsc::UnboundedSender<ForegroundUpdate>,
     changes: &mut ForegroundChanges,
@@ -222,11 +211,11 @@ mod tests {
 
         assert_eq!(
             original.saturating_duration_since(started),
-            MACOS_IDLE_RECOVERY_INTERVAL
+            IDLE_RECOVERY_INTERVAL
         );
         assert_eq!(
             deferred.saturating_duration_since(activation),
-            MACOS_IDLE_RECOVERY_INTERVAL
+            IDLE_RECOVERY_INTERVAL
         );
         assert!(deferred > original);
     }

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -1,25 +1,31 @@
-//! HID inventory watcher: periodic polling, woken early by hotplug events.
+//! Event-first HID inventory reconciliation.
 //!
-//! Spawns a dedicated OS thread with a one-shot tokio runtime that calls
-//! `openlogi_hid::enumerate` every `period` and forwards each completed
-//! snapshot over an unbounded mpsc to the agent's select loop, which applies
-//! it via `Orchestrator::refresh_inventory`.
-//!
-//! An OS hotplug event (`openlogi_hid::watch_hotplug`) cuts the wait short so
-//! a just-plugged device is probed — and gets its persisted settings applied —
-//! within a settle delay instead of a full period. The periodic tick stays as
-//! the reconciliation pass (battery refresh, missed events, platforms where
-//! the hotplug stream is unavailable).
+//! A dedicated thread owns the persistent enumerator and every HID++ channel
+//! it opens. OS hotplug, receiver/device lifecycle broadcasts, native/system
+//! resume, bounded repair, and settings confirmation are typed reasons to run
+//! one full authoritative reconciliation. A named half-minute recovery scan is
+//! retained because some firmware/hosts miss lifecycle events and legacy or
+//! voltage battery features have no broadcast API.
 
 use std::collections::{BTreeMap, HashSet};
+use std::future::pending;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::{Instant, SystemTime};
 
 use futures_lite::StreamExt as _;
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
 use openlogi_hid::ChannelRegistry;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
+
+use schedule::{
+    DeadlinePurpose, HID_EVENT_SETTLE, HOTPLUG_SETTLE, ReconcileTrigger, SYSTEM_RESUME_SETTLE,
+    Schedule, WakeDetector,
+};
+
+mod schedule;
 
 /// Consecutive *initial* enumerate failures before the watcher declares
 /// enumeration [`InventoryEvent::Unavailable`]. Only counts before the first
@@ -34,17 +40,6 @@ const INITIAL_FAILURE_LIMIT: u8 = 3;
 /// snapshot is not immediately destructive for standalone lights.
 const RAW_NODE_MISS_GRACE: u8 = 2;
 
-/// Pause between a hotplug event and the early enumerate, so a just-connected
-/// node finishes registering with the OS before the probe opens it.
-const HOTPLUG_SETTLE: Duration = Duration::from_millis(400);
-
-/// Wall-clock slack past `period` before a late tick is read as a sleep/wake
-/// gap. Generously above the worst honest iteration (period + a fully
-/// timed-out probe pass), so only a genuine suspend trips it; a rare false
-/// positive (e.g. a large NTP step) merely re-applies settings the devices
-/// already have.
-const WAKE_GAP: Duration = Duration::from_mins(1);
-
 /// What the watcher tells the agent.
 #[derive(Debug)]
 pub enum InventoryEvent {
@@ -54,7 +49,7 @@ pub enum InventoryEvent {
         inventories: Vec<DeviceInventory>,
         /// Recognized standalone raw-HID devices.
         standalone: Vec<StandaloneDevice>,
-        /// Whether this tick failed to open at least one HID++ node — on
+        /// Whether this pass failed to open at least one HID++ node — on
         /// macOS the observable signature of a missing or stale Input
         /// Monitoring grant (the open denial itself is silent).
         hid_open_failures: bool,
@@ -63,20 +58,19 @@ pub enum InventoryEvent {
     /// starting" any longer; without this the GUI would show its scanning
     /// state forever on a broken HID backend.
     Unavailable,
-    /// The wall clock jumped far past the polling period — the system almost
-    /// certainly slept and woke. Devices may have power-cycled while their
+    /// A native resume notification or wall/monotonic clock gap says the
+    /// system slept and woke. Devices may have power-cycled while their
     /// set/route/online state looks unchanged across the gap, so the agent
-    /// re-applies volatile settings on the next snapshot (#189). Detected by
-    /// wall clock because the monotonic clock pauses during sleep on macOS.
+    /// re-applies volatile settings on the next snapshot (#189).
     SystemWake,
 }
 
-/// The watcher's cross-tick memory, factored out of the poll loop so the
-/// tick → event decision is unit-testable without spawning the thread or
+/// The watcher's cross-pass memory, factored out of the I/O loop so the
+/// result → event decision is unit-testable without spawning the thread or
 /// touching real HID.
 #[derive(Default)]
 struct WatchState {
-    /// Set once any enumeration has completed. After that, a failed tick keeps
+    /// Set once any enumeration has completed. After that, a failed pass keeps
     /// the last good snapshot forever instead of ever reporting `Unavailable`.
     succeeded: bool,
     /// Consecutive failures, counted only before the first success.
@@ -138,6 +132,10 @@ impl RawNodeLedger {
             .map(|entry| entry.device.clone())
             .collect()
     }
+
+    fn has_pending_misses(&self) -> bool {
+        self.entries.values().any(|entry| entry.misses > 0)
+    }
 }
 
 fn raw_node_key(device: &StandaloneDevice) -> String {
@@ -168,7 +166,7 @@ impl WatchState {
             Err(e) => {
                 warn!(
                     error = ?e,
-                    "standalone enumerate failed during watch tick — keeping last raw snapshot"
+                    "standalone enumerate failed during reconciliation — keeping last raw snapshot"
                 );
                 self.raw_nodes.snapshot()
             }
@@ -180,7 +178,7 @@ impl WatchState {
         }
     }
 
-    /// Decide what (if anything) a watch tick emits.
+    /// Decide what (if anything) a reconciliation pass emits.
     ///
     /// - `Ok(snapshot)` — a completed enumeration (an empty one included: that's
     ///   a genuine disconnect) — is forwarded so the agent's device set tracks
@@ -189,7 +187,7 @@ impl WatchState {
     ///   (#218/#222).
     /// - `Err(..)` means enumeration itself failed (OS-level HID enumerate
     ///   error): emit nothing, so the agent keeps its last good device set and
-    ///   live bindings instead of wiping them for ~one period. Before the *first*
+    ///   live bindings instead of wiping them. Before the *first*
     ///   success there is no good set to keep, so persistent initial failure is
     ///   reported once as [`InventoryEvent::Unavailable`]; the loop keeps
     ///   retrying and a later success recovers.
@@ -202,7 +200,7 @@ impl WatchState {
                 Some(self.classify_parts(inventories, Ok(standalone), false))
             }
             Err(e) => {
-                warn!(error = ?e, "enumerate failed during watch tick — keeping last snapshot");
+                warn!(error = ?e, "enumerate failed during reconciliation — keeping last snapshot");
                 if self.succeeded {
                     return None;
                 }
@@ -214,35 +212,58 @@ impl WatchState {
     }
 }
 
-/// Spawn the watcher and return a receiver of inventory events. The
-/// channel is unbounded so a slow consumer cannot back-pressure the HID
-/// poll loop into stalling on a real device disconnect.
-///
-/// Dropping the receiver shuts the watcher down: the next `send` fails and
-/// the loop exits cleanly. The watcher dying instead (a panic inside the HID
-/// backend) closes the channel — the agent select loop maps that closure to
-/// `Unavailable` too.
-#[must_use]
-pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<InventoryEvent> {
-    spawn_inner(period, None)
+/// A handle for requesting inventory work whose purpose belongs to the
+/// authoritative orchestrator rather than a HID event source.
+#[derive(Clone)]
+pub struct InventoryRefresh {
+    sender: mpsc::Sender<RefreshRequest>,
 }
 
-/// Spawn the persistent watcher and publish its inventory-owned HID++ channels
-/// into `registry` for Agent capture and hardware operations.
+impl InventoryRefresh {
+    /// Request the next delayed confirmation pass for volatile settings.
+    /// Repeated requests coalesce into the bounded one-slot channel.
+    pub fn request_settings_confirmation(&self) {
+        let _ = self.sender.try_send(RefreshRequest::SettingsConfirmation);
+    }
+}
+
+/// The watcher's event stream plus its settings-confirmation request handle.
+pub struct InventoryWatcher {
+    /// Completed snapshots and watcher-health events.
+    pub events: mpsc::UnboundedReceiver<InventoryEvent>,
+    /// Requests driven by state known only after the orchestrator applies a
+    /// snapshot.
+    pub refresh: InventoryRefresh,
+}
+
+#[derive(Clone, Copy)]
+enum RefreshRequest {
+    SettingsConfirmation,
+}
+
+/// Spawn a watcher without publishing channels into a registry.
+#[must_use]
+pub fn spawn() -> InventoryWatcher {
+    spawn_inner(None, None)
+}
+
+/// Spawn the persistent watcher, publish its already-open HID++ channels into
+/// `registry`, and consume an optional coalesced native-resume flag.
 #[must_use]
 pub fn spawn_with_registry(
-    period: Duration,
     registry: ChannelRegistry,
-) -> mpsc::UnboundedReceiver<InventoryEvent> {
-    spawn_inner(period, Some(registry))
+    resume_pending: Option<Arc<AtomicBool>>,
+) -> InventoryWatcher {
+    spawn_inner(Some(registry), resume_pending)
 }
 
 fn spawn_inner(
-    period: Duration,
     registry: Option<ChannelRegistry>,
-) -> mpsc::UnboundedReceiver<InventoryEvent> {
-    let (tx, rx) = mpsc::unbounded_channel();
-    let worker_tx = tx.clone();
+    resume_pending: Option<Arc<AtomicBool>>,
+) -> InventoryWatcher {
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let worker_tx = event_tx.clone();
+    let (refresh_tx, refresh_rx) = mpsc::channel(1);
     let spawn_result = thread::Builder::new()
         .name("openlogi-inventory-watcher".into())
         .spawn(move || {
@@ -256,88 +277,7 @@ fn spawn_inner(
                     return;
                 }
             };
-            // A persistent enumerator so its per-device probe cache survives
-            // across ticks — a known device's immutable data (model, features)
-            // is reused instead of being re-handshaked every poll.
-            // Warm-start from the persisted probe cache too, so devices keep
-            // their identity across agent restarts without a fresh interview.
-            let mut enumerator = openlogi_hid::host::persisted_enumerator();
-            if let Some(registry) = registry {
-                enumerator = enumerator.with_registry(registry);
-            }
-            let mut state = WatchState::default();
-            let mut last_tick = SystemTime::now();
-            // `block_on` installs runtime context so a backend that registers an
-            // `AsyncFd` (Linux udev) fails as a catchable `Err`, not a panic that
-            // would take down the whole watcher thread.
-            let mut hotplug = match rt.block_on(async { openlogi_hid::watch_hotplug() }) {
-                Ok(stream) => Some(stream),
-                Err(e) => {
-                    warn!(error = ?e, "hotplug watch unavailable — polling only");
-                    None
-                }
-            };
-            loop {
-                // A tick arriving far past its period means the system slept;
-                // `duration_since` errs when the clock stepped backwards, in
-                // which case there is nothing to conclude — just re-anchor.
-                let now = SystemTime::now();
-                if let Ok(elapsed) = now.duration_since(last_tick)
-                    && elapsed > period + WAKE_GAP
-                {
-                    info!(?elapsed, "wall-clock gap — assuming a system wake");
-                    if worker_tx.send(InventoryEvent::SystemWake).is_err() {
-                        return;
-                    }
-                }
-                last_tick = now;
-                let event = match rt.block_on(enumerator.enumerate()) {
-                    Ok(inventories) => {
-                        let standalone = rt.block_on(openlogi_hid::enumerate_standalone());
-                        let open_failures = enumerator.open_failures_last_tick();
-                        Some(state.classify_parts(inventories, standalone, open_failures))
-                    }
-                    Err(error) => state.classify(Err(error)),
-                };
-                if let Some(event) = event
-                    && worker_tx.send(event).is_err()
-                {
-                    debug!("inventory watcher receiver dropped — exiting");
-                    return;
-                }
-                let stream_alive = rt.block_on(async {
-                    let Some(stream) = hotplug.as_mut() else {
-                        tokio::time::sleep(period).await;
-                        return true;
-                    };
-                    tokio::select! {
-                        () = tokio::time::sleep(period) => true,
-                        event = stream.next() => match event {
-                            Some(event) => {
-                                debug!(?event, "hotplug event — enumerating early");
-                                tokio::time::sleep(HOTPLUG_SETTLE).await;
-                                // Drain the burst so one enumerate covers every node that just
-                                // arrived; a `None` here is the stream closing, so report it now
-                                // rather than after a spurious extra enumerate next tick.
-                                let mut alive = true;
-                                while let Some(drained) =
-                                    futures_lite::future::poll_once(stream.next()).await
-                                {
-                                    if drained.is_none() {
-                                        alive = false;
-                                        break;
-                                    }
-                                }
-                                alive
-                            }
-                            None => false,
-                        },
-                    }
-                });
-                if !stream_alive && hotplug.take().is_some() {
-                    warn!("hotplug stream ended — falling back to pure polling");
-                }
-            }
+            rt.block_on(run_watcher(worker_tx, refresh_rx, registry, resume_pending));
         });
     if let Err(e) = spawn_result {
         // OS thread / fork limits are non-fatal for the agent as a whole, but
@@ -345,9 +285,200 @@ fn spawn_inner(
         // here would forge a "checked, no devices" answer for a check that
         // never happened.
         warn!(error = %e, "could not spawn inventory watcher — device scanning unavailable");
-        let _ = tx.send(InventoryEvent::Unavailable);
+        let _ = event_tx.send(InventoryEvent::Unavailable);
     }
-    rx
+    InventoryWatcher {
+        events: event_rx,
+        refresh: InventoryRefresh { sender: refresh_tx },
+    }
+}
+
+async fn run_watcher(
+    events: mpsc::UnboundedSender<InventoryEvent>,
+    refresh_requests: mpsc::Receiver<RefreshRequest>,
+    registry: Option<ChannelRegistry>,
+    resume_pending: Option<Arc<AtomicBool>>,
+) {
+    // The listener is attached to each inventory-owned channel before its
+    // first probe, and its bounded queue is subscribed before every snapshot.
+    let (event_notifier, hid_events) = openlogi_hid::inventory::events::event_channel();
+    let mut enumerator =
+        openlogi_hid::host::persisted_enumerator().with_event_notifier(event_notifier);
+    if let Some(registry) = registry {
+        enumerator = enumerator.with_registry(registry);
+    }
+    let hotplug = match openlogi_hid::watch_hotplug() {
+        Ok(stream) => Some(stream),
+        Err(error) => {
+            warn!(
+                ?error,
+                "hotplug watch unavailable — recovery scan remains active"
+            );
+            None
+        }
+    };
+    let now = Instant::now();
+    InventoryWorker {
+        events,
+        refresh_requests,
+        enumerator,
+        state: WatchState::default(),
+        hotplug,
+        hid_events,
+        schedule: Schedule::new(now),
+        wake_detector: WakeDetector::new(SystemTime::now(), now),
+        resume_pending,
+        refresh_open: true,
+    }
+    .run()
+    .await;
+}
+
+struct InventoryWorker {
+    events: mpsc::UnboundedSender<InventoryEvent>,
+    refresh_requests: mpsc::Receiver<RefreshRequest>,
+    enumerator: openlogi_hid::inventory::Enumerator,
+    state: WatchState,
+    hotplug: Option<openlogi_hid::backend::HotplugStream>,
+    hid_events: openlogi_hid::inventory::events::EventReceiver,
+    schedule: Schedule,
+    wake_detector: WakeDetector,
+    resume_pending: Option<Arc<AtomicBool>>,
+    refresh_open: bool,
+}
+
+impl InventoryWorker {
+    async fn run(&mut self) {
+        let mut trigger = ReconcileTrigger::Initial;
+        loop {
+            if !self.settle_trigger(trigger).await || !self.reconcile(trigger).await {
+                return;
+            }
+            trigger = self.next_trigger().await;
+        }
+    }
+
+    async fn settle_trigger(&mut self, trigger: ReconcileTrigger) -> bool {
+        match trigger {
+            ReconcileTrigger::Hotplug => {
+                tokio::time::sleep(HOTPLUG_SETTLE).await;
+                if let Some(stream) = self.hotplug.as_mut() {
+                    while let Some(drained) = futures_lite::future::poll_once(stream.next()).await {
+                        if drained.is_none() {
+                            self.hotplug = None;
+                            warn!("hotplug stream ended — recovery scan remains active");
+                            break;
+                        }
+                    }
+                }
+            }
+            ReconcileTrigger::HidEvent(source) => {
+                debug!(?source, "HID++ lifecycle event — reconciling inventory");
+                tokio::time::sleep(HID_EVENT_SETTLE).await;
+                while self.hid_events.try_recv().is_ok() {}
+            }
+            ReconcileTrigger::SystemResume => {
+                info!("system resume — replaying settings on a settled inventory");
+                if self.events.send(InventoryEvent::SystemWake).is_err() {
+                    return false;
+                }
+                tokio::time::sleep(SYSTEM_RESUME_SETTLE).await;
+            }
+            ReconcileTrigger::Initial
+            | ReconcileTrigger::RepairRetry
+            | ReconcileTrigger::SettingsConfirmation
+            | ReconcileTrigger::RecoveryScan => {}
+        }
+        true
+    }
+
+    async fn reconcile(&mut self, trigger: ReconcileTrigger) -> bool {
+        let (event, needs_repair) = match self.enumerator.enumerate().await {
+            Ok(inventories) => {
+                let standalone = openlogi_hid::enumerate_standalone().await;
+                let standalone_failed = standalone.is_err();
+                let open_failures = self.enumerator.open_failures_last_tick();
+                let event = self
+                    .state
+                    .classify_parts(inventories, standalone, open_failures);
+                let needs_repair = self.enumerator.retry_needed_last_tick()
+                    || standalone_failed
+                    || self.state.raw_nodes.has_pending_misses();
+                (Some(event), needs_repair)
+            }
+            Err(error) => (self.state.classify(Err(error)), true),
+        };
+        if let Some(event) = event
+            && self.events.send(event).is_err()
+        {
+            debug!("inventory watcher receiver dropped — exiting");
+            return false;
+        }
+        self.schedule
+            .scan_finished(trigger, needs_repair, Instant::now());
+        true
+    }
+
+    async fn next_trigger(&mut self) -> ReconcileTrigger {
+        loop {
+            let (deadline, purpose) = self.schedule.next_deadline();
+            let sleep = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline));
+            tokio::pin!(sleep);
+            tokio::select! {
+                hotplug_event = async {
+                    match self.hotplug.as_mut() {
+                        Some(stream) => stream.next().await,
+                        None => pending().await,
+                    }
+                } => if let Some(event) = hotplug_event {
+                    debug!(?event, "hotplug event — scheduling settled reconciliation");
+                    break ReconcileTrigger::Hotplug;
+                } else {
+                    self.hotplug = None;
+                    warn!("hotplug stream ended — recovery scan remains active");
+                },
+                Some(source) = self.hid_events.recv() => {
+                    break ReconcileTrigger::HidEvent(source);
+                }
+                request = async {
+                    if self.refresh_open {
+                        self.refresh_requests.recv().await
+                    } else {
+                        pending().await
+                    }
+                } => match request {
+                    Some(RefreshRequest::SettingsConfirmation) => {
+                        self.schedule.request_settings_confirmation(Instant::now());
+                    }
+                    None => self.refresh_open = false,
+                },
+                () = &mut sleep => {
+                    let now = Instant::now();
+                    match purpose {
+                        DeadlinePurpose::RepairRetry => {
+                            break ReconcileTrigger::RepairRetry;
+                        }
+                        DeadlinePurpose::SettingsConfirmation => {
+                            break ReconcileTrigger::SettingsConfirmation;
+                        }
+                        DeadlinePurpose::RecoveryScan => {
+                            break ReconcileTrigger::RecoveryScan;
+                        }
+                        DeadlinePurpose::SystemWakeCheck => {
+                            self.schedule.wake_check_finished(now);
+                            let native = self.resume_pending.as_ref().is_some_and(|pending| {
+                                pending.swap(false, Ordering::Relaxed)
+                            });
+                            let clock_gap = self.wake_detector.observe(SystemTime::now(), now);
+                            if native || clock_gap {
+                                break ReconcileTrigger::SystemResume;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -9,8 +9,6 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::future::pending;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Instant, SystemTime};
 
@@ -63,6 +61,41 @@ pub enum InventoryEvent {
     /// set/route/online state looks unchanged across the gap, so the agent
     /// re-applies volatile settings on the next snapshot (#189).
     SystemWake,
+}
+
+/// Non-blocking producer for native OS resume callbacks.
+#[derive(Clone)]
+pub struct ResumeSignal {
+    sender: mpsc::Sender<()>,
+}
+
+/// Single-consumer stream of coalesced native OS resume transitions.
+pub struct ResumeEvents {
+    receiver: mpsc::Receiver<()>,
+}
+
+/// Create the directional native-resume channel.
+///
+/// Capacity one intentionally coalesces the equivalent wake, screen-wake, and
+/// session-active bursts some operating systems emit for one resume.
+#[must_use]
+pub fn resume_channel() -> (ResumeSignal, ResumeEvents) {
+    let (sender, receiver) = mpsc::channel(1);
+    (ResumeSignal { sender }, ResumeEvents { receiver })
+}
+
+impl ResumeSignal {
+    /// Publish one native resume transition without blocking the OS callback.
+    pub fn notify(&self) {
+        let _ = self.sender.try_send(());
+    }
+}
+
+impl ResumeEvents {
+    /// Wait for one resume transition. `None` means every producer was dropped.
+    pub async fn recv(&mut self) -> Option<()> {
+        self.receiver.recv().await
+    }
 }
 
 /// The watcher's cross-pass memory, factored out of the I/O loop so the
@@ -248,18 +281,18 @@ pub fn spawn() -> InventoryWatcher {
 }
 
 /// Spawn the persistent watcher, publish its already-open HID++ channels into
-/// `registry`, and consume an optional coalesced native-resume flag.
+/// `registry`, and consume a coalesced native-resume signal.
 #[must_use]
 pub fn spawn_with_registry(
     registry: ChannelRegistry,
-    resume_pending: Option<Arc<AtomicBool>>,
+    resume_events: ResumeEvents,
 ) -> InventoryWatcher {
-    spawn_inner(Some(registry), resume_pending)
+    spawn_inner(Some(registry), Some(resume_events))
 }
 
 fn spawn_inner(
     registry: Option<ChannelRegistry>,
-    resume_pending: Option<Arc<AtomicBool>>,
+    resume_events: Option<ResumeEvents>,
 ) -> InventoryWatcher {
     let (event_tx, event_rx) = mpsc::unbounded_channel();
     let worker_tx = event_tx.clone();
@@ -277,7 +310,7 @@ fn spawn_inner(
                     return;
                 }
             };
-            rt.block_on(run_watcher(worker_tx, refresh_rx, registry, resume_pending));
+            rt.block_on(run_watcher(worker_tx, refresh_rx, registry, resume_events));
         });
     if let Err(e) = spawn_result {
         // OS thread / fork limits are non-fatal for the agent as a whole, but
@@ -297,7 +330,7 @@ async fn run_watcher(
     events: mpsc::UnboundedSender<InventoryEvent>,
     refresh_requests: mpsc::Receiver<RefreshRequest>,
     registry: Option<ChannelRegistry>,
-    resume_pending: Option<Arc<AtomicBool>>,
+    resume_events: Option<ResumeEvents>,
 ) {
     // The listener is attached to each inventory-owned channel before its
     // first probe, and its bounded queue is subscribed before every snapshot.
@@ -327,7 +360,7 @@ async fn run_watcher(
         hid_events,
         schedule: Schedule::new(now),
         wake_detector: WakeDetector::new(SystemTime::now(), now),
-        resume_pending,
+        resume_events,
         refresh_open: true,
     }
     .run()
@@ -343,7 +376,7 @@ struct InventoryWorker {
     hid_events: openlogi_hid::inventory::events::EventReceiver,
     schedule: Schedule,
     wake_detector: WakeDetector,
-    resume_pending: Option<Arc<AtomicBool>>,
+    resume_events: Option<ResumeEvents>,
     refresh_open: bool,
 }
 
@@ -420,7 +453,7 @@ impl InventoryWorker {
     }
 
     async fn next_trigger(&mut self) -> ReconcileTrigger {
-        loop {
+        let trigger = loop {
             let (deadline, purpose) = self.schedule.next_deadline();
             let sleep = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline));
             tokio::pin!(sleep);
@@ -440,6 +473,17 @@ impl InventoryWorker {
                 Some(source) = self.hid_events.recv() => {
                     break ReconcileTrigger::HidEvent(source);
                 }
+                resumed = async {
+                    match self.resume_events.as_mut() {
+                        Some(events) => events.recv().await,
+                        None => pending().await,
+                    }
+                } => {
+                    if resumed.is_some() {
+                        break ReconcileTrigger::SystemResume;
+                    }
+                    self.resume_events = None;
+                }
                 request = async {
                     if self.refresh_open {
                         self.refresh_requests.recv().await
@@ -453,7 +497,6 @@ impl InventoryWorker {
                     None => self.refresh_open = false,
                 },
                 () = &mut sleep => {
-                    let now = Instant::now();
                     match purpose {
                         DeadlinePurpose::RepairRetry => {
                             break ReconcileTrigger::RepairRetry;
@@ -464,19 +507,24 @@ impl InventoryWorker {
                         DeadlinePurpose::RecoveryScan => {
                             break ReconcileTrigger::RecoveryScan;
                         }
-                        DeadlinePurpose::SystemWakeCheck => {
-                            self.schedule.wake_check_finished(now);
-                            let native = self.resume_pending.as_ref().is_some_and(|pending| {
-                                pending.swap(false, Ordering::Relaxed)
-                            });
-                            let clock_gap = self.wake_detector.observe(SystemTime::now(), now);
-                            if native || clock_gap {
-                                break ReconcileTrigger::SystemResume;
-                            }
-                        }
                     }
                 }
             }
+        };
+
+        // Any event that wakes this task is also an opportunity to compare the
+        // clocks. This preserves resume recovery when the native source is
+        // unavailable without restoring a dedicated wake-check timer. A
+        // SystemResume reconciliation is already authoritative, so replacing
+        // another trigger loses no inventory work.
+        if trigger != ReconcileTrigger::SystemResume
+            && self
+                .wake_detector
+                .observe(SystemTime::now(), Instant::now())
+        {
+            ReconcileTrigger::SystemResume
+        } else {
+            trigger
         }
     }
 }
@@ -484,11 +532,26 @@ impl InventoryWorker {
 #[cfg(test)]
 mod tests {
     use std::assert_matches;
+    use std::time::Duration;
 
     use openlogi_core::device::{DeviceKind, RawDeviceAddress, StandaloneDevice};
     use openlogi_hid::{BackendError, InventoryError};
 
-    use super::{INITIAL_FAILURE_LIMIT, InventoryEvent, WatchState};
+    use super::{INITIAL_FAILURE_LIMIT, InventoryEvent, WatchState, resume_channel};
+
+    #[tokio::test]
+    async fn resume_signal_retains_and_coalesces_native_callbacks() {
+        let (signal, mut events) = resume_channel();
+        signal.notify();
+        signal.notify();
+        tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("a callback before the waiter is retained")
+            .expect("the signal producer remains alive");
+        tokio::time::timeout(Duration::from_millis(10), events.recv())
+            .await
+            .expect_err("equivalent callbacks coalesce into one resume");
+    }
 
     /// A transport-level enumerate failure — what the watcher's `Err` arm now
     /// sees (a partial per-node read is replayed by the hid ledger as `Ok`).

--- a/crates/openlogi-agent-core/src/watchers/inventory/schedule.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory/schedule.rs
@@ -1,0 +1,258 @@
+//! Deterministic scheduling policy for event-first inventory reconciliation.
+
+use std::time::{Duration, Instant, SystemTime};
+
+use openlogi_hid::inventory::events::HidppEventSource;
+
+/// A bounded repair/confirmation retry delay. This keeps the old two-second
+/// cadence only while an explicit lifecycle contract still needs it.
+pub(super) const FAST_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Pause after an OS node event while the HID interface set settles.
+pub(super) const HOTPLUG_SETTLE: Duration = Duration::from_millis(400);
+
+/// Pause after a HID++ burst so one reconciliation covers the whole burst.
+pub(super) const HID_EVENT_SETTLE: Duration = Duration::from_millis(200);
+
+/// Pause after resume before probing devices that may still be reconnecting.
+pub(super) const SYSTEM_RESUME_SETTLE: Duration = Duration::from_millis(400);
+
+/// Authoritative recovery cadence when no trustworthy event arrives.
+///
+/// Receiver notifications and OS hotplug can be disabled, unsupported, or
+/// missed across firmware/host transitions. Unified battery has an event, but
+/// legacy `0x1000` and voltage `0x1001` batteries do not. Thirty seconds
+/// preserves the probe cache's prior freshness bound, keeps those readings
+/// useful, and bounds recovery without returning to constant full HID scans.
+pub(super) const RECOVERY_SCAN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// The wake check does no HID work. It preserves the wall-clock-gap fallback
+/// on platforms without (or after failure of) a native resume notification.
+pub(super) const SYSTEM_WAKE_CHECK_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Wall-clock lead over monotonic time that means the monotonic clock paused
+/// during system sleep. NTP false positives only cause harmless re-apply.
+const WAKE_GAP: Duration = Duration::from_mins(1);
+
+/// Fast passes after the scan that first found an unhealthy node. Four are
+/// enough to cross the ledger's second-failure retirement, let users release
+/// the old channel, defer reopen for one pass, and then probe the replacement.
+const FAST_RETRY_LIMIT: u8 = 4;
+
+/// One explicit reason for an authoritative reconciliation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReconcileTrigger {
+    /// First inventory after the agent arms.
+    Initial,
+    /// Bounded repair of a failed open/probe or pending miss grace.
+    RepairRetry,
+    /// A persistent HID++ channel reported lifecycle state.
+    HidEvent(HidppEventSource),
+    /// The host HID node set changed.
+    Hotplug,
+    /// Native notification or wall/monotonic gap reported system resume.
+    SystemResume,
+    /// Volatile setting writes still need their bounded confirmation pass.
+    SettingsConfirmation,
+    /// Low-frequency authority for unsupported or missed event paths.
+    RecoveryScan,
+}
+
+/// A deadline owned by the inventory worker.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DeadlinePurpose {
+    RepairRetry,
+    SettingsConfirmation,
+    RecoveryScan,
+    SystemWakeCheck,
+}
+
+/// Scheduling state only; all I/O stays in the watcher loop.
+pub(super) struct Schedule {
+    retry_due: Option<Instant>,
+    settings_due: Option<Instant>,
+    recovery_due: Instant,
+    wake_check_due: Instant,
+    retry_count: u8,
+}
+
+impl Schedule {
+    pub(super) fn new(now: Instant) -> Self {
+        Self {
+            retry_due: None,
+            settings_due: None,
+            recovery_due: now + RECOVERY_SCAN_INTERVAL,
+            wake_check_due: now + SYSTEM_WAKE_CHECK_INTERVAL,
+            retry_count: 0,
+        }
+    }
+
+    /// Earliest deadline and its single purpose. Ties prefer work that will
+    /// perform a reconciliation over the clock-only wake check.
+    pub(super) fn next_deadline(&self) -> (Instant, DeadlinePurpose) {
+        let mut next = (self.recovery_due, DeadlinePurpose::RecoveryScan);
+        for candidate in [
+            self.retry_due.map(|at| (at, DeadlinePurpose::RepairRetry)),
+            self.settings_due
+                .map(|at| (at, DeadlinePurpose::SettingsConfirmation)),
+            Some((self.wake_check_due, DeadlinePurpose::SystemWakeCheck)),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if candidate.0 < next.0
+                || (candidate.0 == next.0 && matches!(next.1, DeadlinePurpose::SystemWakeCheck))
+            {
+                next = candidate;
+            }
+        }
+        next
+    }
+
+    /// Any completed full pass satisfies pending repair and settings deadlines.
+    /// An unhealthy result then starts (or advances) one bounded repair run.
+    pub(super) fn scan_finished(
+        &mut self,
+        trigger: ReconcileTrigger,
+        needs_repair: bool,
+        now: Instant,
+    ) {
+        self.retry_due = None;
+        self.settings_due = None;
+        self.recovery_due = now + RECOVERY_SCAN_INTERVAL;
+
+        if !matches!(trigger, ReconcileTrigger::RepairRetry) {
+            self.retry_count = 0;
+        }
+        if needs_repair && self.retry_count < FAST_RETRY_LIMIT {
+            self.retry_count += 1;
+            self.retry_due = Some(now + FAST_RETRY_DELAY);
+        } else if !needs_repair {
+            self.retry_count = 0;
+        }
+    }
+
+    /// Request one delayed settings-confirmation pass. Repeated requests
+    /// coalesce, and any intervening full scan satisfies the request.
+    pub(super) fn request_settings_confirmation(&mut self, now: Instant) {
+        self.settings_due.get_or_insert(now + FAST_RETRY_DELAY);
+    }
+
+    /// Rearm the clock-only wake check after one observation.
+    pub(super) fn wake_check_finished(&mut self, now: Instant) {
+        self.wake_check_due = now + SYSTEM_WAKE_CHECK_INTERVAL;
+    }
+}
+
+/// Detects suspend by comparing wall and monotonic elapsed time.
+pub(super) struct WakeDetector {
+    wall: SystemTime,
+    monotonic: Instant,
+}
+
+impl WakeDetector {
+    pub(super) fn new(wall: SystemTime, monotonic: Instant) -> Self {
+        Self { wall, monotonic }
+    }
+
+    pub(super) fn observe(&mut self, wall: SystemTime, monotonic: Instant) -> bool {
+        let monotonic_elapsed = monotonic.saturating_duration_since(self.monotonic);
+        let woke = wall
+            .duration_since(self.wall)
+            .is_ok_and(|wall_elapsed| wall_elapsed > monotonic_elapsed + WAKE_GAP);
+        self.wall = wall;
+        self.monotonic = monotonic;
+        woke
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repair_retries_are_fast_but_bounded() {
+        let start = Instant::now();
+        let mut schedule = Schedule::new(start);
+
+        schedule.scan_finished(ReconcileTrigger::Initial, true, start);
+        for _ in 0..FAST_RETRY_LIMIT {
+            let due = loop {
+                let (due, purpose) = schedule.next_deadline();
+                if purpose == DeadlinePurpose::RepairRetry {
+                    break due;
+                }
+                assert_eq!(purpose, DeadlinePurpose::SystemWakeCheck);
+                schedule.wake_check_finished(due);
+            };
+            schedule.scan_finished(ReconcileTrigger::RepairRetry, true, due);
+        }
+
+        assert!(schedule.retry_due.is_none());
+        assert_eq!(schedule.retry_count, FAST_RETRY_LIMIT);
+    }
+
+    #[test]
+    fn healthy_pass_resets_the_repair_budget() {
+        let start = Instant::now();
+        let mut schedule = Schedule::new(start);
+        schedule.scan_finished(ReconcileTrigger::Initial, true, start);
+        let retry = schedule.next_deadline().0;
+        schedule.scan_finished(ReconcileTrigger::RepairRetry, false, retry);
+
+        assert!(schedule.retry_due.is_none());
+        assert_eq!(schedule.retry_count, 0);
+    }
+
+    #[test]
+    fn settings_confirmation_has_one_explicit_delayed_deadline() {
+        let start = Instant::now();
+        let mut schedule = Schedule::new(start);
+        schedule.request_settings_confirmation(start);
+        schedule.request_settings_confirmation(start + Duration::from_secs(1));
+
+        assert_eq!(
+            schedule.next_deadline(),
+            (
+                start + FAST_RETRY_DELAY,
+                DeadlinePurpose::SettingsConfirmation,
+            )
+        );
+        schedule.scan_finished(
+            ReconcileTrigger::SettingsConfirmation,
+            false,
+            start + FAST_RETRY_DELAY,
+        );
+        assert!(schedule.settings_due.is_none());
+    }
+
+    #[test]
+    fn event_scan_reanchors_the_inactivity_recovery_deadline() {
+        let start = Instant::now();
+        let mut schedule = Schedule::new(start);
+        let event_time = start + Duration::from_secs(30);
+        schedule.scan_finished(
+            ReconcileTrigger::HidEvent(HidppEventSource::UnifiedBattery),
+            false,
+            event_time,
+        );
+
+        assert_eq!(schedule.recovery_due, event_time + RECOVERY_SCAN_INTERVAL);
+    }
+
+    #[test]
+    fn wake_detection_uses_wall_lead_not_a_slow_iteration() {
+        let monotonic = Instant::now();
+        let wall = SystemTime::now();
+        let mut detector = WakeDetector::new(wall, monotonic);
+
+        assert!(!detector.observe(
+            wall + Duration::from_secs(70),
+            monotonic + Duration::from_secs(70),
+        ));
+        assert!(detector.observe(
+            wall + Duration::from_secs(140),
+            monotonic + Duration::from_secs(72),
+        ));
+    }
+}

--- a/crates/openlogi-agent-core/src/watchers/inventory/schedule.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory/schedule.rs
@@ -26,10 +26,6 @@ pub(super) const SYSTEM_RESUME_SETTLE: Duration = Duration::from_millis(400);
 /// useful, and bounds recovery without returning to constant full HID scans.
 pub(super) const RECOVERY_SCAN_INTERVAL: Duration = Duration::from_secs(30);
 
-/// The wake check does no HID work. It preserves the wall-clock-gap fallback
-/// on platforms without (or after failure of) a native resume notification.
-pub(super) const SYSTEM_WAKE_CHECK_INTERVAL: Duration = Duration::from_secs(2);
-
 /// Wall-clock lead over monotonic time that means the monotonic clock paused
 /// during system sleep. NTP false positives only cause harmless re-apply.
 const WAKE_GAP: Duration = Duration::from_mins(1);
@@ -64,7 +60,6 @@ pub(super) enum DeadlinePurpose {
     RepairRetry,
     SettingsConfirmation,
     RecoveryScan,
-    SystemWakeCheck,
 }
 
 /// Scheduling state only; all I/O stays in the watcher loop.
@@ -72,7 +67,6 @@ pub(super) struct Schedule {
     retry_due: Option<Instant>,
     settings_due: Option<Instant>,
     recovery_due: Instant,
-    wake_check_due: Instant,
     retry_count: u8,
 }
 
@@ -82,27 +76,22 @@ impl Schedule {
             retry_due: None,
             settings_due: None,
             recovery_due: now + RECOVERY_SCAN_INTERVAL,
-            wake_check_due: now + SYSTEM_WAKE_CHECK_INTERVAL,
             retry_count: 0,
         }
     }
 
-    /// Earliest deadline and its single purpose. Ties prefer work that will
-    /// perform a reconciliation over the clock-only wake check.
+    /// Earliest deadline and its single purpose.
     pub(super) fn next_deadline(&self) -> (Instant, DeadlinePurpose) {
         let mut next = (self.recovery_due, DeadlinePurpose::RecoveryScan);
         for candidate in [
             self.retry_due.map(|at| (at, DeadlinePurpose::RepairRetry)),
             self.settings_due
                 .map(|at| (at, DeadlinePurpose::SettingsConfirmation)),
-            Some((self.wake_check_due, DeadlinePurpose::SystemWakeCheck)),
         ]
         .into_iter()
         .flatten()
         {
-            if candidate.0 < next.0
-                || (candidate.0 == next.0 && matches!(next.1, DeadlinePurpose::SystemWakeCheck))
-            {
+            if candidate.0 < next.0 {
                 next = candidate;
             }
         }
@@ -136,11 +125,6 @@ impl Schedule {
     /// coalesce, and any intervening full scan satisfies the request.
     pub(super) fn request_settings_confirmation(&mut self, now: Instant) {
         self.settings_due.get_or_insert(now + FAST_RETRY_DELAY);
-    }
-
-    /// Rearm the clock-only wake check after one observation.
-    pub(super) fn wake_check_finished(&mut self, now: Instant) {
-        self.wake_check_due = now + SYSTEM_WAKE_CHECK_INTERVAL;
     }
 }
 
@@ -177,14 +161,8 @@ mod tests {
 
         schedule.scan_finished(ReconcileTrigger::Initial, true, start);
         for _ in 0..FAST_RETRY_LIMIT {
-            let due = loop {
-                let (due, purpose) = schedule.next_deadline();
-                if purpose == DeadlinePurpose::RepairRetry {
-                    break due;
-                }
-                assert_eq!(purpose, DeadlinePurpose::SystemWakeCheck);
-                schedule.wake_check_finished(due);
-            };
+            let (due, purpose) = schedule.next_deadline();
+            assert_eq!(purpose, DeadlinePurpose::RepairRetry);
             schedule.scan_finished(ReconcileTrigger::RepairRetry, true, due);
         }
 

--- a/crates/openlogi-agent-core/src/watchers/mod.rs
+++ b/crates/openlogi-agent-core/src/watchers/mod.rs
@@ -1,6 +1,6 @@
-//! Background watchers that poll external state — HID inventory, foreground
-//! app, Accessibility, device pairing — and forward changes over channels to a
-//! consumer (the agent's orchestrator, or the GUI).
+//! Background watchers that observe external state — event-first HID inventory,
+//! polled foreground app and permissions, device pairing — and forward changes
+//! over channels to a consumer (the agent's orchestrator, or the GUI).
 
 pub mod accessibility;
 pub mod camera;

--- a/crates/openlogi-agent-core/src/watchers/mod.rs
+++ b/crates/openlogi-agent-core/src/watchers/mod.rs
@@ -1,5 +1,5 @@
-//! Background watchers that observe external state — event-first HID inventory,
-//! polled foreground app and permissions, device pairing — and forward changes
+//! Background watchers that observe external state — event-first HID inventory
+//! and foreground app, polled permissions, device pairing — and forward changes
 //! over channels to a consumer (the agent's orchestrator, or the GUI).
 
 pub mod accessibility;

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -50,6 +50,9 @@ objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSRunningApplication", "NSWorkspace"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSData", "NSArray", "NSNotification"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = "5"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"
 windows-sys = { workspace = true, features = [

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -3,23 +3,22 @@
 //! Every process start walks the same ladder, and each state is a type:
 //!
 //! ```text
-//! startup::bootstrap ──► Booted ──gate──► Wanted ──arm──► Armed ──run──► exit
-//!         │                 │                                    │
-//!         └─ init failed    └─ dormant start nobody wanted       └─ signal / uninstall
+//! startup::bootstrap ──► Booted ──gate──► Wanted ──arm──► Armed ──► Running ──► exit
+//!         │                 │                                         │
+//!         └─ init failed    └─ dormant start nobody wanted            └─ signal / uninstall
 //! ```
 //!
-//! The moves are the type protection for three contracts: the uninstall
-//! receiver travels inside the states (gate consumes it first, then the run
-//! loop — no third consumer can exist), the demand channel dies at
+//! The moves are the type protection for these lifecycle contracts: the
+//! uninstall receiver travels inside the states (gate consumes it first, then
+//! the run loop — no third consumer can exist), the demand channel dies at
 //! [`Wanted::arm`], and arming without settling the dormancy question is
 //! unrepresentable — `arm` exists only on [`Wanted`], whose sole producer is
-//! the gate. The gate *waits* only on macOS, where the sunk launch-at-login
-//! switch makes an unwanted login start possible; Windows and Linux only ever
-//! start wanted, so their gate passes unconditionally.
+//! the gate. Moving `Armed` into `Running` also hands the single-consumer resume
+//! stream to inventory exactly once. The gate *waits* only on macOS, where the
+//! sunk launch-at-login switch makes an unwanted login start possible; Windows
+//! and Linux only ever start wanted, so their gate passes unconditionally.
 
 use std::sync::Arc;
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-use std::sync::atomic::AtomicBool;
 #[cfg(target_os = "macos")]
 use std::time::Duration;
 
@@ -29,7 +28,7 @@ use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::runtime::hook;
 use openlogi_agent_core::watchers::foreground_app::ForegroundUpdate;
-use openlogi_agent_core::watchers::inventory::{InventoryEvent, InventoryRefresh};
+use openlogi_agent_core::watchers::inventory::{InventoryEvent, InventoryRefresh, ResumeEvents};
 use openlogi_core::config::Config;
 use openlogi_hook::Hook;
 use tokio::sync::Mutex;
@@ -55,7 +54,7 @@ const DORMANT_DEADLINE: Duration = Duration::from_secs(60);
 /// core's entry point; `main` only decides which thread it runs on.
 pub(crate) async fn run(
     config: Config,
-    #[cfg(any(target_os = "macos", target_os = "windows"))] resume_pending: Arc<AtomicBool>,
+    resume_events: ResumeEvents,
     uninstalled: UnboundedReceiver<()>,
     #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
 ) {
@@ -65,8 +64,7 @@ pub(crate) async fn run(
 
     let Some(booted) = Booted::bootstrap(
         config,
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
-        resume_pending,
+        resume_events,
         uninstalled,
         #[cfg(target_os = "macos")]
         armed_tx,
@@ -99,14 +97,13 @@ struct Booted {
     /// Releases the main thread's tray loop once the agent arms.
     #[cfg(target_os = "macos")]
     armed_tx: std::sync::mpsc::Sender<()>,
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    resume_pending: Arc<AtomicBool>,
+    resume_events: ResumeEvents,
 }
 
 impl Booted {
     async fn bootstrap(
         config: Config,
-        #[cfg(any(target_os = "macos", target_os = "windows"))] resume_pending: Arc<AtomicBool>,
+        resume_events: ResumeEvents,
         uninstalled: UnboundedReceiver<()>,
         #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
     ) -> Option<Self> {
@@ -124,8 +121,7 @@ impl Booted {
             launch_at_login,
             #[cfg(target_os = "macos")]
             armed_tx,
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
-            resume_pending,
+            resume_events,
         })
     }
 
@@ -195,8 +191,7 @@ impl Wanted {
             capture_mouse_events,
             #[cfg(target_os = "macos")]
             armed_tx,
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
-            resume_pending,
+            resume_events,
             ..
         } = self.0;
         #[cfg(target_os = "macos")]
@@ -217,24 +212,35 @@ impl Wanted {
         // the server's `declare_client` handler.
         drop(demand);
         Armed {
-            orchestrator,
-            shared,
-            observable,
-            event_monitor,
-            inputs,
-            ring_haptics,
-            signals,
-            uninstalled,
-            hook: None,
-            capture_mouse_events,
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
-            resume_pending,
+            resume_events,
+            running: Running {
+                orchestrator,
+                shared,
+                observable,
+                event_monitor,
+                inputs,
+                ring_haptics,
+                signals,
+                uninstalled,
+                hook: None,
+                capture_mouse_events,
+            },
         }
     }
 }
 
-/// The armed agent — everything the select loop folds events into.
+/// An armed agent whose one-shot resume stream has not yet been handed to the
+/// inventory watcher.
 struct Armed {
+    resume_events: ResumeEvents,
+    running: Running,
+}
+
+/// The live agent state into which the select loop folds events.
+///
+/// Separate from [`Armed`] so starting the watcher structurally consumes the
+/// single-owner resume stream; no optional or already-consumed state exists.
+struct Running {
     orchestrator: Arc<Mutex<Orchestrator>>,
     shared: SharedRuntime,
     observable: Arc<ObservableState>,
@@ -247,50 +253,44 @@ struct Armed {
     /// revoke (dropping the handle stops its thread).
     hook: Option<Hook>,
     capture_mouse_events: bool,
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    resume_pending: Arc<AtomicBool>,
 }
 
 impl Armed {
     /// Start the watcher fleets, then drain every control-plane source until
     /// told to leave (low-frequency by contract — [`startup::WatcherEvent`]).
-    async fn run(mut self) {
+    async fn run(self) {
+        let Self {
+            resume_events,
+            mut running,
+        } = self;
         #[cfg(target_os = "macos")]
         request_input_monitoring().await;
 
         // HID++ watchers need no Accessibility — start them up front.
-        startup::spawn_hidpp_watchers(&self.shared, &self.inputs);
-        let resume_pending = {
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
-            {
-                Some(Arc::clone(&self.resume_pending))
-            }
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-            {
-                None
-            }
-        };
+        startup::spawn_hidpp_watchers(&running.shared, &running.inputs);
         let (mut watchers, inventory_refresh) =
-            startup::spawn_state_watchers(&self.shared, resume_pending);
+            startup::spawn_state_watchers(&running.shared, resume_events);
 
         info!("openlogi-agent started");
         loop {
             tokio::select! {
                 Some(event) = watchers.next() => {
-                    self.apply_watcher(event, &inventory_refresh).await;
+                    running.apply_watcher(event, &inventory_refresh).await;
                 }
-                Some(device_key) = self.inputs.triggers.recv() => {
-                    self.begin_action_ring(device_key.as_deref()).await;
+                Some(device_key) = running.inputs.triggers.recv() => {
+                    running.begin_action_ring(device_key.as_deref()).await;
                 }
-                () = self.signals.recv() => self.shut_down("shutdown signal"),
+                () = running.signals.recv() => running.shut_down("shutdown signal"),
                 // Uninstalled while running — leave through the same door so
                 // the event tap goes with us (#807).
-                Some(()) = self.uninstalled.recv() => self.shut_down("the app was uninstalled"),
+                Some(()) = running.uninstalled.recv() => running.shut_down("the app was uninstalled"),
                 else => break,
             }
         }
     }
+}
 
+impl Running {
     /// Retire a terminal Windows hook worker and publish that input capture is
     /// no longer installed. The native callbacks have already been cleared,
     /// so the interval before this check remains pass-through rather than

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 #[cfg(target_os = "macos")]
 use std::time::Duration;
 
@@ -29,7 +29,7 @@ use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::runtime::hook;
 use openlogi_agent_core::watchers::foreground_app::ForegroundUpdate;
-use openlogi_agent_core::watchers::inventory::InventoryEvent;
+use openlogi_agent_core::watchers::inventory::{InventoryEvent, InventoryRefresh};
 use openlogi_core::config::Config;
 use openlogi_hook::Hook;
 use tokio::sync::Mutex;
@@ -260,12 +260,25 @@ impl Armed {
 
         // HID++ watchers need no Accessibility — start them up front.
         startup::spawn_hidpp_watchers(&self.shared, &self.inputs);
-        let mut watchers = startup::spawn_state_watchers(&self.shared);
+        let resume_pending = {
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            {
+                Some(Arc::clone(&self.resume_pending))
+            }
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            {
+                None
+            }
+        };
+        let (mut watchers, inventory_refresh) =
+            startup::spawn_state_watchers(&self.shared, resume_pending);
 
         info!("openlogi-agent started");
         loop {
             tokio::select! {
-                Some(event) = watchers.next() => self.apply_watcher(event).await,
+                Some(event) = watchers.next() => {
+                    self.apply_watcher(event, &inventory_refresh).await;
+                }
                 Some(device_key) = self.inputs.triggers.recv() => {
                     self.begin_action_ring(device_key.as_deref()).await;
                 }
@@ -301,16 +314,22 @@ impl Armed {
     }
 
     /// Fold one watcher event into the agent's state.
-    async fn apply_watcher(&mut self, event: startup::WatcherEvent) {
+    async fn apply_watcher(
+        &mut self,
+        event: startup::WatcherEvent,
+        inventory_refresh: &InventoryRefresh,
+    ) {
         use startup::{Watcher, WatcherEvent};
 
-        // Inventory and foreground-app samples make this a periodic health
+        // Inventory and foreground-app samples make this a health
         // reconciliation without another timer in the control-plane loop.
         #[cfg(target_os = "windows")]
         self.apply_hook_health().await;
 
         match event {
-            WatcherEvent::Inventory(event) => self.apply_inventory(event).await,
+            WatcherEvent::Inventory(event) => {
+                self.apply_inventory(event, inventory_refresh).await;
+            }
             WatcherEvent::Camera(active) => {
                 self.orchestrator.lock().await.set_camera_active(active);
             }
@@ -334,7 +353,7 @@ impl Armed {
     }
 
     /// Fold one inventory-watcher event into the orchestrator.
-    async fn apply_inventory(&self, event: InventoryEvent) {
+    async fn apply_inventory(&self, event: InventoryEvent, refresh: &InventoryRefresh) {
         match event {
             InventoryEvent::Snapshot {
                 inventories,
@@ -342,15 +361,12 @@ impl Armed {
                 hid_open_failures,
             } => {
                 let mut orchestrator = self.orchestrator.lock().await;
-                // Native suspend/resume notifications cover the sleeps the
-                // polling gap misses; consume the coalesced signal at the
-                // point that can replay it.
-                #[cfg(any(target_os = "macos", target_os = "windows"))]
-                if self.resume_pending.swap(false, Ordering::Relaxed) {
-                    info!("native resume notification — replaying volatile settings");
-                    orchestrator.reapply_volatile_on_next_refresh();
-                }
                 orchestrator.refresh_inventory(&inventories, &standalone, hid_open_failures);
+                let confirm_settings = orchestrator.needs_reapply_confirmation();
+                drop(orchestrator);
+                if confirm_settings {
+                    refresh.request_settings_confirmation();
+                }
             }
             InventoryEvent::Unavailable => {
                 self.orchestrator.lock().await.mark_inventory_unavailable();

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -21,6 +21,8 @@ mod lifecycle;
 mod logging;
 mod overlay;
 mod pairing;
+#[cfg(target_os = "linux")]
+mod resume_linux;
 #[cfg(target_os = "windows")]
 mod resume_windows;
 // The shared locale catalogs live in `openlogi-ui`; the negotiation that picks
@@ -39,13 +41,7 @@ mod tray;
 #[cfg(target_os = "windows")]
 mod tray_windows;
 
-// Only the resume-notification flag is atomic now, and that exists on the two
-// platforms that have a native suspend/resume signal.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-use std::sync::Arc;
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-use std::sync::atomic::AtomicBool;
-
+use openlogi_agent_core::watchers::inventory::resume_channel;
 use openlogi_core::config::Config;
 use tracing::{info, warn};
 
@@ -109,14 +105,13 @@ fn main() {
     // the process main thread — so the async core (orchestrator, IPC, watchers,
     // hook) runs on the tokio runtime on a dedicated thread, and the main thread
     // runs AppKit. Elsewhere there is no tray, so just block on the core.
+    let (resume_signal, resume_events) = resume_channel();
     #[cfg(target_os = "macos")]
     {
         // Read the menu-bar preference before `config` moves into the core
         // thread; the main thread hosts the tray.
         let show_in_menu_bar = config.app_settings.show_in_menu_bar;
         let app_icon = config.app_settings.app_icon;
-        let resume_pending = Arc::new(AtomicBool::new(false));
-        let core_resume_pending = Arc::clone(&resume_pending);
         // The tray waits for the core to declare the agent *armed*: a dormant
         // agent (launch_at_login off, started at login, no client yet) must
         // not put an icon in the menu bar only to vanish seconds later. A
@@ -126,19 +121,14 @@ fn main() {
         if let Err(e) = std::thread::Builder::new()
             .name("openlogi-agent-core".into())
             .spawn(move || {
-                runtime.block_on(lifecycle::run(
-                    config,
-                    core_resume_pending,
-                    uninstalled,
-                    armed_tx,
-                ));
+                runtime.block_on(lifecycle::run(config, resume_events, uninstalled, armed_tx));
             })
         {
             warn!(error = %e, "could not spawn the agent core thread; exiting");
             return;
         }
         if armed_rx.recv().is_ok() {
-            tray::run_app_loop(show_in_menu_bar, app_icon, resume_pending);
+            tray::run_app_loop(show_in_menu_bar, app_icon, resume_signal);
         }
     }
     #[cfg(not(target_os = "macos"))]
@@ -148,15 +138,16 @@ fn main() {
         #[cfg(target_os = "windows")]
         {
             tray_windows::spawn(config.app_settings.show_in_menu_bar);
-            // Native resume notifications feed the same seam the macOS
-            // workspace observer does: the core replays volatile settings
-            // when the flag is set.
-            let resume_pending = Arc::new(AtomicBool::new(false));
-            resume_windows::register(Arc::clone(&resume_pending));
-            runtime.block_on(lifecycle::run(config, resume_pending, uninstalled));
+            // Native resume notifications feed the same event seam as macOS
+            // and Linux: inventory wakes immediately and replays volatile
+            // settings on its settled authoritative snapshot.
+            resume_windows::register(resume_signal.clone());
         }
-        #[cfg(not(target_os = "windows"))]
-        runtime.block_on(lifecycle::run(config, uninstalled));
+        #[cfg(target_os = "linux")]
+        resume_linux::register(resume_signal.clone());
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        drop(resume_signal);
+        runtime.block_on(lifecycle::run(config, resume_events, uninstalled));
     }
 }
 

--- a/crates/openlogi-agent/src/resume_linux.rs
+++ b/crates/openlogi-agent/src/resume_linux.rs
@@ -1,0 +1,103 @@
+//! Native Linux suspend/resume notifications from systemd-logind.
+//!
+//! `PrepareForSleep(false)` is emitted once the system has resumed. The
+//! process-lifetime listener reconnects only after D-Bus failure; steady state
+//! blocks on the native signal and performs no timed inventory work.
+
+use std::thread;
+use std::time::Duration;
+
+use openlogi_agent_core::watchers::inventory::ResumeSignal;
+use tracing::{debug, info, warn};
+use zbus::blocking::Connection;
+use zbus::proxy;
+
+const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(60);
+
+#[proxy(
+    interface = "org.freedesktop.login1.Manager",
+    default_service = "org.freedesktop.login1",
+    default_path = "/org/freedesktop/login1",
+    gen_blocking = true
+)]
+trait LoginManager {
+    #[zbus(signal, name = "PrepareForSleep")]
+    fn prepare_for_sleep(&self, sleeping: bool) -> zbus::Result<()>;
+}
+
+/// Start a process-lifetime logind listener. Failure is non-fatal: the
+/// inventory recovery scan still detects long suspend gaps from the clocks.
+pub fn register(signal: ResumeSignal) {
+    let spawned = thread::Builder::new()
+        .name("openlogi-linux-resume".into())
+        .spawn(move || {
+            let mut reconnect_delay = RECONNECT_DELAY;
+            loop {
+                let failed = match listen(&signal) {
+                    Ok(()) => {
+                        warn!("logind resume signal stream ended; reconnecting");
+                        reconnect_delay = RECONNECT_DELAY;
+                        false
+                    }
+                    Err(error) if reconnect_delay == RECONNECT_DELAY => {
+                        warn!(%error, "logind resume listener failed; reconnecting");
+                        true
+                    }
+                    Err(error) => {
+                        debug!(%error, "logind resume listener still unavailable");
+                        true
+                    }
+                };
+                thread::sleep(reconnect_delay);
+                if failed {
+                    reconnect_delay = next_reconnect_delay(reconnect_delay);
+                }
+            }
+        });
+    if let Err(error) = spawned {
+        warn!(%error, "could not start logind resume listener; clock-gap recovery remains active");
+    }
+}
+
+fn listen(signal: &ResumeSignal) -> zbus::Result<()> {
+    let connection = Connection::system()?;
+    let proxy = LoginManagerProxyBlocking::new(&connection)?;
+    let changes = proxy.receive_prepare_for_sleep()?;
+    info!("logind suspend/resume notifications registered");
+    for change in changes {
+        let args = change.args()?;
+        if is_resume_edge(*args.sleeping()) {
+            signal.notify();
+        }
+    }
+    Ok(())
+}
+
+fn is_resume_edge(sleeping: bool) -> bool {
+    !sleeping
+}
+
+fn next_reconnect_delay(current: Duration) -> Duration {
+    current.saturating_mul(2).min(MAX_RECONNECT_DELAY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_RECONNECT_DELAY, RECONNECT_DELAY, is_resume_edge, next_reconnect_delay};
+
+    #[test]
+    fn only_the_post_sleep_edge_is_resume() {
+        assert!(!is_resume_edge(true));
+        assert!(is_resume_edge(false));
+    }
+
+    #[test]
+    fn reconnect_backoff_is_bounded() {
+        let mut delay = RECONNECT_DELAY;
+        for _ in 0..10 {
+            delay = next_reconnect_delay(delay);
+        }
+        assert_eq!(delay, MAX_RECONNECT_DELAY);
+    }
+}

--- a/crates/openlogi-agent/src/resume_windows.rs
+++ b/crates/openlogi-agent/src/resume_windows.rs
@@ -5,7 +5,7 @@
 //! and clear when devices power-cycle across a system sleep, but the first
 //! post-wake inventory snapshot can look identical to the last pre-sleep one,
 //! so no per-device transition re-applies them (#393, #527). The inventory
-//! watcher's wall-clock-gap heuristic only catches sleeps longer than a
+//! watcher's clock-gap heuristic only catches sleeps longer than a
 //! minute; the native notification covers the rest.
 //!
 //! `RegisterSuspendResumeNotification` with `DEVICE_NOTIFY_CALLBACK` rather
@@ -19,9 +19,8 @@
 )]
 
 use std::ffi::c_void;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
+use openlogi_agent_core::watchers::inventory::ResumeSignal;
 use tracing::{info, warn};
 use windows_sys::Win32::System::Power::{
     DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS, RegisterSuspendResumeNotification,
@@ -31,28 +30,35 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 };
 
 /// Register for suspend/resume notifications for the process lifetime; the
-/// system invokes [`on_power_event`] and each resume sets `pending`. Failure
-/// is logged, never fatal — the polling-gap heuristic still covers long
+/// system invokes [`on_power_event`] and each resume notifies `signal`. Failure
+/// is logged, never fatal — the clock-gap heuristic still covers long
 /// sleeps.
-pub fn register(pending: Arc<AtomicBool>) {
-    // Leaked on purpose: the subscription is never unregistered, so the
-    // callback may read the flag until process exit.
-    let context = Arc::into_raw(pending);
-    // Also leaked: with `DEVICE_NOTIFY_CALLBACK` the recipient *is* this
-    // parameter block, and the subscription may hold the pointer for its
-    // whole lifetime — a stack-local here would dangle once this returns.
+pub fn register(signal: ResumeSignal) {
+    // Retained for the process lifetime on successful registration: the
+    // callback may notify the signal until process exit.
+    let context = Box::into_raw(Box::new(signal));
+    // Likewise, with `DEVICE_NOTIFY_CALLBACK` the recipient *is* this
+    // parameter block, so a successful subscription may hold its pointer for
+    // the whole lifetime — a stack-local here would dangle once this returns.
     let params = Box::into_raw(Box::new(DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
         Callback: Some(on_power_event),
-        Context: context.cast_mut().cast::<c_void>(),
+        Context: context.cast::<c_void>(),
     }));
-    // SAFETY: `params` and the Arc behind its context are both leaked for the
-    // process lifetime, matching the never-unregistered subscription, and the
-    // callback matches `PDEVICE_NOTIFY_CALLBACK_ROUTINE`.
+    // SAFETY: `params` and the `ResumeSignal` behind its context remain valid
+    // for the call, and the callback matches
+    // `PDEVICE_NOTIFY_CALLBACK_ROUTINE`. A successful subscription keeps both
+    // allocations for the process lifetime below.
     let handle = unsafe {
         RegisterSuspendResumeNotification(params.cast::<c_void>(), DEVICE_NOTIFY_CALLBACK)
     };
     if handle == 0 {
-        warn!("suspend/resume registration failed — only the polling-gap heuristic detects wakes");
+        // SAFETY: registration failed, so Windows retained neither pointer and
+        // cannot invoke the callback with `context` after this call.
+        unsafe {
+            drop(Box::from_raw(params));
+            drop(Box::from_raw(context));
+        }
+        warn!("suspend/resume registration failed — only the clock-gap heuristic detects wakes");
     } else {
         info!("suspend/resume notifications registered");
     }
@@ -61,22 +67,23 @@ pub fn register(pending: Arc<AtomicBool>) {
 /// Whether a `PBT_*` power event means the system just resumed.
 /// `PBT_APMRESUMEAUTOMATIC` fires on every wake, `PBT_APMRESUMESUSPEND`
 /// additionally once user input confirms it — both can arrive for one wake,
-/// and the flag coalesces them.
+/// and the bounded resume channel coalesces them.
 fn is_resume_event(event: u32) -> bool {
     matches!(event, PBT_APMRESUMEAUTOMATIC | PBT_APMRESUMESUSPEND)
 }
 
-/// Invoked by the system on an arbitrary thread; only touches the atomic.
+/// Invoked by the system on an arbitrary thread; only attempts a non-blocking
+/// send to the bounded resume channel.
 unsafe extern "system" fn on_power_event(
     context: *const c_void,
     event: u32,
     _setting: *const c_void,
 ) -> u32 {
     if is_resume_event(event) {
-        // SAFETY: `context` is the `Arc<AtomicBool>` this module leaked at
+        // SAFETY: `context` is the `ResumeSignal` this module leaked at
         // registration, alive for the process lifetime.
-        let pending = unsafe { &*context.cast::<AtomicBool>() };
-        pending.store(true, Ordering::Relaxed);
+        let signal = unsafe { &*context.cast::<ResumeSignal>() };
+        signal.notify();
     }
     0
 }
@@ -84,20 +91,27 @@ unsafe extern "system" fn on_power_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlogi_agent_core::watchers::inventory::resume_channel;
     use windows_sys::Win32::UI::WindowsAndMessaging::PBT_APMSUSPEND;
 
-    #[test]
-    fn resume_events_set_the_flag_and_a_suspend_does_not() {
-        let pending = AtomicBool::new(false);
-        let context = (&raw const pending).cast::<c_void>();
-        for event in [PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND] {
-            // SAFETY: `context` points at the flag above, live for the whole
-            // test; the callback runs synchronously here.
-            unsafe { on_power_event(context, event, std::ptr::null()) };
-            assert!(pending.swap(false, Ordering::Relaxed), "event {event}");
-        }
-        // SAFETY: same live context; a suspend must not request a re-apply.
+    #[tokio::test]
+    async fn resume_events_notify_and_a_suspend_does_not() {
+        let (signal, mut events) = resume_channel();
+        let context = (&raw const signal).cast::<c_void>();
+        // SAFETY: `context` points at the signal above, live for this test;
+        // the callback executes synchronously.
         unsafe { on_power_event(context, PBT_APMSUSPEND, std::ptr::null()) };
-        assert!(!pending.load(Ordering::Relaxed));
+        tokio::time::timeout(std::time::Duration::from_millis(10), events.recv())
+            .await
+            .expect_err("a suspend edge does not notify inventory");
+
+        // SAFETY: `context` points at the signal above, live for this test;
+        // the callback executes synchronously.
+        unsafe { on_power_event(context, PBT_APMRESUMEAUTOMATIC, std::ptr::null()) };
+        tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("resume callback notifies the inventory signal")
+            .expect("the signal producer remains alive");
+        assert!(is_resume_event(PBT_APMRESUMESUSPEND));
     }
 }

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -5,6 +5,7 @@
 //! is `crate::lifecycle`.
 
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use futures::StreamExt as _;
@@ -225,7 +226,11 @@ pub(crate) enum Watcher {
 /// stream.
 pub(crate) fn spawn_state_watchers(
     shared: &SharedRuntime,
-) -> impl Stream<Item = WatcherEvent> + Unpin + use<> {
+    resume_pending: Option<Arc<AtomicBool>>,
+) -> (
+    impl Stream<Item = WatcherEvent> + Unpin + use<>,
+    watchers::inventory::InventoryRefresh,
+) {
     fn tagged<T: Send + 'static>(
         rx: tokio::sync::mpsc::UnboundedReceiver<T>,
         source: Watcher,
@@ -238,12 +243,11 @@ pub(crate) fn spawn_state_watchers(
         .chain(stream::iter([WatcherEvent::Lost(source)]))
         .boxed()
     }
-    stream::select_all([
+    let inventory =
+        watchers::inventory::spawn_with_registry(shared.channel_registry.clone(), resume_pending);
+    let streams = stream::select_all([
         tagged(
-            watchers::inventory::spawn_with_registry(
-                Duration::from_secs(2),
-                shared.channel_registry.clone(),
-            ),
+            inventory.events,
             Watcher::Inventory,
             WatcherEvent::Inventory,
         ),
@@ -267,7 +271,8 @@ pub(crate) fn spawn_state_watchers(
             Watcher::InputMonitoring,
             WatcherEvent::InputMonitoring,
         ),
-    ])
+    ]);
+    (streams, inventory.refresh)
 }
 
 /// Seed the permission facts with non-prompting reads, so a client that

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -5,7 +5,6 @@
 //! is `crate::lifecycle`.
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use futures::StreamExt as _;
@@ -17,6 +16,7 @@ use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::runtime::scroll::{ScrollInputHandle, ScrollRuntime};
 use openlogi_agent_core::runtime::{ActionDispatcher, ActionRuntime};
+use openlogi_agent_core::watchers::inventory::ResumeEvents;
 use openlogi_agent_core::watchers::{self, gesture::GestureOutputs};
 use openlogi_core::config::Config;
 #[cfg(target_os = "macos")]
@@ -226,7 +226,7 @@ pub(crate) enum Watcher {
 /// stream.
 pub(crate) fn spawn_state_watchers(
     shared: &SharedRuntime,
-    resume_pending: Option<Arc<AtomicBool>>,
+    resume_events: ResumeEvents,
 ) -> (
     impl Stream<Item = WatcherEvent> + Unpin + use<>,
     watchers::inventory::InventoryRefresh,
@@ -244,7 +244,7 @@ pub(crate) fn spawn_state_watchers(
         .boxed()
     }
     let inventory =
-        watchers::inventory::spawn_with_registry(shared.channel_registry.clone(), resume_pending);
+        watchers::inventory::spawn_with_registry(shared.channel_registry.clone(), resume_events);
     let streams = stream::select_all([
         tagged(
             inventory.events,
@@ -257,7 +257,7 @@ pub(crate) fn spawn_state_watchers(
             WatcherEvent::Camera,
         ),
         tagged(
-            watchers::foreground_app::spawn(Duration::from_secs(1)),
+            watchers::foreground_app::spawn(),
             Watcher::App,
             WatcherEvent::App,
         ),

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -19,8 +19,6 @@
 )]
 
 use std::cell::RefCell;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use dispatch2::DispatchQueue;
 use objc2::rc::Retained;
@@ -35,6 +33,7 @@ use objc2_app_kit::{
     NSWorkspaceSessionDidBecomeActiveNotification,
 };
 use objc2_foundation::{NSNotification, NSNotificationName, NSString};
+use openlogi_agent_core::watchers::inventory::ResumeSignal;
 use openlogi_core::brand::{self, DeeplinkCommand};
 use openlogi_core::config::AppIcon;
 use tracing::{info, warn};
@@ -107,7 +106,7 @@ pub fn relocalize() {
 }
 
 struct ResumeTargetIvars {
-    pending: Arc<AtomicBool>,
+    signal: ResumeSignal,
 }
 
 define_class!(
@@ -121,14 +120,14 @@ define_class!(
     impl ResumeTarget {
         #[unsafe(method(workspaceDidResume:))]
         fn workspace_did_resume(&self, _notification: &NSNotification) {
-            self.ivars().pending.store(true, Ordering::Relaxed);
+            self.ivars().signal.notify();
         }
     }
 );
 
 impl ResumeTarget {
-    fn new(pending: Arc<AtomicBool>) -> Retained<Self> {
-        let this = Self::alloc().set_ivars(ResumeTargetIvars { pending });
+    fn new(signal: ResumeSignal) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(ResumeTargetIvars { signal });
         // SAFETY: `init` initializes our freshly allocated NSObject subclass.
         unsafe { msg_send![super(this), init] }
     }
@@ -240,12 +239,8 @@ fn gui_is_running() -> bool {
 /// tokio core still does all the work). The toggle takes effect on the agent's
 /// next launch — a no-restart live toggle would need a main-thread hop from the
 /// IPC reload path (deferred; it can't be verified headlessly).
-/// `resume_pending` forwards coalesced workspace resume notifications to that core.
-pub fn run_app_loop(
-    show_in_menu_bar: bool,
-    app_icon: AppIcon,
-    resume_pending: Arc<AtomicBool>,
-) -> ! {
+/// `resume_signal` forwards coalesced workspace resume notifications to that core.
+pub fn run_app_loop(show_in_menu_bar: bool, app_icon: AppIcon, resume_signal: ResumeSignal) -> ! {
     let Some(mtm) = MainThreadMarker::new() else {
         warn!("agent AppKit loop not started off the main thread — exiting");
         #[expect(
@@ -260,7 +255,7 @@ pub fn run_app_loop(
     // Bind the status item (+ its target/menu) so they outlive `run()` — the
     // menu items only weakly reference the target. `None` when hidden.
     let _tray = show_in_menu_bar.then(|| install_status_item(mtm, app_icon));
-    let _resume_target = install_resume_observer(resume_pending);
+    let _resume_target = install_resume_observer(resume_signal);
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
@@ -271,10 +266,10 @@ pub fn run_app_loop(
     std::process::exit(0);
 }
 
-/// Observe native resume transitions that the inventory polling-gap heuristic
+/// Observe native resume transitions that the inventory clock-gap heuristic
 /// cannot see. The returned target must live for the AppKit loop's lifetime.
-fn install_resume_observer(pending: Arc<AtomicBool>) -> Retained<ResumeTarget> {
-    let target = ResumeTarget::new(pending);
+fn install_resume_observer(signal: ResumeSignal) -> Retained<ResumeTarget> {
+    let target = ResumeTarget::new(signal);
     let workspace = NSWorkspace::sharedWorkspace();
     let center = workspace.notificationCenter();
     for name in resume_notification_names() {
@@ -392,11 +387,12 @@ fn build_menu(mtm: MainThreadMarker, target: &MenuTarget) -> Retained<objc2_app_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlogi_agent_core::watchers::inventory::resume_channel;
 
-    #[test]
-    fn resume_notifications_are_forwarded_and_coalesced() {
-        let pending = Arc::new(AtomicBool::new(false));
-        let target = install_resume_observer(Arc::clone(&pending));
+    #[tokio::test]
+    async fn resume_notifications_are_forwarded() {
+        let (signal, mut events) = resume_channel();
+        let target = install_resume_observer(signal.clone());
         let workspace = NSWorkspace::sharedWorkspace();
         let center = workspace.notificationCenter();
 
@@ -404,14 +400,11 @@ mod tests {
             // SAFETY: `workspace` is live, matches the registration filter,
             // and notification delivery completes synchronously.
             unsafe { center.postNotificationName_object(name, Some(&workspace)) };
-            assert!(pending.swap(false, Ordering::Relaxed));
         }
-        for name in resume_notification_names() {
-            // SAFETY: Same live object and synchronous delivery as above.
-            unsafe { center.postNotificationName_object(name, Some(&workspace)) };
-        }
-        assert!(pending.swap(false, Ordering::Relaxed));
-        assert!(!pending.swap(false, Ordering::Relaxed));
+        tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("workspace notification reaches the inventory signal")
+            .expect("the signal producer remains alive");
 
         // SAFETY: This is the same live target registered with `center` above.
         unsafe { center.removeObserver(&target) };

--- a/crates/openlogi-device/AGENTS.md
+++ b/crates/openlogi-device/AGENTS.md
@@ -22,8 +22,10 @@ owns the layer. `crates/openlogi-hid/AGENTS.md` points back here.
   string, and `openlogi_core::device::DeviceKind`) — the same small integers mean
   different things in each. Never cross them by raw value; convert at the boundary.
   `kind` is identity-only; capability decisions come from the feature table.
-- Enumeration runs on a poll with cache/ledger grace logic so sleeping or briefly
-  unreachable devices keep their identity and panels. Changes to probing must keep the
-  "replay last-good inventory through transient failures" behavior intact — run the
-  inventory/watcher tests and think about the partial-failure paths, not just clean
-  enumeration.
+- The Agent's persistent enumerator is event-first: OS hotplug and HID++ lifecycle
+  notifications request authoritative reconciliation, while a named low-frequency
+  recovery scan covers missed/unsupported events and non-broadcast battery features.
+  Cache/ledger grace keeps sleeping or briefly unreachable devices visible. Changes to
+  probing must preserve last-good replay, bounded repair, and channel retirement/reopen
+  ordering — run the inventory/watcher tests and inspect partial-failure paths, not just
+  clean enumeration.

--- a/crates/openlogi-device/Cargo.toml
+++ b/crates/openlogi-device/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     hash::Hash,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use futures_concurrency::future::Join as _;
@@ -16,10 +16,11 @@ use tracing::{debug, warn};
 
 use crate::ChannelRegistry;
 use crate::backend::{BackendError, HidBackend, NodeId, NodeInfo};
-use crate::channel::route::{DeviceRoute, is_receiver_pid};
+use crate::channel::route::{DeviceRoute, find_receiver, is_receiver_pid};
 use ledger::NodeLedger;
 
 mod cache;
+pub mod events;
 mod features;
 pub mod hotplug;
 mod ledger;
@@ -29,6 +30,7 @@ mod probe;
 pub mod standalone;
 
 use cache::{CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached};
+use events::{ChannelEventSubscriptions, EventNotifier, EventSubscriptionHandle};
 use persist::{ProbeCacheSnapshot, ProbeCacheStore};
 use probe::{NodeProbe, probe_one};
 
@@ -44,11 +46,12 @@ const MAX_BOLT_SLOTS: u8 = 6;
 
 /// Upper bound on probing one HID node. `hidpp`'s request/response has no
 /// timeout of its own, so without this a single unresponsive (e.g. asleep)
-/// device wedges the whole enumeration — and the GUI runs `enumerate` on a
-/// polling watcher, so a permanent hang would stall every later refresh.
+/// device wedges the whole enumeration, so a permanent hang would stall every
+/// later event or recovery reconciliation.
 ///
-/// A timed-out node is skipped and re-probed on the next watcher tick (~2 s),
-/// and the first probe usually wakes the device so the retry succeeds fast.
+/// A timed-out node is skipped and re-probed by the bounded two-second repair
+/// deadline, and the first probe usually wakes the device so the retry succeeds
+/// fast.
 /// Slots are probed concurrently on both receiver paths, so a receiver's worst
 /// case is the 1.5 s arrival drain plus a single slot's [`BOLT_SLOT_PROBE`] /
 /// [`UNIFYING_SLOT_PROBE`] — not their sum — plus, on Bolt only, the
@@ -90,7 +93,7 @@ const RECEIVER_PROBE_BUDGET: Duration = Duration::from_secs(13);
 /// per-slot cap ensures each slot's feature walk is bounded independently of
 /// how many other slots are being probed at the same time.  A timed-out slot
 /// still surfaces in the inventory (kind + wpid from the arrival event) — it
-/// just lacks capabilities / battery until the next tick.
+/// just lacks capabilities / battery until the next reconciliation.
 const UNIFYING_SLOT_PROBE: Duration = Duration::from_millis(3500);
 
 /// Per-slot budget when a Unifying device already has a fresh immutable probe.
@@ -99,7 +102,7 @@ const UNIFYING_SLOT_PROBE: Duration = Duration::from_millis(3500);
 /// occasionally omit that reply even though their receiver has just emitted a
 /// live device-arrival event. Do not let that optional refresh consume the
 /// full first-sight feature-walk budget or delay publication of a known-online
-/// mouse on every watcher tick.
+/// mouse on every reconciliation.
 const UNIFYING_CACHED_SLOT_PROBE: Duration = Duration::from_millis(750);
 
 /// Per-slot budget for the HID++ 2.0 feature walk on a Bolt paired device.
@@ -130,20 +133,20 @@ pub enum InventoryError {
     AmbiguousRawDevice,
 }
 
-/// Stateful device enumerator: holds the per-device probe cache so the polling
-/// watcher reuses immutable data across ticks instead of re-handshaking every
-/// device every ~2s. One-shot callers use the [`enumerate`] free function, which
+/// Stateful device enumerator: owns persistent channels and the per-device
+/// probe cache so the event-first watcher reuses immutable data across
+/// reconciliations. One-shot callers use the [`enumerate`] free function, which
 /// runs against a fresh (empty) cache.
 pub struct Enumerator {
     /// The HID stack this enumerator walks. `openlogi-hid` supplies this
     /// host's; tests and other hosts supply their own.
     backend: Arc<dyn HidBackend>,
     cache: HashMap<CacheKey, Cached>,
-    /// Consecutive ticks each cached device has been missing, for grace-period
+    /// Consecutive passes each cached device has been missing, for grace-period
     /// eviction.
     misses: HashMap<CacheKey, u8>,
-    /// Open HID++ channels reused across ticks, keyed by OS node id. Opening (and
-    /// tearing down) a device every ~2s tick is the churn issue #99 is about —
+    /// Open HID++ channels reused across reconciliations, keyed by OS node id.
+    /// Opening (and tearing down) a device every pass is the churn issue #99 is about —
     /// each open also leaks an `io_service_t` in async-hid's macOS backend — so a
     /// steadily-connected node is opened once here and reused until it
     /// disconnects.
@@ -155,15 +158,19 @@ pub struct Enumerator {
     /// Optional publication sink used by the persistent Agent watcher. One-shot
     /// callers keep this `None` and retain the route-opening library behavior.
     registry: Option<ChannelRegistry>,
-    tick: u64,
     /// Where the immutable probe cache is kept across restarts, `None` for a
     /// memory-only enumerator (one-shot CLI calls, tests).
     store: Option<Arc<dyn ProbeCacheStore>>,
     /// Whether the persistable cache content changed since the last save —
-    /// fresh full probes and evictions, not per-tick battery refreshes.
+    /// fresh full probes and evictions, not per-pass battery refreshes.
     cache_dirty: bool,
-    /// Whether the most recent tick failed to open at least one HID++ node.
+    /// Whether the most recent pass failed to open at least one HID++ node.
     open_failures_last_tick: bool,
+    /// Whether the most recent pass needs a bounded fast follow-up to advance
+    /// ledger/channel/cache grace or retry a failed open.
+    retry_needed_last_tick: bool,
+    /// Coalesced lifecycle-event sink installed on newly opened channels.
+    event_notifier: Option<EventNotifier>,
 }
 
 /// An open channel to a receiver / direct-device HID node, held across
@@ -173,10 +180,13 @@ pub struct Enumerator {
 struct CachedChannel {
     info: NodeInfo,
     channel: Arc<HidppChannel>,
+    events: Option<ChannelEventSubscriptions>,
 }
 
+type ActiveNode = (NodeInfo, Arc<HidppChannel>, Option<EventSubscriptionHandle>);
+
 struct PreparedNodes {
-    active: Vec<(NodeInfo, Arc<HidppChannel>)>,
+    active: Vec<ActiveNode>,
     open_failures: Vec<NodeId>,
     retiring: Vec<NodeId>,
 }
@@ -344,7 +354,7 @@ fn settle_unhealthy_node<Node: Eq + Hash + Clone>(
 pub async fn enumerate(
     backend: Arc<dyn HidBackend>,
 ) -> Result<Vec<DeviceInventory>, InventoryError> {
-    // The polling [`Enumerator`] keeps a per-node ledger across ticks, so a
+    // The persistent [`Enumerator`] keeps a per-node ledger across passes, so a
     // transient probe miss replays the node's last good inventory. A one-shot
     // caller (CLI `list` / `diag`) builds a fresh `Enumerator` whose ledger is
     // empty, so a miss has nothing to replay and would surface as an empty or
@@ -442,7 +452,7 @@ const ONESHOT_ATTEMPTS: u8 = 4;
 /// asleep device, so a short pause lets the next attempt read it cleanly.
 const ONESHOT_RETRY_DELAY: Duration = Duration::from_millis(300);
 
-/// Nodes that remain valid for this tick: everything the OS enumerated plus
+/// Nodes that remain valid for this pass: everything the OS enumerated plus
 /// cached channels whose open transport still reports a live connection.
 fn retained_nodes<K>(
     enumerated: &HashSet<K>,
@@ -465,7 +475,7 @@ where
 fn append_live_cached_channels(
     nodes: &mut HashSet<NodeId>,
     channels: &ChannelCache<NodeId, CachedChannel>,
-    active: &mut Vec<(NodeInfo, Arc<HidppChannel>)>,
+    active: &mut Vec<ActiveNode>,
 ) {
     let retained = retained_nodes(
         nodes,
@@ -480,23 +490,34 @@ fn append_live_cached_channels(
                 name = %open.info.name,
                 "OS enumeration omitted a live HID node; probing cached channel"
             );
-            active.push((open.info.clone(), Arc::clone(&open.channel)));
+            active.push((
+                open.info.clone(),
+                Arc::clone(&open.channel),
+                open.events.as_ref().map(ChannelEventSubscriptions::handle),
+            ));
         }
     }
     *nodes = retained;
 }
 
 impl Enumerator {
-    /// Whether the most recent [`enumerate`](Self::enumerate) tick failed to
-    /// open at least one HID++ node. `false` before the first tick.
+    /// Whether the most recent [`enumerate`](Self::enumerate) pass failed to
+    /// open at least one HID++ node. `false` before the first pass.
     ///
-    /// On macOS a run of ticks with this set is the observable signature of a
+    /// On macOS a run of passes with this set is the observable signature of a
     /// denied Input Monitoring grant or a stale permission session — paired
     /// with the grant state it separates "grant it" from "log out", which the
     /// bare open error cannot (the denial is silent).
     #[must_use]
     pub fn open_failures_last_tick(&self) -> bool {
         self.open_failures_last_tick
+    }
+
+    /// Whether the last pass needs a bounded fast follow-up to advance a
+    /// probe/channel/cache recovery policy. `false` before the first pass.
+    #[must_use]
+    pub fn retry_needed_last_tick(&self) -> bool {
+        self.retry_needed_last_tick
     }
 
     /// An enumerator that walks `backend` — this host's HID stack, a scripted
@@ -510,18 +531,27 @@ impl Enumerator {
             channels: ChannelCache::default(),
             ledger: NodeLedger::default(),
             registry: None,
-            tick: 0,
             store: None,
             cache_dirty: false,
             open_failures_last_tick: false,
+            retry_needed_last_tick: false,
+            event_notifier: None,
         }
     }
 
     /// Publish this enumerator's already-open channels into `registry` after
-    /// each settled inventory tick.
+    /// each settled inventory pass.
     #[must_use]
     pub fn with_registry(mut self, registry: ChannelRegistry) -> Self {
         self.registry = Some(registry);
+        self
+    }
+
+    /// Subscribe this enumerator's already-open channels to lifecycle events
+    /// and coalesce them into reconciliation requests sent through `notifier`.
+    #[must_use]
+    pub fn with_event_notifier(mut self, notifier: EventNotifier) -> Self {
+        self.event_notifier = Some(notifier);
         self
     }
 
@@ -562,23 +592,37 @@ impl Enumerator {
                 continue;
             }
             if let Some(open) = self.channels.get(&node) {
-                active.push((open.info.clone(), Arc::clone(&open.channel)));
+                active.push((
+                    open.info.clone(),
+                    Arc::clone(&open.channel),
+                    open.events.as_ref().map(ChannelEventSubscriptions::handle),
+                ));
                 continue;
             }
             match backend.open_hidpp(&info).await {
                 Ok(Some(channel)) => {
+                    // Attach before the first feature/register check. Receiver
+                    // events are recognizable immediately; per-device feature
+                    // indexes are registered during the ensuing table walk.
+                    let events = self.event_notifier.as_ref().map(|notifier| {
+                        let protocol = find_receiver(info.vendor_id, info.product_id)
+                            .map(|receiver| receiver.protocol);
+                        ChannelEventSubscriptions::attach(&channel, protocol, notifier.clone())
+                    });
+                    let event_handle = events.as_ref().map(ChannelEventSubscriptions::handle);
                     self.channels.insert(
                         node,
                         CachedChannel {
                             info: info.clone(),
                             channel: Arc::clone(&channel),
+                            events,
                         },
                     );
-                    active.push((info, channel));
+                    active.push((info, channel, event_handle));
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    warn!(error = ?e, "failed to open HID++ channel — retrying next tick");
+                    warn!(error = ?e, "failed to open HID++ channel — requesting repair");
                     open_failures.push(node);
                 }
             }
@@ -607,8 +651,8 @@ impl Enumerator {
     }
 
     /// Write the cache through to its store when the persistable content
-    /// changed this tick. Best-effort: a failed write is logged and retried on
-    /// the next dirty tick.
+    /// changed this pass. Best-effort: a failed write is logged and retried on
+    /// the next cache-dirty pass.
     fn flush_cache(&mut self) {
         if !self.cache_dirty {
             return;
@@ -649,8 +693,7 @@ impl Enumerator {
     async fn enumerate_reporting_completeness(
         &mut self,
     ) -> Result<(Vec<DeviceInventory>, bool, bool), InventoryError> {
-        self.tick = self.tick.wrapping_add(1);
-        let tick = self.tick;
+        let now = Instant::now();
         let backend = Arc::clone(&self.backend);
         let candidates = backend.enumerate_hidpp().await?;
         debug!(count = candidates.len(), "HID++ candidate interfaces");
@@ -670,7 +713,7 @@ impl Enumerator {
             let cache = &self.cache;
             active
                 .into_iter()
-                .map(|(info, channel)| async move {
+                .map(|(info, channel, events)| async move {
                     let node = info.id.clone();
                     // Receivers answer register reads over local USB in
                     // milliseconds; only direct (esp. Bluetooth) devices need
@@ -684,8 +727,11 @@ impl Enumerator {
                     } else {
                         PROBE_BUDGET
                     };
-                    let probe =
-                        timeout(budget, probe_one(info, Arc::clone(&channel), cache, tick)).await;
+                    let probe = timeout(
+                        budget,
+                        probe_one(info, Arc::clone(&channel), cache, now, events.as_ref()),
+                    )
+                    .await;
                     (node, channel, probe, budget, receiver)
                 })
                 .collect::<Vec<_>>()
@@ -729,7 +775,7 @@ impl Enumerator {
             // exceeds it. Evicting on that unpublishes *every* device behind
             // the receiver — a Bolt publishes all six slots under one node —
             // and tears down each one's capture plan. A channel whose delivery
-            // really is dead times out again on the next tick and is replaced
+            // really is dead times out again on the repair pass and is replaced
             // then, with the ledger replaying its last-good inventory
             // meanwhile, so nothing disappears from the GUI in between.
             if settled.evict_channel {
@@ -764,7 +810,7 @@ impl Enumerator {
                 &mut all_healthy,
             ));
         }
-        // Nodes that wouldn't open this tick still replay their last snapshot
+        // Nodes that wouldn't open this pass still replay their last snapshot
         // (they have no cached channel to evict).
         for node in open_failures {
             inventories.extend(settle_unhealthy_node(
@@ -777,11 +823,12 @@ impl Enumerator {
 
         let seen_keys = self.apply_outcomes(outcomes);
         self.evict_unseen(&seen_keys);
+        self.retry_needed_last_tick = !all_healthy || !self.misses.is_empty();
         self.flush_cache();
         Ok((inventories, all_complete, all_healthy))
     }
 
-    /// Fold this tick's probe outcomes into the cache, returning the keys seen
+    /// Fold this pass's probe outcomes into the cache, returning the keys seen
     /// so [`Self::evict_unseen`] can age out the rest.
     fn apply_outcomes(&mut self, outcomes: Vec<CacheOutcome>) -> HashSet<CacheKey> {
         let mut seen_keys = HashSet::new();
@@ -791,7 +838,7 @@ impl Enumerator {
                     seen_keys.insert(key.clone());
                     // A completed full probe of a persistable device is worth
                     // writing through; battery `Update`s are not (they would
-                    // rewrite the file every tick for a value that is re-read
+                    // rewrite the file every pass for a value that is re-read
                     // live anyway), and neither are keys `persist::save`
                     // filters out — dirtying on those would rewrite an
                     // unchanged file on every refresh of a direct-only system.
@@ -811,7 +858,7 @@ impl Enumerator {
         seen_keys
     }
 
-    /// Drop cache entries for devices not seen this tick, after a short grace so
+    /// Drop cache entries for devices not seen this pass, after a short grace so
     /// a transient receiver timeout doesn't discard a still-present device.
     fn evict_unseen(&mut self, seen_keys: &HashSet<CacheKey>) {
         for key in seen_keys {

--- a/crates/openlogi-device/src/inventory/cache.rs
+++ b/crates/openlogi-device/src/inventory/cache.rs
@@ -1,20 +1,23 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use hidpp::channel::HidppChannel;
 use openlogi_core::device::{BatteryInfo, BatteryStatus};
 
+use super::events::{EventFeatureIndices, EventSubscriptionHandle};
 use super::features::{BatteryProbe, ProbedFeatures, probe_features, read_battery};
 use crate::backend::NodeId;
 
-/// How many `enumerate` ticks a device's probe is reused before a fresh read.
+/// How long a device's probe is reused before a fresh read.
 /// The expensive part of a probe (the `enumerate_features` feature-table walk)
 /// reads *immutable* data — model, capabilities, marketing type — so it never
 /// needs re-reading for a known device; the periodic full probe is kept only as
 /// a self-healing pass (e.g. a firmware update reshuffling the feature table).
 /// The volatile battery does NOT ride this window: cache hits re-read it every
-/// tick through the memoized feature index (see [`read_battery`]), so it stays
-/// as fresh as it was before the cache existed (#153).
-pub(super) const REFRESH_TICKS: u64 = 15;
+/// reconciliation through the memoized feature index (see [`read_battery`]).
+/// Elapsed time rather than scan count preserves cache freshness now that
+/// event-driven scans are intentionally irregular.
+pub(super) const REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Stable identity used to memoize a device's probe across `enumerate` ticks.
 /// Keyed on the device's *own* identity (never its slot) so a re-paired or
@@ -40,7 +43,7 @@ pub(super) enum CacheKey {
 /// device's memoized data.
 pub(super) const CACHE_MISS_GRACE: u8 = 3;
 
-/// A memoized probe result plus the tick it was taken on.
+/// A memoized probe result plus the instant it was taken.
 #[derive(Clone)]
 pub(super) struct Cached {
     pub(super) probe: ProbedFeatures,
@@ -49,7 +52,9 @@ pub(super) struct Cached {
     /// round-trip — no `Device::new` ping, no table walk. `None` when the device
     /// exposes neither `0x1004` nor the legacy `0x1000`.
     pub(super) battery: Option<BatteryProbe>,
-    pub(super) probed_tick: u64,
+    /// Event-capable feature indexes found by the same immutable table walk.
+    pub(super) events: EventFeatureIndices,
+    pub(super) probed_at: Instant,
 }
 
 /// The legacy `0x1000` battery feature (MX2S-era mice) reports `discharge_level
@@ -107,8 +112,8 @@ pub(super) fn seen(id: Option<CacheKey>) -> CacheOutcome {
 }
 
 /// Whether `cached` is stale enough that the device should be re-probed.
-pub(super) fn is_stale(cached: &Cached, tick: u64) -> bool {
-    tick.wrapping_sub(cached.probed_tick) >= REFRESH_TICKS
+pub(super) fn is_stale(cached: &Cached, now: Instant) -> bool {
+    now.saturating_duration_since(cached.probed_at) >= REFRESH_INTERVAL
 }
 
 /// Decide a device's probe: reuse a fresh cache, or (online + miss/stale)
@@ -122,10 +127,14 @@ pub(super) async fn probe_or_reuse(
     id: Option<CacheKey>,
     cached: Option<&Cached>,
     online: bool,
-    tick: u64,
+    now: Instant,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> (ProbedFeatures, CacheOutcome) {
-    if online && cached.is_none_or(|c| is_stale(c, tick)) {
-        let (mut fresh, battery) = probe_features(channel, index).await;
+    if let (Some(cached), Some(subscriptions)) = (cached, subscriptions) {
+        subscriptions.register_device(index, cached.events);
+    }
+    if online && cached.is_none_or(|c| is_stale(c, now)) {
+        let (mut fresh, battery, events) = probe_features(channel, index, subscriptions).await;
         if let (Some(reading), Some(probe)) = (fresh.battery.take(), battery) {
             fresh.battery = Some(hold_percentage_while_charging(
                 reading,
@@ -141,15 +150,16 @@ pub(super) async fn probe_or_reuse(
             }
             // A first-sight probe whose identity reads failed is served but not
             // memoized: caching it would pin a wrong (all-zero unit or
-            // serial-less) config key for `REFRESH_TICKS` (#482). The next tick
-            // re-probes instead.
+            // serial-less) config key for `REFRESH_INTERVAL` (#482). The next
+            // reconciliation re-probes instead.
             if fresh.identity_incomplete && cached.is_none() {
                 return (fresh, seen(id));
             }
             // Same reasoning for a capability read that failed part-way: the
             // walk understates the device, and memoizing that hides a panel in
-            // the GUI for `REFRESH_TICKS`. A previous complete walk outranks
-            // this partial one, so defer to it and re-probe next tick.
+            // the GUI for `REFRESH_INTERVAL`. A previous complete walk
+            // outranks this partial one, so defer to it and re-probe next
+            // reconciliation.
             if fresh.capabilities_incomplete {
                 if let Some(c) = cached {
                     keep_known_capabilities(&mut fresh, &c.probe);
@@ -161,7 +171,8 @@ pub(super) async fn probe_or_reuse(
                     let value = Cached {
                         probe: fresh.clone(),
                         battery,
-                        probed_tick: tick,
+                        events,
+                        probed_at: now,
                     };
                     (fresh, CacheOutcome::Fresh(key, value))
                 }

--- a/crates/openlogi-device/src/inventory/events.rs
+++ b/crates/openlogi-device/src/inventory/events.rs
@@ -1,0 +1,380 @@
+//! Coalesced lifecycle events from inventory-owned HID++ channels.
+//!
+//! The persistent [`super::Enumerator`] opens each OS HID node once. This
+//! module attaches one message listener to that existing channel and keeps
+//! only the feature indexes needed to recognize lifecycle notifications. The
+//! events never mutate inventory: they request another authoritative
+//! reconciliation from the enumerator.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, PoisonError, RwLock};
+
+use hidpp::channel::{HidppChannel, HidppMessage, MessageListenerGuard};
+use hidpp::feature::unified_battery::BatteryEvent;
+use hidpp::feature::wireless_device_status::WirelessDeviceStatusEvent;
+use hidpp::protocol::{v10, v20};
+use hidpp::receiver::{bolt, unifying};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use crate::ReceiverProtocol;
+
+/// A HID++ lifecycle source that requested authoritative inventory
+/// reconciliation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HidppEventSource {
+    /// A receiver reported a paired slot connecting or disconnecting.
+    ReceiverConnection,
+    /// A device's `WirelessDeviceStatus` feature reported reconnection.
+    WirelessDeviceStatus,
+    /// A device's event-capable `UnifiedBattery` feature reported a change.
+    UnifiedBattery,
+}
+
+/// The sending half of the bounded HID++ reconciliation-request channel.
+///
+/// Clones are installed only on inventory-owned channels. Capacity is one:
+/// every source asks for the same full reconciliation, so a burst has no
+/// additional meaning and must not grow memory while a slow probe is running.
+#[derive(Clone)]
+pub struct EventNotifier {
+    sender: mpsc::Sender<HidppEventSource>,
+}
+
+impl EventNotifier {
+    fn notify(&self, source: HidppEventSource) {
+        let _ = self.sender.try_send(source);
+    }
+}
+
+/// The receiving half of the coalesced HID++ reconciliation-request channel.
+pub type EventReceiver = mpsc::Receiver<HidppEventSource>;
+
+/// Build the bounded channel used by an inventory watcher and its enumerator.
+#[must_use]
+pub fn event_channel() -> (EventNotifier, EventReceiver) {
+    let (sender, receiver) = mpsc::channel(1);
+    (EventNotifier { sender }, receiver)
+}
+
+/// Runtime feature indexes whose unsolicited events affect inventory.
+///
+/// Stored with the immutable feature-table cache because these indexes are
+/// discovered by the same walk. Only unified battery has a battery event;
+/// legacy `0x1000` and voltage `0x1001` remain recovery-scan reads.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct EventFeatureIndices {
+    pub(super) wireless_status: Option<u8>,
+    pub(super) unified_battery: Option<u8>,
+}
+
+impl EventFeatureIndices {
+    pub(super) fn from_feature_ids(ids: &[u16]) -> Self {
+        let mut indices = Self::default();
+        for (position, id) in ids.iter().copied().enumerate() {
+            let Ok(index) = u8::try_from(position + 1) else {
+                break;
+            };
+            match id {
+                0x1d4b => indices.wireless_status = Some(index),
+                0x1004 => indices.unified_battery = Some(index),
+                _ => {}
+            }
+        }
+        indices
+    }
+
+    fn recognizes(self, message: &v20::Message) -> Option<HidppEventSource> {
+        let header = message.header();
+        if header.software_id.to_lo() != 0 {
+            return None;
+        }
+        let function_id = header.function_id.to_lo();
+        let payload = message.extend_payload();
+        if self.wireless_status == Some(header.feature_index)
+            && WirelessDeviceStatusEvent::decode(function_id, &payload).is_some()
+        {
+            return Some(HidppEventSource::WirelessDeviceStatus);
+        }
+        if self.unified_battery == Some(header.feature_index)
+            && BatteryEvent::decode(function_id, &payload).is_some()
+        {
+            return Some(HidppEventSource::UnifiedBattery);
+        }
+        None
+    }
+}
+
+#[derive(Clone, Copy)]
+struct DeviceEvents {
+    device_index: u8,
+    features: EventFeatureIndices,
+}
+
+struct SubscriptionState {
+    protocol: Option<ReceiverProtocol>,
+    devices: RwLock<Vec<DeviceEvents>>,
+    receiver_snapshot_depth: AtomicUsize,
+    notifier: EventNotifier,
+}
+
+impl SubscriptionState {
+    fn decode(&self, raw: HidppMessage, matched: bool) -> Option<HidppEventSource> {
+        if matched {
+            return None;
+        }
+
+        let receiver_connection = match self.protocol {
+            Some(ReceiverProtocol::Bolt) => matches!(
+                bolt::decode_notification(&v10::Message::from(raw)),
+                Some(bolt::Event::DeviceConnection(_))
+            ),
+            Some(ReceiverProtocol::Unifying) => matches!(
+                unifying::decode_notification(&v10::Message::from(raw)),
+                Some(unifying::Event::DeviceConnection(_))
+            ),
+            None => false,
+        };
+        if receiver_connection {
+            return (self.receiver_snapshot_depth.load(Ordering::Acquire) == 0)
+                .then_some(HidppEventSource::ReceiverConnection);
+        }
+
+        let message = v20::Message::from(raw);
+        let device_index = message.header().device_index;
+        self.devices
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .iter()
+            .find(|device| device.device_index == device_index)
+            .and_then(|device| device.features.recognizes(&message))
+    }
+}
+
+/// Cloneable registration handle passed through a node's probe.
+#[derive(Clone)]
+pub(super) struct EventSubscriptionHandle {
+    state: Arc<SubscriptionState>,
+}
+
+impl EventSubscriptionHandle {
+    /// Replace the decoder metadata for `device_index` as soon as a valid
+    /// feature table (or its cached equivalent) is available. The channel
+    /// listener was installed before the probe began, closing the wakeup race
+    /// before the resulting snapshot is published.
+    pub(super) fn register_device(&self, device_index: u8, features: EventFeatureIndices) {
+        let mut devices = self
+            .state
+            .devices
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some(device) = devices
+            .iter_mut()
+            .find(|device| device.device_index == device_index)
+        {
+            device.features = features;
+        } else {
+            devices.push(DeviceEvents {
+                device_index,
+                features,
+            });
+        }
+    }
+
+    /// Suppress receiver connection events fabricated by the enumerator's own
+    /// arrival trigger. A real event in this interval is covered by the probe
+    /// already in progress; events immediately before or after remain queued.
+    pub(super) fn begin_receiver_snapshot(&self) -> ReceiverSnapshotGuard {
+        self.state
+            .receiver_snapshot_depth
+            .fetch_add(1, Ordering::AcqRel);
+        ReceiverSnapshotGuard {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+/// Persistent listener owned alongside one cached HID++ channel.
+pub(super) struct ChannelEventSubscriptions {
+    handle: EventSubscriptionHandle,
+    _listener: MessageListenerGuard,
+}
+
+impl ChannelEventSubscriptions {
+    pub(super) fn attach(
+        channel: &Arc<HidppChannel>,
+        protocol: Option<ReceiverProtocol>,
+        notifier: EventNotifier,
+    ) -> Self {
+        let state = Arc::new(SubscriptionState {
+            protocol,
+            devices: RwLock::new(Vec::new()),
+            receiver_snapshot_depth: AtomicUsize::new(0),
+            notifier,
+        });
+        let listener = channel.add_msg_listener_guarded({
+            let state = Arc::clone(&state);
+            move |raw, matched| {
+                if let Some(source) = state.decode(raw, matched) {
+                    state.notifier.notify(source);
+                }
+            }
+        });
+        Self {
+            handle: EventSubscriptionHandle { state },
+            _listener: listener,
+        }
+    }
+
+    pub(super) fn handle(&self) -> EventSubscriptionHandle {
+        self.handle.clone()
+    }
+}
+
+/// Receiver-arrival suppression scoped to one authoritative snapshot.
+pub(super) struct ReceiverSnapshotGuard {
+    state: Arc<SubscriptionState>,
+}
+
+impl Drop for ReceiverSnapshotGuard {
+    fn drop(&mut self) {
+        self.state
+            .receiver_snapshot_depth
+            .fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hidpp::nibble::U4;
+    use hidpp::protocol::{v10, v20};
+
+    use super::*;
+
+    fn state(protocol: Option<ReceiverProtocol>) -> Arc<SubscriptionState> {
+        let (notifier, _receiver) = event_channel();
+        Arc::new(SubscriptionState {
+            protocol,
+            devices: RwLock::new(Vec::new()),
+            receiver_snapshot_depth: AtomicUsize::new(0),
+            notifier,
+        })
+    }
+
+    #[test]
+    fn feature_indices_are_runtime_table_positions() {
+        assert_eq!(
+            EventFeatureIndices::from_feature_ids(&[0x0001, 0x1d4b, 0x1004]),
+            EventFeatureIndices {
+                wireless_status: Some(2),
+                unified_battery: Some(3),
+            }
+        );
+    }
+
+    #[test]
+    fn receiver_snapshot_suppresses_only_triggered_connection_wakeups() {
+        let state = state(Some(ReceiverProtocol::Unifying));
+        let raw = v10::Message::Short(
+            v10::MessageHeader {
+                device_index: 2,
+                sub_id: 0x41,
+            },
+            [0, 0x02, 0x34, 0x12],
+        )
+        .into();
+
+        assert_eq!(
+            state.decode(raw, false),
+            Some(HidppEventSource::ReceiverConnection)
+        );
+        state.receiver_snapshot_depth.store(1, Ordering::Release);
+        assert_eq!(state.decode(raw, false), None);
+    }
+
+    #[test]
+    fn receiver_snapshot_does_not_suppress_device_feature_events() {
+        let state = state(Some(ReceiverProtocol::Bolt));
+        state.devices.write().unwrap().push(DeviceEvents {
+            device_index: 2,
+            features: EventFeatureIndices {
+                wireless_status: Some(5),
+                unified_battery: None,
+            },
+        });
+        state.receiver_snapshot_depth.store(1, Ordering::Release);
+        let wireless = v20::Message::Long(
+            v20::MessageHeader {
+                device_index: 2,
+                feature_index: 5,
+                function_id: U4::from_lo(0),
+                software_id: U4::from_lo(0),
+            },
+            [0; 16],
+        )
+        .into();
+
+        assert_eq!(
+            state.decode(wireless, false),
+            Some(HidppEventSource::WirelessDeviceStatus)
+        );
+    }
+
+    #[test]
+    fn registered_device_events_decode_to_typed_sources() {
+        let state = state(None);
+        state.devices.write().unwrap().push(DeviceEvents {
+            device_index: 3,
+            features: EventFeatureIndices {
+                wireless_status: Some(5),
+                unified_battery: Some(7),
+            },
+        });
+
+        let wireless = v20::Message::Long(
+            v20::MessageHeader {
+                device_index: 3,
+                feature_index: 5,
+                function_id: U4::from_lo(0),
+                software_id: U4::from_lo(0),
+            },
+            [0; 16],
+        )
+        .into();
+        assert_eq!(
+            state.decode(wireless, false),
+            Some(HidppEventSource::WirelessDeviceStatus)
+        );
+
+        let mut payload = [0; 16];
+        payload[0] = 80;
+        payload[1] = 4;
+        let battery = v20::Message::Long(
+            v20::MessageHeader {
+                device_index: 3,
+                feature_index: 7,
+                function_id: U4::from_lo(0),
+                software_id: U4::from_lo(0),
+            },
+            payload,
+        )
+        .into();
+        assert_eq!(
+            state.decode(battery, false),
+            Some(HidppEventSource::UnifiedBattery)
+        );
+    }
+
+    #[test]
+    fn event_requests_are_bounded_and_coalesced() {
+        let (notifier, mut receiver) = event_channel();
+        notifier.notify(HidppEventSource::ReceiverConnection);
+        notifier.notify(HidppEventSource::UnifiedBattery);
+
+        assert_eq!(
+            receiver.try_recv(),
+            Ok(HidppEventSource::ReceiverConnection)
+        );
+        assert_eq!(receiver.try_recv(), Err(mpsc::error::TryRecvError::Empty));
+    }
+}

--- a/crates/openlogi-device/src/inventory/features.rs
+++ b/crates/openlogi-device/src/inventory/features.rs
@@ -21,6 +21,7 @@ use openlogi_core::device::{
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
+use super::events::{EventFeatureIndices, EventSubscriptionHandle};
 use super::mappings::{
     legacy_battery_level_from_percentage, map_battery_level, map_battery_status, map_device_type,
     map_legacy_battery_status, map_voltage_battery_status, normalize_serial_number,
@@ -55,7 +56,7 @@ pub(super) struct ProbedFeatures {
     pub(super) identity_incomplete: bool,
     /// A capability read *failed* (vs. the device not having the capability),
     /// so `capabilities` above understates what the device can do. Memoizing
-    /// that would hide a panel in the GUI for `REFRESH_TICKS`.
+    /// that would hide a panel in the GUI for `REFRESH_INTERVAL`.
     pub(super) capabilities_incomplete: bool,
 }
 
@@ -74,8 +75,8 @@ pub(super) enum BatteryProbe {
 /// Read just the battery by addressing its feature at the known runtime index —
 /// one round-trip, with no `Device::new` ping and no feature-table walk. This is
 /// both the full probe's battery read (the walk just produced the index) and the
-/// cheap per-tick refresh for cache hits. `None` when the device doesn't answer
-/// (asleep, switched hosts).
+/// cheap per-reconciliation refresh for cache hits. `None` when the device
+/// doesn't answer (asleep, switched hosts).
 pub(super) async fn read_battery(
     channel: &Arc<HidppChannel>,
     slot: u8,
@@ -196,29 +197,45 @@ async fn read_marketing_identity(
 pub(super) async fn probe_features(
     channel: &Arc<HidppChannel>,
     slot: u8,
-) -> (ProbedFeatures, Option<BatteryProbe>) {
+    subscriptions: Option<&EventSubscriptionHandle>,
+) -> (ProbedFeatures, Option<BatteryProbe>, EventFeatureIndices) {
     let mut device = match Device::new(Arc::clone(channel), slot).await {
         Ok(d) => d,
         Err(e) => {
             debug!(slot, error = ?e, "Device::new failed");
-            return (ProbedFeatures::default(), None);
+            return (
+                ProbedFeatures::default(),
+                None,
+                EventFeatureIndices::default(),
+            );
         }
     };
     // The enumeration response IS the device's feature-ID table — capture it
     // for capability derivation instead of discarding it.
     let mut battery_probe = None;
+    let mut event_features = EventFeatureIndices::default();
     let mut probe_haptic_controls = false;
     let mut capabilities = match device.enumerate_features().await {
         Ok(Some(features)) => {
             let ids: Vec<u16> = features.iter().map(|f| f.id).collect();
             battery_probe = battery_feature_index(ids.iter().copied());
+            event_features = EventFeatureIndices::from_feature_ids(&ids);
+            if let Some(subscriptions) = subscriptions {
+                // Register immediately after the table read, before the
+                // battery/identity snapshot that will be published.
+                subscriptions.register_device(slot, event_features);
+            }
             probe_haptic_controls = ids.contains(&0x19b0) || ids.contains(&0x19c0);
             Some(Capabilities::from_feature_ids(&ids))
         }
         Ok(None) => None,
         Err(e) => {
             debug!(slot, error = ?e, "enumerate_features failed");
-            return (ProbedFeatures::default(), None);
+            return (
+                ProbedFeatures::default(),
+                None,
+                EventFeatureIndices::default(),
+            );
         }
     };
     let mut capabilities_incomplete = false;
@@ -288,6 +305,7 @@ pub(super) async fn probe_features(
             capabilities_incomplete,
         },
         battery_probe,
+        event_features,
     )
 }
 
@@ -329,7 +347,7 @@ async fn probe_extra_capabilities(
 /// Whether the device exposes a divertable haptic panel, or `None` when a read
 /// failed part-way through the ~40-entry control walk.
 ///
-/// The distinction matters because the answer is memoized for `REFRESH_TICKS`:
+/// The distinction matters because the answer is memoized for `REFRESH_INTERVAL`:
 /// reporting a lost reply as `false` hides the Actions Ring binding for half a
 /// minute on a device that has the panel.
 async fn has_haptic_panel(feature: &ReprogControlsFeature) -> Option<bool> {

--- a/crates/openlogi-device/src/inventory/persist.rs
+++ b/crates/openlogi-device/src/inventory/persist.rs
@@ -12,27 +12,30 @@
 //! can silently reassign. A `CacheKey::UnifyingSlot` is `receiver + slot`: a
 //! different device paired into that slot while the agent is down would
 //! inherit the previous occupant's probe on warm start. A `CacheKey::Direct`
-//! is an OS-runtime node id with no cross-boot stability. Loaded entries get
-//! `probed_tick = 0`, so the regular `cache::REFRESH_TICKS`
-//! self-healing pass re-walks them on schedule; until (and unless) that walk
-//! succeeds, the persisted data serves exactly like an in-memory cache hit.
+//! is an OS-runtime node id with no cross-boot stability. Loaded entries
+//! restart the elapsed refresh window, so the regular self-healing pass
+//! re-walks them on schedule; until (and unless) that walk succeeds, the
+//! persisted data serves exactly like an in-memory cache hit.
 //!
 //! *Where* a snapshot is kept is the host's business, not this module's: the
 //! enumerator writes through a [`ProbeCacheStore`]; `openlogi-hid` supplies
 //! the file-backed one every native build uses.
 
 use std::collections::HashMap;
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::cache::{CacheKey, Cached};
+use super::events::EventFeatureIndices;
 use super::features::{BatteryProbe, ProbedFeatures};
 
 /// Bumped when the persisted shape changes; a mismatched snapshot is discarded
 /// (the cache is a warm-start optimization, not data anyone must keep).
 /// v2 dropped the `UnifyingSlot` key (slot-keyed, so not re-pair-safe).
-const SCHEMA_VERSION: u32 = 2;
+/// v3 adds event-capable feature indexes discovered by the immutable walk.
+const SCHEMA_VERSION: u32 = 3;
 
 impl ProbeCacheError {
     /// Report why a store could not keep a snapshot.
@@ -67,7 +70,7 @@ pub trait ProbeCacheStore: Send + Sync {
     /// Persist `snapshot`.
     ///
     /// An `Err` is logged by the caller and the snapshot retried on the next
-    /// tick that dirties the cache, so a store may fail freely.
+    /// pass that dirties the cache, so a store may fail freely.
     fn save(&self, snapshot: &ProbeCacheSnapshot) -> Result<(), ProbeCacheError>;
 }
 
@@ -83,6 +86,7 @@ struct PersistedEntry {
     key: PersistedKey,
     probe: ProbedFeatures,
     battery: Option<BatteryProbe>,
+    events: EventFeatureIndices,
 }
 
 /// The persistable subset of [`CacheKey`] — Bolt only (see the module docs).
@@ -144,6 +148,7 @@ impl ProbeCacheSnapshot {
                         key,
                         probe,
                         battery: cached.battery,
+                        events: cached.events,
                     }
                 })
             })
@@ -175,11 +180,12 @@ impl ProbeCacheSnapshot {
                     Cached {
                         probe: entry.probe,
                         battery: entry.battery,
+                        events: entry.events,
                         // Restart the refresh clock: the entry serves
                         // immediately as a cache hit, and the periodic
                         // self-healing re-walk decides when it is due for a
                         // fresh read.
-                        probed_tick: 0,
+                        probed_at: Instant::now(),
                     },
                 )
             })
@@ -190,12 +196,14 @@ impl ProbeCacheSnapshot {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::time::Instant;
 
     use openlogi_core::device::{
         BatteryInfo, BatteryLevel, BatteryStatus, DeviceModelInfo, DeviceTransports,
     };
 
     use super::super::cache::{CacheKey, Cached};
+    use super::super::events::EventFeatureIndices;
     use super::super::features::{BatteryProbe, ProbedFeatures};
     use super::{ProbeCacheSnapshot, SCHEMA_VERSION};
 
@@ -229,7 +237,11 @@ mod tests {
                     ..Default::default()
                 },
                 battery: Some(BatteryProbe::Unified(9)),
-                probed_tick: 7,
+                events: EventFeatureIndices {
+                    wireless_status: Some(7),
+                    unified_battery: Some(9),
+                },
+                probed_at: Instant::now(),
             },
         );
         cache.insert(
@@ -240,11 +252,14 @@ mod tests {
             Cached {
                 probe: ProbedFeatures::default(),
                 battery: None,
-                probed_tick: 3,
+                events: EventFeatureIndices::default(),
+                probed_at: Instant::now(),
             },
         );
 
-        let restored = ProbeCacheSnapshot::of(&cache).into_entries();
+        let snapshot = ProbeCacheSnapshot::of(&cache);
+        let restored_after = Instant::now();
+        let restored = snapshot.into_entries();
 
         let bolt = restored
             .get(&CacheKey::Bolt {
@@ -257,12 +272,20 @@ mod tests {
             Some(BatteryProbe::Unified(9)),
             "the battery *feature index* is immutable and kept"
         );
+        assert_eq!(
+            bolt.events,
+            EventFeatureIndices {
+                wireless_status: Some(7),
+                unified_battery: Some(9),
+            },
+            "event feature indexes are immutable and kept"
+        );
         assert!(
             bolt.probe.battery.is_none(),
             "the battery *reading* is volatile — restoring it would resurrect a stale value"
         );
-        assert_eq!(
-            bolt.probed_tick, 0,
+        assert!(
+            bolt.probed_at >= restored_after,
             "a restored entry restarts the refresh clock"
         );
         assert!(

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use futures_concurrency::future::Join as _;
 use hidpp::{
@@ -18,6 +18,7 @@ use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverI
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
+use super::events::EventSubscriptionHandle;
 use super::mappings::{map_kind, map_unifying_kind, resolve_device_kind};
 use crate::backend::NodeInfo;
 use crate::channel::route::DIRECT_DEVICE_INDEX;
@@ -95,19 +96,22 @@ pub(super) async fn probe_one(
     info: NodeInfo,
     channel: Arc<HidppChannel>,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
+    now: Instant,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     match receiver::detect(Arc::clone(&channel)) {
-        Some(Receiver::Bolt(bolt)) => probe_bolt_receiver(channel, info, bolt, cache, tick).await,
+        Some(Receiver::Bolt(bolt)) => {
+            probe_bolt_receiver(channel, info, bolt, cache, now, subscriptions).await
+        }
         Some(Receiver::Unifying(unifying)) => {
-            probe_unifying_receiver(channel, info, unifying, cache, tick).await
+            probe_unifying_receiver(channel, info, unifying, cache, now, subscriptions).await
         }
         None | Some(_) => {
             // No recognised receiver — this might be a directly-paired device
             // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
             // addresses the device's own features. Probe in case it answers.
             // P2.4 — verified path; no Bolt-pairing slot indirection needed.
-            probe_direct(channel, &info, cache, tick).await
+            probe_direct(channel, &info, cache, now, subscriptions).await
         }
     }
 }
@@ -117,13 +121,14 @@ async fn probe_bolt_receiver(
     info: NodeInfo,
     bolt: BoltReceiver,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
+    now: Instant,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     let unique_id = bolt.get_unique_id().await.ok();
     let pairing_count = bolt.count_pairings().await.ok();
     debug!(?pairing_count, "receiver reports pairing count");
 
-    let connections = drain_device_arrival(&bolt).await;
+    let connections = drain_device_arrival(&bolt, subscriptions).await;
     debug!(events = connections.len(), "drained device-arrival events");
     let by_slot: HashMap<u8, BoltDeviceConnection> =
         connections.into_iter().map(|c| (c.index, c)).collect();
@@ -151,7 +156,7 @@ async fn probe_bolt_receiver(
     // device list stable across ticks without an explicit sort.
     let slot_results = identities
         .iter()
-        .map(|identity| walk_bolt_slot(&channel, identity, cache, tick))
+        .map(|identity| walk_bolt_slot(&channel, identity, cache, now, subscriptions))
         .collect::<Vec<_>>()
         .join()
         .await;
@@ -206,7 +211,8 @@ async fn probe_unifying_receiver(
     info: NodeInfo,
     unifying: UnifyingReceiver,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
+    now: Instant,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     // Pairing count is the health gate for this path: without it the result is
     // settled as a failed probe regardless of any later arrival events. Check
@@ -235,7 +241,9 @@ async fn probe_unifying_receiver(
     // The drain is therefore the *only* device source on this path, so a
     // failed arrival trigger is "couldn't check", not "no devices online":
     // settle it as a failed probe and let the ledger replay the last snapshot.
-    let Some(connections) = drain_device_arrival_unifying(&unifying, pairing_count).await else {
+    let Some(connections) =
+        drain_device_arrival_unifying(&unifying, pairing_count, subscriptions).await
+    else {
         return NodeProbe::failed();
     };
     debug!(events = connections.len(), "drained device-arrival events");
@@ -271,7 +279,7 @@ async fn probe_unifying_receiver(
     };
     let slot_results = connections
         .iter()
-        .map(|conn| probe_unifying_slot(&channel, conn, receiver_uid, cache, tick))
+        .map(|conn| probe_unifying_slot(&channel, conn, receiver_uid, cache, now, subscriptions))
         .collect::<Vec<_>>()
         .join()
         .await;
@@ -387,7 +395,8 @@ async fn walk_bolt_slot(
     channel: &Arc<HidppChannel>,
     identity: &BoltSlotIdentity,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
+    now: Instant,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> (PairedDevice, CacheOutcome) {
     let &BoltSlotIdentity {
         slot,
@@ -406,7 +415,15 @@ async fn walk_bolt_slot(
     // mirroring the Unifying path (#218).
     let probe_result = timeout(
         BOLT_SLOT_PROBE,
-        probe_or_reuse(channel, slot, id.clone(), cached, online, tick),
+        probe_or_reuse(
+            channel,
+            slot,
+            id.clone(),
+            cached,
+            online,
+            now,
+            subscriptions,
+        ),
     )
     .await;
     let (probe, outcome) = if let Ok(r) = probe_result {
@@ -470,14 +487,23 @@ async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &NodeInfo,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
+    now: Instant,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     let id = CacheKey::Direct(info.id.clone());
     let cached = cache.get(&id);
     // A direct device is always "present" (its HID node is the candidate), so
     // treat it as online: reuse the cached probe while fresh, otherwise probe.
-    let (probe, outcome) =
-        probe_or_reuse(&channel, DIRECT_DEVICE_INDEX, Some(id), cached, true, tick).await;
+    let (probe, outcome) = probe_or_reuse(
+        &channel,
+        DIRECT_DEVICE_INDEX,
+        Some(id),
+        cached,
+        true,
+        now,
+        subscriptions,
+    )
+    .await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or exposes a
     // configuration feature (buttons / pointer / lighting). A Bolt receiver's
@@ -563,8 +589,27 @@ async fn probe_direct(
     }
 }
 
-async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> {
+async fn drain_device_arrival(
+    bolt: &BoltReceiver,
+    subscriptions: Option<&EventSubscriptionHandle>,
+) -> Vec<BoltDeviceConnection> {
     let rx = bolt.listen();
+    // Triggering a snapshot fabricates the same connection messages as a real
+    // lifecycle event. Suppress raw reconciliation requests only during this
+    // drain, whose typed receiver consumes every such message into the current
+    // snapshot. Drop the guard before slot probes so a later transition cannot
+    // be lost behind unrelated feature reads.
+    let _receiver_snapshot = subscriptions.map(EventSubscriptionHandle::begin_receiver_snapshot);
+    match bolt.get_notification_state().await {
+        Ok(mut state) if !state.wireless_notifications => {
+            state.wireless_notifications = true;
+            if let Err(error) = bolt.set_notification_state(state).await {
+                debug!(?error, "enable Bolt wireless notifications failed");
+            }
+        }
+        Ok(_) => {}
+        Err(error) => debug!(?error, "read Bolt notification state failed"),
+    }
     if let Err(e) = bolt.trigger_device_arrival().await {
         debug!(error = ?e, "trigger_device_arrival failed; receiver may report no devices");
         return Vec::new();
@@ -589,8 +634,10 @@ async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> 
 async fn drain_device_arrival_unifying(
     unifying: &UnifyingReceiver,
     pairing_count: u8,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> Option<Vec<UnifyingDeviceConnection>> {
     let rx = unifying.listen();
+    let _receiver_snapshot = subscriptions.map(EventSubscriptionHandle::begin_receiver_snapshot);
     // Newer Lightspeed receivers can already have notifications enabled (or
     // emit the requested arrival event without changing the legacy Unifying
     // flag). Ask first: c54d has been observed to answer this trigger while
@@ -608,17 +655,22 @@ async fn drain_device_arrival_unifying(
             Ok(Err(_)) | Err(_) => break,
         }
     }
+    // Keep unsolicited lifecycle notifications enabled after the triggered
+    // snapshot. This is read-modify-write and a no-op when already enabled.
+    let notification_result = unifying.set_wireless_notifications(true).await;
     // A receiver with no pairings legitimately emits nothing: don't pay a
-    // notification-register round trip and a second drain window for it on
-    // every watcher tick.
+    // second drain window for it on every reconciliation.
     if !out.is_empty() || pairing_count == 0 {
+        if let Err(error) = notification_result {
+            debug!(?error, "enable persistent wireless notifications failed");
+        }
         return Some(out);
     }
 
     // Classic Unifying receivers only re-broadcast 0x41 arrival events while
     // wireless notifications are on. Fall back to enabling that flag when the
     // direct trigger produced no device, then retry once on the same listener.
-    if let Err(error) = unifying.set_wireless_notifications(true).await {
+    if let Err(error) = notification_result {
         // A register write the receiver stopped ACK'ing is "couldn't check",
         // exactly like a failed trigger: settle it as a failed probe so the
         // ledger replays the last snapshot, instead of publishing an
@@ -654,7 +706,8 @@ pub(super) async fn probe_unifying_slot(
     event: &UnifyingDeviceConnection,
     receiver_uid: &str,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
+    now: Instant,
+    subscriptions: Option<&EventSubscriptionHandle>,
 ) -> Option<(PairedDevice, CacheOutcome)> {
     let slot = event.index;
     // Cache key: full receiver serial + slot so two Unifying receivers with
@@ -673,10 +726,18 @@ pub(super) async fn probe_unifying_slot(
     // announced itself into "offline" — and don't probe an offline slot at
     // all, which would burn the budget on a link the receiver just reported
     // as not established.
-    let probe_budget = unifying_probe_budget(cached, tick);
+    let probe_budget = unifying_probe_budget(cached, now);
     let probe_result = timeout(
         probe_budget,
-        probe_or_reuse(channel, slot, Some(id.clone()), cached, event.online, tick),
+        probe_or_reuse(
+            channel,
+            slot,
+            Some(id.clone()),
+            cached,
+            event.online,
+            now,
+            subscriptions,
+        ),
     )
     .await;
     let (probe, outcome) = if let Ok(result) = probe_result {
@@ -722,8 +783,8 @@ pub(super) async fn probe_unifying_slot(
 
 /// A fresh cache hit needs only an optional battery refresh; first-sight and
 /// stale entries retain the larger budget needed for a complete feature walk.
-pub(super) fn unifying_probe_budget(cached: Option<&Cached>, tick: u64) -> std::time::Duration {
-    if cached.is_some_and(|entry| !is_stale(entry, tick)) {
+pub(super) fn unifying_probe_budget(cached: Option<&Cached>, now: Instant) -> std::time::Duration {
+    if cached.is_some_and(|entry| !is_stale(entry, now)) {
         UNIFYING_CACHED_SLOT_PROBE
     } else {
         UNIFYING_SLOT_PROBE

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use hidpp::protocol::v10::{Message, MessageHeader};
 use hidpp::receiver::unifying::{Event as UnifyingEvent, decode_notification};
@@ -9,9 +10,10 @@ use openlogi_core::device::{
 };
 
 use super::cache::{
-    CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, backfill_identity, is_stale,
-    keep_known_capabilities,
+    CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_INTERVAL, backfill_identity,
+    is_stale, keep_known_capabilities,
 };
+use super::events::EventFeatureIndices;
 use super::features::ProbedFeatures;
 use super::probe::{
     NodeProbe, ProbeVerdict, assemble_bolt_probe, assemble_unifying_device,
@@ -26,11 +28,12 @@ use crate::channel::scripted::{
 };
 use crate::{DIRECT_DEVICE_INDEX, DeviceRoute};
 
-fn cache_entry(probed_tick: u64) -> Cached {
+fn cache_entry() -> Cached {
     Cached {
         probe: ProbedFeatures::default(),
         battery: None,
-        probed_tick,
+        events: EventFeatureIndices::default(),
+        probed_at: Instant::now(),
     }
 }
 
@@ -53,7 +56,7 @@ fn cache_dirty_tracks_only_persistable_keys() {
         receiver_uid: "DA2699E1".into(),
         slot: 1,
     };
-    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying.clone(), cache_entry(0))]);
+    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying.clone(), cache_entry())]);
     assert!(
         !e.cache_dirty,
         "non-persistable fresh probe dirtied the cache"
@@ -71,7 +74,7 @@ fn cache_dirty_tracks_only_persistable_keys() {
     let bolt = CacheKey::Bolt {
         unit_id: [1, 2, 3, 4],
     };
-    e.apply_outcomes(vec![CacheOutcome::Fresh(bolt, cache_entry(0))]);
+    e.apply_outcomes(vec![CacheOutcome::Fresh(bolt, cache_entry())]);
     assert!(
         e.cache_dirty,
         "persistable fresh probe must dirty the cache"
@@ -84,7 +87,7 @@ fn cache_entry_survives_grace_then_evicts() {
     let key = CacheKey::Bolt {
         unit_id: [1, 2, 3, 4],
     };
-    e.cache.insert(key.clone(), cache_entry(0));
+    e.cache.insert(key.clone(), cache_entry());
     let nobody = HashSet::new();
     // Missing for the whole grace window: kept.
     for _ in 0..CACHE_MISS_GRACE {
@@ -106,7 +109,7 @@ fn cache_entry_survives_grace_then_evicts() {
 fn being_seen_resets_the_miss_counter() {
     let mut e = Enumerator::with_backend(ScriptedBackend::new(Vec::new()));
     let key = CacheKey::Bolt { unit_id: [9; 4] };
-    e.cache.insert(key.clone(), cache_entry(0));
+    e.cache.insert(key.clone(), cache_entry());
     let nobody = HashSet::new();
     let seen: HashSet<CacheKey> = std::iter::once(key.clone()).collect();
     e.evict_unseen(&nobody); // miss 1
@@ -121,37 +124,39 @@ fn being_seen_resets_the_miss_counter() {
 }
 
 #[test]
-fn cached_probe_is_reused_until_refresh_ticks() {
+fn cached_probe_is_reused_until_refresh_interval() {
+    let probed_at = Instant::now();
     let cached = Cached {
         probe: ProbedFeatures::default(),
         battery: None,
-        probed_tick: 10,
+        events: EventFeatureIndices::default(),
+        probed_at,
     };
-    assert!(!is_stale(&cached, 10), "same tick is fresh");
+    assert!(!is_stale(&cached, probed_at), "same instant is fresh");
     assert!(
-        !is_stale(&cached, 10 + REFRESH_TICKS - 1),
+        !is_stale(&cached, probed_at + Duration::from_secs(29)),
         "just under the window is still fresh"
     );
     assert!(
-        is_stale(&cached, 10 + REFRESH_TICKS),
+        is_stale(&cached, probed_at + REFRESH_INTERVAL),
         "at the window the probe is refreshed"
     );
 }
 
 #[test]
 fn unifying_cache_hits_use_only_the_battery_refresh_budget() {
-    let cached = cache_entry(10);
+    let cached = cache_entry();
     assert_eq!(
-        unifying_probe_budget(Some(&cached), 10),
+        unifying_probe_budget(Some(&cached), cached.probed_at),
         UNIFYING_CACHED_SLOT_PROBE
     );
     assert_eq!(
-        unifying_probe_budget(Some(&cached), 10 + REFRESH_TICKS),
+        unifying_probe_budget(Some(&cached), cached.probed_at + REFRESH_INTERVAL),
         UNIFYING_SLOT_PROBE,
         "stale entries still get enough time for a full feature walk"
     );
     assert_eq!(
-        unifying_probe_budget(None, 10),
+        unifying_probe_budget(None, Instant::now()),
         UNIFYING_SLOT_PROBE,
         "first sight still gets the full feature-walk budget"
     );
@@ -179,7 +184,7 @@ async fn offline_arrival_rebroadcasts_surface_without_probing_the_device() {
     let writes_before = handle.written_reports().len();
 
     let cache = HashMap::new();
-    let (device, _) = probe_unifying_slot(&channel, &event, "SERIAL", &cache, 0)
+    let (device, _) = probe_unifying_slot(&channel, &event, "SERIAL", &cache, Instant::now(), None)
         .await
         .expect("an offline slot still surfaces from its re-broadcast");
 
@@ -588,7 +593,7 @@ fn probed(model_info: Option<DeviceModelInfo>, identity_incomplete: bool) -> Pro
 }
 
 /// A control-table read that fails half way reads exactly like "no haptic
-/// panel", and the answer is memoized for `REFRESH_TICKS` — so the Actions Ring
+/// panel", and the answer is memoized for `REFRESH_INTERVAL` — so the Actions Ring
 /// binding would vanish from the GUI for half a minute on a device that has it.
 #[test]
 fn an_incomplete_capability_walk_keeps_the_last_complete_answer() {

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -331,9 +331,10 @@ async fn run_capture_session_on(
     // replies and events silently routed elsewhere) turns every captured
     // button to dead air with nothing to notice. Ping the device through this
     // channel; consecutive all-silent pings mean the channel — not the device
-    // — is gone (a sleeping/unreachable device still gets us an error *reply*,
-    // which proves delivery and resets the count). Exiting lets the manager
-    // re-arm on a fresh channel.
+    // — is gone (a sleeping/unreachable device can still send an HID++ error
+    // reply, which proves delivery and resets the count). A transport/setup
+    // error proves neither delivery nor silence, so it restarts immediately.
+    // Exiting lets the manager re-arm on a fresh channel.
     let root = RootFeature::new(Arc::clone(&chan), device_index, 0);
     let wireless = root
         .get_feature(WirelessDeviceStatusFeature::ID)
@@ -583,9 +584,14 @@ async fn monitor_capture(
                         hidpp::channel::ChannelError::Timeout
                         | hidpp::channel::ChannelError::NoResponse,
                     )) => PingOutcome::AllSilent,
-                    // Any reply — pong, feature error, unreachable-device
-                    // error — proves the channel still delivers.
-                    _ => PingOutcome::Delivered,
+                    // A pong, feature error, or unsupported response all prove
+                    // that this channel still receives device replies.
+                    Ok(_)
+                    | Err(
+                        v20::Hidpp20Error::Feature(_)
+                        | v20::Hidpp20Error::UnsupportedResponse,
+                    ) => PingOutcome::Delivered,
+                    Err(_) => PingOutcome::ChannelFailed,
                 };
                 if liveness.finish_ping(
                     tokio::time::Instant::now(),

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -17,6 +17,8 @@
 //! is therefore only diverted when the user's thumbwheel config leaves its
 //! defaults (click bound, rotation rebound, or sensitivity changed).
 
+mod liveness;
+
 use std::sync::{Arc, Mutex, PoisonError};
 
 use hidpp::{
@@ -37,6 +39,8 @@ use crate::backend::HidBackend;
 use crate::channel::route::{DeviceRoute, open_route_channel};
 use crate::{ChannelRegistry, SharedChannel};
 
+use liveness::{CaptureLiveness, ChannelActivity, LivenessDecision, PingOutcome};
+
 #[cfg(test)]
 use super::capture_restore::undivert_change;
 use super::capture_restore::{
@@ -50,15 +54,6 @@ pub use super::capture_restore::{
 };
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::thumbwheel::{self, Thumbwheel, WheelDirection, WheelResolution};
-
-/// How often the capture session pings its device to prove the channel still
-/// delivers input reports. Cheap: one HID++ round-trip per interval.
-const LIVENESS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
-
-/// Consecutive all-silent pings after which the capture channel is declared
-/// dead. Two, so one ping lost to transient receiver congestion (which does
-/// happen under pointer load) doesn't churn the session.
-const LIVENESS_PING_STRIKES: u8 = 2;
 
 /// One input captured from the active device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -291,10 +286,15 @@ async fn run_capture_session_on(
         .map_or(WheelResolution::UNKNOWN, |(_, res)| *res);
     let dpi_set = armed.dpi_cids.clone();
     let button_set = armed.button_cids.clone();
+    let activity = Arc::new(ChannelActivity::default());
     let listener = chan.add_msg_listener_guarded({
         let accum = Arc::clone(&accum);
+        let activity = Arc::clone(&activity);
         let sink = sink.clone();
         move |raw, matched| {
+            // Every parsed inbound HID++ report proves this channel's read
+            // path is alive, including responses matched to another request.
+            activity.record();
             if matched {
                 return;
             }
@@ -350,6 +350,7 @@ async fn run_capture_session_on(
             device_index,
             registry,
             shared: &shared,
+            activity: &activity,
         },
         wireless,
         shutdown,
@@ -517,6 +518,7 @@ struct CaptureMonitor<'a> {
     device_index: u8,
     registry: Option<&'a ChannelRegistry>,
     shared: &'a SharedChannel,
+    activity: &'a ChannelActivity,
 }
 
 /// Keep a capture session alive and reapply its volatile diversions whenever
@@ -529,22 +531,27 @@ async fn monitor_capture(
 ) -> CaptureStop {
     let mut wake_events = wireless.as_ref().map(EmittingFeature::listen);
     let mut shutdown = std::pin::pin!(shutdown);
-    let mut silent_pings = 0u8;
+    let mut liveness =
+        CaptureLiveness::new(tokio::time::Instant::now(), context.activity.generation());
     loop {
+        let activity_generation = liveness.activity_generation();
+        let idle_deadline = liveness.idle_deadline();
         tokio::select! {
-            _ = &mut shutdown => {
-                // Shutdown and inventory replacement can become ready on the
-                // same turn. Prefer the typed channel transition so teardown
-                // never blindly writes through a transport already known to
-                // be obsolete.
-                return stop_for_current_publication(context.registry, context.shared);
-            }
+            biased;
+
             transition = wait_for_channel_change(
                 context.registry,
                 context.shared,
             ) => {
                 info!(index = context.device_index, "inventory replaced or removed capture channel — restarting session");
                 return transition;
+            }
+            _ = &mut shutdown => {
+                // Shutdown and inventory replacement can become ready on the
+                // same turn. Prefer the typed channel transition so teardown
+                // never blindly writes through a transport already known to
+                // be obsolete.
+                return stop_for_current_publication(context.registry, context.shared);
             }
             event = async {
                 match wake_events.as_ref() {
@@ -561,21 +568,32 @@ async fn monitor_capture(
                     CaptureAccum::default();
                 context.armed.rearm().await;
             }
-            () = tokio::time::sleep(LIVENESS_PING_INTERVAL) => {
-                match context.root.ping(0x5a).await {
+            generation = context.activity.changed_after(activity_generation) => {
+                liveness.record_activity(tokio::time::Instant::now(), generation);
+            }
+            () = tokio::time::sleep_until(idle_deadline) => {
+                if !liveness.ping_due(
+                    tokio::time::Instant::now(),
+                    context.activity.generation(),
+                ) {
+                    continue;
+                }
+                let outcome = match context.root.ping(0x5a).await {
                     Err(v20::Hidpp20Error::Channel(
                         hidpp::channel::ChannelError::Timeout
                         | hidpp::channel::ChannelError::NoResponse,
-                    )) => {
-                        silent_pings = silent_pings.saturating_add(1);
-                        if silent_pings >= LIVENESS_PING_STRIKES {
-                            warn!(index = context.device_index, "capture channel stopped delivering — restarting session on a fresh channel");
-                            return stop_for_current_publication(context.registry, context.shared);
-                        }
-                    }
+                    )) => PingOutcome::AllSilent,
                     // Any reply — pong, feature error, unreachable-device
                     // error — proves the channel still delivers.
-                    _ => silent_pings = 0,
+                    _ => PingOutcome::Delivered,
+                };
+                if liveness.finish_ping(
+                    tokio::time::Instant::now(),
+                    context.activity.generation(),
+                    outcome,
+                ) == LivenessDecision::Restart {
+                    warn!(index = context.device_index, "capture channel stopped delivering — restarting session on a fresh channel");
+                    return stop_for_current_publication(context.registry, context.shared);
                 }
             }
         }

--- a/crates/openlogi-device/src/session/gesture/liveness.rs
+++ b/crates/openlogi-device/src/session/gesture/liveness.rs
@@ -1,0 +1,251 @@
+//! Event-aware liveness state for the gesture capture channel.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::time::Instant;
+
+/// A channel must be wholly idle for this long before capture probes it.
+pub(super) const IDLE_INTERVAL: Duration = Duration::from_secs(20);
+
+/// Consecutive all-silent probes after which capture replaces the channel.
+const SILENT_STRIKES_BEFORE_RESTART: u8 = 2;
+
+/// Coalescing signal that the HID++ read thread delivered at least one report.
+///
+/// Recording activity is one atomic increment plus a notification: routine
+/// captured input never takes a lock, blocks the read thread, or builds an
+/// unbounded queue. The generation preserves activity that races waiter setup;
+/// `Notify` only avoids waiting for the next generation change.
+#[derive(Default)]
+pub(super) struct ChannelActivity {
+    generation: AtomicU64,
+    changed: Notify,
+}
+
+impl ChannelActivity {
+    /// Record one or more inbound reports as a new delivery generation.
+    pub(super) fn record(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+        self.changed.notify_one();
+    }
+
+    /// Return the latest coalesced activity generation.
+    pub(super) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    /// Wait until activity differs from `observed`, including activity that
+    /// lands immediately before or during waiter registration.
+    pub(super) async fn changed_after(&self, observed: u64) -> u64 {
+        loop {
+            let notified = self.changed.notified();
+            tokio::pin!(notified);
+
+            // Register before checking the generation. An activity report
+            // between these operations either changes the generation or makes
+            // this already-registered future ready, so no wakeup is lost.
+            let _ = notified.as_mut().enable();
+            let current = self.generation();
+            if current != observed {
+                return current;
+            }
+            notified.await;
+        }
+    }
+}
+
+/// Whether one completed probe observed delivery on the capture channel.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum PingOutcome {
+    /// A response arrived, regardless of whether it was a pong or HID++ error.
+    Delivered,
+    /// Neither a response nor any other report arrived before the timeout.
+    AllSilent,
+}
+
+/// What capture should do after accounting for a completed probe.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum LivenessDecision {
+    Continue,
+    Restart,
+}
+
+/// Pure deadline and strike state for one capture channel.
+pub(super) struct CaptureLiveness {
+    activity_generation: u64,
+    idle_deadline: Instant,
+    silent_strikes: u8,
+}
+
+impl CaptureLiveness {
+    pub(super) fn new(now: Instant, activity_generation: u64) -> Self {
+        Self {
+            activity_generation,
+            idle_deadline: now + IDLE_INTERVAL,
+            silent_strikes: 0,
+        }
+    }
+
+    pub(super) fn activity_generation(&self) -> u64 {
+        self.activity_generation
+    }
+
+    pub(super) fn idle_deadline(&self) -> Instant {
+        self.idle_deadline
+    }
+
+    /// Account for delivered reports and defer probing until another complete
+    /// idle interval has elapsed. Any delivery also clears a silent strike.
+    pub(super) fn record_activity(&mut self, now: Instant, generation: u64) {
+        let _ = self.take_activity(now, generation);
+    }
+
+    /// Re-check activity when the current timer expires. This closes the race
+    /// where a report lands as the deadline becomes ready.
+    pub(super) fn ping_due(&mut self, now: Instant, generation: u64) -> bool {
+        !self.take_activity(now, generation) && now >= self.idle_deadline
+    }
+
+    /// Account for a completed probe and schedule the next one after another
+    /// full interval. Activity racing an all-silent result proves delivery and
+    /// wins over the strike.
+    pub(super) fn finish_ping(
+        &mut self,
+        now: Instant,
+        generation: u64,
+        outcome: PingOutcome,
+    ) -> LivenessDecision {
+        let activity = self.take_activity(now, generation);
+        self.idle_deadline = now + IDLE_INTERVAL;
+        if activity || outcome == PingOutcome::Delivered {
+            self.silent_strikes = 0;
+            return LivenessDecision::Continue;
+        }
+
+        self.silent_strikes = self.silent_strikes.saturating_add(1);
+        if self.silent_strikes >= SILENT_STRIKES_BEFORE_RESTART {
+            LivenessDecision::Restart
+        } else {
+            LivenessDecision::Continue
+        }
+    }
+
+    fn take_activity(&mut self, now: Instant, generation: u64) -> bool {
+        if generation == self.activity_generation {
+            return false;
+        }
+        self.activity_generation = generation;
+        self.idle_deadline = now + IDLE_INTERVAL;
+        self.silent_strikes = 0;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn active_traffic_defers_the_idle_ping() {
+        let activity = ChannelActivity::default();
+        let mut liveness = CaptureLiveness::new(Instant::now(), activity.generation());
+        let almost_idle = IDLE_INTERVAL
+            .checked_sub(Duration::from_secs(1))
+            .expect("the test offset is shorter than the idle interval");
+
+        tokio::time::advance(almost_idle).await;
+        activity.record();
+        liveness.record_activity(Instant::now(), activity.generation());
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        assert!(!liveness.ping_due(Instant::now(), activity.generation()));
+        tokio::time::advance(almost_idle).await;
+        assert!(liveness.ping_due(Instant::now(), activity.generation()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_ping_is_scheduled_after_each_full_interval() {
+        let activity = ChannelActivity::default();
+        let mut liveness = CaptureLiveness::new(Instant::now(), activity.generation());
+        let almost_idle = IDLE_INTERVAL
+            .checked_sub(Duration::from_millis(1))
+            .expect("the test offset is shorter than the idle interval");
+
+        tokio::time::advance(almost_idle).await;
+        assert!(!liveness.ping_due(Instant::now(), activity.generation()));
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(liveness.ping_due(Instant::now(), activity.generation()));
+        assert!(matches!(
+            liveness.finish_ping(
+                Instant::now(),
+                activity.generation(),
+                PingOutcome::AllSilent,
+            ),
+            LivenessDecision::Continue
+        ));
+
+        tokio::time::advance(almost_idle).await;
+        assert!(!liveness.ping_due(Instant::now(), activity.generation()));
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(liveness.ping_due(Instant::now(), activity.generation()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delivery_resets_a_silent_strike() {
+        let activity = ChannelActivity::default();
+        let mut liveness = CaptureLiveness::new(Instant::now(), activity.generation());
+
+        tokio::time::advance(IDLE_INTERVAL).await;
+        assert!(matches!(
+            liveness.finish_ping(
+                Instant::now(),
+                activity.generation(),
+                PingOutcome::AllSilent,
+            ),
+            LivenessDecision::Continue
+        ));
+
+        tokio::time::advance(IDLE_INTERVAL).await;
+        assert!(matches!(
+            liveness.finish_ping(
+                Instant::now(),
+                activity.generation(),
+                PingOutcome::Delivered,
+            ),
+            LivenessDecision::Continue
+        ));
+
+        tokio::time::advance(IDLE_INTERVAL).await;
+        assert!(matches!(
+            liveness.finish_ping(
+                Instant::now(),
+                activity.generation(),
+                PingOutcome::AllSilent,
+            ),
+            LivenessDecision::Continue
+        ));
+        tokio::time::advance(IDLE_INTERVAL).await;
+        assert!(matches!(
+            liveness.finish_ping(
+                Instant::now(),
+                activity.generation(),
+                PingOutcome::AllSilent,
+            ),
+            LivenessDecision::Restart
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn activity_before_wait_registration_is_not_lost() {
+        let activity = ChannelActivity::default();
+        activity.record();
+
+        let generation = tokio::time::timeout(Duration::from_secs(1), activity.changed_after(0))
+            .await
+            .expect("pre-existing activity must make the waiter ready");
+
+        assert_eq!(generation, activity.generation());
+    }
+}

--- a/crates/openlogi-device/src/session/gesture/liveness.rs
+++ b/crates/openlogi-device/src/session/gesture/liveness.rs
@@ -63,6 +63,8 @@ pub(super) enum PingOutcome {
     Delivered,
     /// Neither a response nor any other report arrived before the timeout.
     AllSilent,
+    /// The channel failed before delivery could be established.
+    ChannelFailed,
 }
 
 /// What capture should do after accounting for a completed probe.
@@ -119,6 +121,9 @@ impl CaptureLiveness {
     ) -> LivenessDecision {
         let activity = self.take_activity(now, generation);
         self.idle_deadline = now + IDLE_INTERVAL;
+        if outcome == PingOutcome::ChannelFailed {
+            return LivenessDecision::Restart;
+        }
         if activity || outcome == PingOutcome::Delivered {
             self.silent_strikes = 0;
             return LivenessDecision::Continue;
@@ -232,6 +237,22 @@ mod tests {
                 Instant::now(),
                 activity.generation(),
                 PingOutcome::AllSilent,
+            ),
+            LivenessDecision::Restart
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn channel_failure_restarts_without_a_second_probe() {
+        let activity = ChannelActivity::default();
+        let mut liveness = CaptureLiveness::new(Instant::now(), activity.generation());
+
+        tokio::time::advance(IDLE_INTERVAL).await;
+        assert!(matches!(
+            liveness.finish_ping(
+                Instant::now(),
+                activity.generation(),
+                PingOutcome::ChannelFailed,
             ),
             LivenessDecision::Restart
         ));

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -206,6 +206,38 @@ async fn capture_listener_outlives_native_reporting_restore() {
     );
 }
 
+#[tokio::test(start_paused = true)]
+async fn channel_change_takes_teardown_precedence_over_ready_shutdown() {
+    let route = DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xb35b,
+    };
+    let registry = ChannelRegistry::default();
+    let node = NodeId::from("mouse-node".to_owned());
+    let (retired_raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+    let retired_channel = scripted_channel(retired_raw).await;
+    registry.replace_node(node.clone(), [route.clone()], retired_channel);
+    let retired = registry
+        .lookup(&route)
+        .expect("the capture publication should be current");
+
+    let (replacement_raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+    let replacement = scripted_channel(replacement_raw).await;
+    registry.replace_node(node, [route], replacement);
+
+    // These are the two monitor branches that can become ready together. The
+    // explicit shutdown branch re-checks the publication, so both preserve the
+    // typed replacement teardown rather than restoring through `retired`.
+    assert!(matches!(
+        stop_for_current_publication(Some(&registry), &retired),
+        CaptureStop::ChannelChanged
+    ));
+    assert!(matches!(
+        wait_for_channel_change(Some(&registry), &retired).await,
+        CaptureStop::ChannelChanged
+    ));
+}
+
 /// A control that was *already* diverted when the session armed it — an agent
 /// killed mid-session, or another Logitech app — must not be handed that state
 /// back. Replaying it leaves the button diverted with no listener: no OS event

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -185,12 +185,11 @@ fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
 /// Process-wide HID backend, created once and reused for every enumeration.
 ///
 /// async-hid's macOS backend wraps an `IOHIDManager`; `HidBackend::default()`
-/// builds, schedules, and (on drop) cancels one. The inventory watcher
-/// enumerates every ~2 s, so building a fresh backend per call spun up and tore
-/// down an `IOHIDManager` on every tick — needless churn that kept the process
-/// busy and its heap dirty around the clock (issue #99). Reusing one long-lived
-/// backend is the usage async-hid intends, and keeps the device set warm between
-/// polls. `HidBackend` is `Arc`-backed, so this is shared, not copied.
+/// builds, schedules, and (on drop) cancels one. Building a fresh backend per
+/// reconciliation spun up and tore down an `IOHIDManager` repeatedly — needless
+/// churn (issue #99). Reusing one long-lived backend is the usage async-hid
+/// intends, and keeps the device set warm between event/recovery passes.
+/// `HidBackend` is `Arc`-backed, so this is shared, not copied.
 ///
 /// Inventory and route-addressed standalone operations may enumerate through
 /// this one backend concurrently. That is sound: async-hid declares the backend
@@ -414,8 +413,8 @@ pub(crate) async fn open_hidpp_channel(
             }
         };
         // Logged once per actual open. The inventory watcher reuses channels across
-        // ticks, so a steadily-connected device should log this on first sight (and
-        // on reconnect) only — not every ~2s tick.
+        // reconciliations, so a steadily-connected device should log this on first
+        // sight (and on reconnect) only — not every pass.
         debug!(name = %info.name, vid = format_args!("{:04x}", info.vendor_id), "opened HID++ channel");
         Ok(Some(channel))
     }

--- a/crates/openlogi-hidpp/src/feature/unified_battery.rs
+++ b/crates/openlogi-hidpp/src/feature/unified_battery.rs
@@ -44,6 +44,18 @@ impl DecodeEvent for BatteryEvent {
     }
 }
 
+impl BatteryEvent {
+    /// Decodes one event payload for this feature, or returns `None` for an
+    /// unsupported function or wire value.
+    ///
+    /// Consumers that already own a channel-level listener can use this
+    /// without constructing a second [`UnifiedBatteryFeature`].
+    #[must_use]
+    pub fn decode(function_id: u8, payload: &[u8; 16]) -> Option<Self> {
+        <Self as DecodeEvent>::decode(function_id, payload)
+    }
+}
+
 impl UnifiedBatteryFeature {
     /// Retrieves the capabilities of this feature and the battery in general.
     pub async fn get_battery_capabilities(&self) -> Result<BatteryCapabilities, Hidpp20Error> {

--- a/crates/openlogi-hidpp/src/feature/wireless_device_status.rs
+++ b/crates/openlogi-hidpp/src/feature/wireless_device_status.rs
@@ -55,6 +55,18 @@ impl DecodeEvent for WirelessDeviceStatusEvent {
     }
 }
 
+impl WirelessDeviceStatusEvent {
+    /// Decodes one event payload for this feature, or returns `None` for an
+    /// unsupported event function.
+    ///
+    /// Consumers that already own a channel-level listener can use this
+    /// without constructing a second [`WirelessDeviceStatusFeature`].
+    #[must_use]
+    pub fn decode(function_id: u8, payload: &[u8; 16]) -> Option<Self> {
+        <Self as DecodeEvent>::decode(function_id, payload)
+    }
+}
+
 /// Represents an event emitted by the [`WirelessDeviceStatusFeature`]
 /// feature.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -26,7 +26,9 @@ use crate::{
 
 mod event;
 
-pub use event::{DeviceConnection, DeviceKind, Event, PairingPasskeyPressType};
+pub use event::{
+    DeviceConnection, DeviceKind, Event, PairingPasskeyPressType, decode as decode_notification,
+};
 
 /// All known registers of the Bolt receiver.
 ///

--- a/crates/openlogi-hidpp/src/receiver/bolt/event.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt/event.rs
@@ -53,8 +53,10 @@ enum DiscoveryPart {
 /// drops.
 ///
 /// Kept separate from the message listener in [`super::Receiver::new`] so the
-/// wire layout is reachable from tests without a HID channel behind it.
-pub(super) fn decode(msg: &v10::Message) -> Option<Event> {
+/// wire layout is reachable from consumers and tests without a HID channel
+/// behind it.
+#[must_use]
+pub fn decode(msg: &v10::Message) -> Option<Event> {
     let header = msg.header();
     let payload = msg.extend_payload();
 

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -50,6 +50,7 @@ objc2-foundation = { workspace = true, features = [
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_System_Threading",
+    "Win32_UI_Accessibility",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = { workspace = true }
+futures-lite = { workspace = true }
 libc = "0.2"
 wayland-client = "0.31"
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }

--- a/crates/openlogi-hook/gnome-shell-extension/README.md
+++ b/crates/openlogi-hook/gnome-shell-extension/README.md
@@ -3,8 +3,9 @@
 GNOME (Mutter) does not let ordinary clients see which window is focused on
 Wayland, and it implements neither `wlr-foreign-toplevel` nor a focused-window
 portal. This minimal extension bridges that gap: it exports the WM_CLASS of the
-focused window over D-Bus so OpenLogi's `gnome-shell` frontmost backend can
-drive per-app mouse-profile switching.
+focused window over D-Bus and emits every native focus change so OpenLogi's
+`gnome-shell` backend can drive per-app mouse-profile switching without
+polling.
 
 It reads only `global.display.focus_window.get_wm_class()`. No titles, no window
 contents, no input, no UI.
@@ -14,6 +15,7 @@ contents, no input, no UI.
 - name: `org.openlogi.Frontmost`
 - path: `/org/openlogi/Frontmost`
 - method: `GetFocusedWmClass() -> s` (empty string when nothing is focused)
+- signal: `FocusedWmClassChanged(s)` (emitted on each GNOME focus change)
 
 ## Install
 
@@ -43,10 +45,16 @@ gdbus call --session \
   -d org.openlogi.Frontmost \
   -o /org/openlogi/Frontmost \
   -m org.openlogi.Frontmost.GetFocusedWmClass
+
+# Watch focus changes:
+gdbus monitor --session \
+  -d org.openlogi.Frontmost \
+  -o /org/openlogi/Frontmost
 ```
 
-If `gdbus call` prints the focused window's WM_CLASS, OpenLogi's GNOME backend
-will pick it up automatically the next time the hook starts.
+If the call prints the focused window's WM_CLASS and the monitor reports
+`FocusedWmClassChanged` while switching windows, OpenLogi's GNOME backend will
+pick it up automatically the next time the hook starts.
 
 ## Notes
 

--- a/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/extension.js
+++ b/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/extension.js
@@ -1,14 +1,15 @@
 // OpenLogi Frontmost Window — GNOME Shell extension.
 //
 // Exports a tiny D-Bus service that returns the WM_CLASS of the currently
-// focused window. OpenLogi's `gnome_shell` frontmost backend polls this to
-// drive per-app mouse-profile switching on GNOME Wayland, where the focused
-// window is otherwise not visible to ordinary clients.
+// focused window and signals focus changes. OpenLogi's `gnome_shell` backend
+// uses this to drive per-app mouse-profile switching on GNOME Wayland, where
+// the focused window is otherwise not visible to ordinary clients.
 //
 // It reads only `global.display.focus_window.get_wm_class()` — no titles, no
 // window contents, no input. ESM module style; targets GNOME Shell 45+.
 
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const DBUS_NAME = 'org.openlogi.Frontmost';
@@ -19,6 +20,9 @@ const DBUS_INTERFACE = `
     <method name="GetFocusedWmClass">
       <arg type="s" direction="out" name="wmClass"/>
     </method>
+    <signal name="FocusedWmClassChanged">
+      <arg type="s" name="wmClass"/>
+    </signal>
   </interface>
 </node>`;
 
@@ -32,9 +36,16 @@ export default class OpenLogiFrontmostExtension extends Extension {
             Gio.BusNameOwnerFlags.NONE,
             null,
             null);
+        this._focusChangedId = global.display.connect(
+            'notify::focus-window',
+            () => this._emitFocusedWmClassChanged());
     }
 
     disable() {
+        if (this._focusChangedId) {
+            global.display.disconnect(this._focusChangedId);
+            this._focusChangedId = 0;
+        }
         if (this._nameId) {
             Gio.bus_unown_name(this._nameId);
             this._nameId = 0;
@@ -51,5 +62,13 @@ export default class OpenLogiFrontmostExtension extends Extension {
         if (!win)
             return '';
         return win.get_wm_class() || '';
+    }
+
+    _emitFocusedWmClassChanged() {
+        if (this._dbus) {
+            this._dbus.emit_signal(
+                'FocusedWmClassChanged',
+                new GLib.Variant('(s)', [this.GetFocusedWmClass()]));
+        }
     }
 }

--- a/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/metadata.json
+++ b/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/metadata.json
@@ -4,5 +4,5 @@
   "description": "Exposes the focused window's WM_CLASS over D-Bus so OpenLogi can switch per-app mouse profiles on GNOME Wayland. Read-only; no UI, no window contents.",
   "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/AprilNEA/OpenLogi",
-  "version": 1
+  "version": 2
 }

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -26,6 +26,9 @@
 //! ```
 
 use std::cfg_select;
+use std::sync::Arc;
+
+use thiserror::Error;
 
 pub use openlogi_core::app::ForegroundApp;
 pub use openlogi_core::binding::ButtonId;
@@ -523,16 +526,108 @@ impl Hook {
 /// `None` when no app is frontmost, when reading fails, or on an unsupported
 /// platform — including a pure-Wayland session with no backend (see
 /// `linux::detect_frontmost_source`). Costs one X11 round-trip on Linux and a
-/// handful of `objc_msgSend`s on macOS. macOS callers can use
-/// `watch_frontmost_application_activations` to drive reads from native
-/// activation notifications instead of polling.
+/// handful of `objc_msgSend`s on macOS. Callers can use
+/// [`watch_frontmost_application_changes`] to drive reads from native platform
+/// events instead of polling.
 #[must_use]
 pub fn frontmost_application() -> Option<ForegroundApp> {
     Backend::frontmost_app()
 }
 
-#[cfg(target_os = "macos")]
-pub use macos::ForegroundApplicationObserver;
+/// Failure to install or operate a native foreground-application observer.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ForegroundApplicationObserverError {
+    /// This target has no foreground-application event source.
+    #[error("foreground-application observation is unsupported on this platform")]
+    Unsupported,
+    /// The selected platform observer failed.
+    #[error("foreground-application observer failed: {0}")]
+    Platform(String),
+}
+
+/// RAII owner of the current platform's foreground-application observer.
+///
+/// Dropping this value synchronously unregisters the native observer and stops
+/// any worker it owns.
+#[must_use]
+pub struct ForegroundApplicationObserver {
+    #[cfg(target_os = "macos")]
+    platform: macos::ForegroundApplicationObserver,
+    #[cfg(target_os = "linux")]
+    platform: linux::ForegroundApplicationObserver,
+    #[cfg(target_os = "windows")]
+    platform: windows::foreground::ForegroundApplicationObserver,
+}
+
+impl ForegroundApplicationObserver {
+    /// Return an error if a fallible observer worker has stopped delivering.
+    ///
+    /// Native macOS registration has no independently observable worker
+    /// health, so it relies on the consumer's idle recovery read.
+    pub fn check_health(&self) -> Result<(), ForegroundApplicationObserverError> {
+        #[cfg(target_os = "linux")]
+        {
+            self.platform
+                .check_health()
+                .map_err(|error| ForegroundApplicationObserverError::Platform(error.to_owned()))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            self.platform
+                .check_health()
+                .map_err(|error| ForegroundApplicationObserverError::Platform(error.to_string()))
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let _ = &self.platform;
+            Ok(())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        {
+            Err(ForegroundApplicationObserverError::Unsupported)
+        }
+    }
+}
+
+/// Observe native foreground-application changes.
+///
+/// The callback is an invalidation, not another source of application identity:
+/// call [`frontmost_application`] to read the authoritative current value. It
+/// may run on any thread, must return quickly, and is invoked once after native
+/// registration so the consumer can seed its state without a polling read.
+pub fn watch_frontmost_application_changes(
+    on_change: impl Fn() + Send + Sync + 'static,
+) -> Result<ForegroundApplicationObserver, ForegroundApplicationObserverError> {
+    let on_change: Arc<dyn Fn() + Send + Sync> = Arc::new(on_change);
+
+    #[cfg(target_os = "macos")]
+    {
+        let native_callback = Arc::clone(&on_change);
+        let platform = macos::watch_frontmost_application_activations(move |_| native_callback());
+        on_change();
+        Ok(ForegroundApplicationObserver { platform })
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let platform = linux::watch_frontmost_application_activations(move |_| on_change())
+            .map_err(|error| ForegroundApplicationObserverError::Platform(error.to_string()))?;
+        Ok(ForegroundApplicationObserver { platform })
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let platform = windows::foreground::watch_frontmost_application_activations(move |_| {
+            on_change();
+        })
+        .map_err(|error| ForegroundApplicationObserverError::Platform(error.to_string()))?;
+        Ok(ForegroundApplicationObserver { platform })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = on_change;
+        Err(ForegroundApplicationObserverError::Unsupported)
+    }
+}
 
 /// Observe macOS foreground-application activations.
 ///
@@ -543,7 +638,9 @@ pub use macos::ForegroundApplicationObserver;
 pub fn watch_frontmost_application_activations(
     on_activation: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
 ) -> ForegroundApplicationObserver {
-    macos::watch_frontmost_application_activations(on_activation)
+    ForegroundApplicationObserver {
+        platform: macos::watch_frontmost_application_activations(on_activation),
+    }
 }
 
 /// Return the current global cursor position without installing an input hook.

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -30,6 +30,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{
     Arc, Condvar, LazyLock, Mutex, MutexGuard,
     atomic::{AtomicBool, Ordering},
+    mpsc,
 };
 use std::thread;
 use std::time::{Duration, Instant};
@@ -38,6 +39,7 @@ use evdev::uinput::VirtualDevice;
 use evdev::{
     AbsoluteAxisCode, AttributeSetRef, Device, EventSummary, KeyCode, PropType, RelativeAxisCode,
 };
+use thiserror::Error;
 use tracing::{debug, error, warn};
 use x11rb::connection::Connection as _;
 use x11rb::properties::WmClass;
@@ -1153,6 +1155,18 @@ struct ObserverWorker {
     thread: thread::JoinHandle<Box<dyn FrontmostSource>>,
 }
 
+type ObserverWorkerStart = (Box<dyn FrontmostSource>, StopToken, PublishAppId);
+
+#[derive(Debug, Error)]
+pub(crate) enum ForegroundApplicationObserverError {
+    #[error("could not create the Linux foreground observer stop pipe: {0}")]
+    StopPipe(io::Error),
+    #[error("could not spawn the Linux foreground observer thread: {0}")]
+    ThreadSpawn(io::Error),
+    #[error("the Linux foreground observer thread stopped during startup")]
+    WorkerStoppedDuringStartup,
+}
+
 struct FrontmostRuntime {
     source: Option<Box<dyn FrontmostSource>>,
     worker: Option<ObserverWorker>,
@@ -1206,7 +1220,7 @@ impl FrontmostController {
     fn watch(
         self: &Arc<Self>,
         callback: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
-    ) -> ForegroundApplicationObserver {
+    ) -> Result<ForegroundApplicationObserver, ForegroundApplicationObserverError> {
         let subscriber = Arc::new(Subscriber::new(callback));
         let mut runtime = lock_unpoisoned(&self.runtime);
         while runtime.stopping {
@@ -1218,26 +1232,40 @@ impl FrontmostController {
 
         let id = runtime.next_subscriber_id;
         runtime.next_subscriber_id += 1;
-        if runtime.worker.is_none() {
-            self.publication.begin();
-        }
-        let initial = self.publication.subscribe(id, &subscriber);
+        let initial = if runtime.worker.is_none() {
+            let (stop, stop_token) =
+                stop_pair().map_err(ForegroundApplicationObserverError::StopPipe)?;
+            let (start_tx, start_rx) = mpsc::sync_channel::<ObserverWorkerStart>(0);
+            let thread = thread::Builder::new()
+                .name("openlogi-frontmost".into())
+                .spawn(move || match start_rx.recv() {
+                    Ok((source, stop_token, publish)) => source.observe(stop_token, publish),
+                    Err(_) => Box::new(NullSource),
+                })
+                .map_err(ForegroundApplicationObserverError::ThreadSpawn)?;
 
-        if runtime.worker.is_none() {
+            self.publication.begin();
+            let initial = self.publication.subscribe(id, &subscriber);
             let source = runtime
                 .source
                 .take()
                 .unwrap_or_else(|| Box::new(NullSource));
-            let (stop, stop_token) = stop_pair()
-                .unwrap_or_else(|error| panic!("failed to create frontmost stop pipe: {error}"));
             let publication = Arc::clone(&self.publication);
             let publish: PublishAppId = Arc::new(move |app| publication.publish(app));
-            let thread = thread::Builder::new()
-                .name("openlogi-frontmost".into())
-                .spawn(move || source.observe(stop_token, publish))
-                .unwrap_or_else(|error| panic!("failed to start frontmost observer: {error}"));
+            if let Err(error) = start_tx.send((source, stop_token, publish)) {
+                let (source, _, _) = error.0;
+                runtime.source = Some(source);
+                self.publication.unsubscribe(id);
+                self.publication.finish();
+                drop(runtime);
+                let _ = thread.join();
+                return Err(ForegroundApplicationObserverError::WorkerStoppedDuringStartup);
+            }
             runtime.worker = Some(ObserverWorker { stop, thread });
-        }
+            initial
+        } else {
+            self.publication.subscribe(id, &subscriber)
+        };
         drop(runtime);
 
         // Do not call user code while holding the controller lock. If the
@@ -1247,9 +1275,22 @@ impl FrontmostController {
             subscriber.deliver(version, app);
         }
 
-        ForegroundApplicationObserver {
+        Ok(ForegroundApplicationObserver {
             controller: Arc::clone(self),
             subscriber_id: id,
+        })
+    }
+
+    fn check_health(&self) -> Result<(), &'static str> {
+        let runtime = lock_unpoisoned(&self.runtime);
+        if runtime
+            .worker
+            .as_ref()
+            .is_some_and(|worker| worker.thread.is_finished())
+        {
+            Err("Linux foreground observer worker stopped")
+        } else {
+            Ok(())
         }
     }
 
@@ -1277,7 +1318,7 @@ impl FrontmostController {
         worker.stop.request();
         let source = worker.thread.join().unwrap_or_else(|panic| {
             error!("foreground-application worker panicked on shutdown: {panic:?}");
-            Box::new(NullSource)
+            detect_frontmost_source()
         });
 
         let mut runtime = lock_unpoisoned(&self.runtime);
@@ -1301,6 +1342,12 @@ pub(crate) struct ForegroundApplicationObserver {
     subscriber_id: u64,
 }
 
+impl ForegroundApplicationObserver {
+    pub(crate) fn check_health(&self) -> Result<(), &'static str> {
+        self.controller.check_health()
+    }
+}
+
 impl Drop for ForegroundApplicationObserver {
     fn drop(&mut self) {
         self.controller.remove_observer(self.subscriber_id);
@@ -1310,14 +1357,9 @@ impl Drop for ForegroundApplicationObserver {
 /// Observe foreground-application changes from the selected native backend.
 pub(crate) fn watch_frontmost_application_activations(
     callback: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
-) -> ForegroundApplicationObserver {
+) -> Result<ForegroundApplicationObserver, ForegroundApplicationObserverError> {
     FRONTMOST.watch(callback)
 }
-
-/// Keep this intentionally unwired Linux-internal API type-checked until the
-/// cross-platform facade adopts it.
-const _: fn(fn(Option<ForegroundApp>)) -> ForegroundApplicationObserver =
-    watch_frontmost_application_activations;
 
 #[cfg(test)]
 mod tests {
@@ -1393,9 +1435,11 @@ mod tests {
             stopped: Arc::clone(&stopped),
         }));
         let (tx, rx) = mpsc::channel();
-        let observer = controller.watch(move |app| {
-            tx.send(app).expect("test receiver remains alive");
-        });
+        let observer = controller
+            .watch(move |app| {
+                tx.send(app).expect("test receiver remains alive");
+            })
+            .expect("observer starts");
 
         let initial = rx
             .recv_timeout(Duration::from_secs(1))
@@ -1417,9 +1461,11 @@ mod tests {
     fn unsupported_foreground_source_publishes_none_and_stops_cleanly() {
         let controller = FrontmostController::new(Box::new(NullSource));
         let (tx, rx) = mpsc::channel();
-        let observer = controller.watch(move |app| {
-            tx.send(app).expect("test receiver remains alive");
-        });
+        let observer = controller
+            .watch(move |app| {
+                tx.send(app).expect("test receiver remains alive");
+            })
+            .expect("observer starts");
 
         assert_eq!(
             rx.recv_timeout(Duration::from_secs(1))

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -23,13 +23,16 @@
     reason = "the wake pipe and the Wayland toplevel listener call libc directly"
 )]
 
+use std::collections::HashMap;
 use std::io;
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{
-    Arc, LazyLock,
+    Arc, Condvar, LazyLock, Mutex, MutexGuard,
     atomic::{AtomicBool, Ordering},
 };
 use std::thread;
+use std::time::{Duration, Instant};
 
 use evdev::uinput::VirtualDevice;
 use evdev::{
@@ -38,7 +41,10 @@ use evdev::{
 use tracing::{debug, error, warn};
 use x11rb::connection::Connection as _;
 use x11rb::properties::WmClass;
-use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Window};
+use x11rb::protocol::Event;
+use x11rb::protocol::xproto::{
+    Atom, AtomEnum, ChangeWindowAttributesAux, ConnectionExt as _, EventMask, Window,
+};
 use x11rb::rust_connection::RustConnection;
 
 use crate::{
@@ -129,9 +135,7 @@ impl HookBackend for Backend {
     /// backend. No Linux source reports an application name separate from its
     /// identifier, so the two are the same string here.
     fn frontmost_app() -> Option<ForegroundApp> {
-        FRONTMOST_SOURCE
-            .frontmost_app_id()
-            .map(ForegroundApp::unnamed)
+        FRONTMOST.frontmost_app()
     }
 
     /// Read the global cursor position through X11 when an X server is available.
@@ -529,13 +533,7 @@ fn device_thread(
     // Dropping `device` releases the exclusive grab, restoring normal input delivery.
 }
 
-// ── frontmost_app_id ─────────────────────────────────────────────────────────
-
-// The frontmost-app reader is backend-driven so that Wayland support can be
-// added without touching callers. Exactly one backend is selected at startup
-// from the session environment (see `detect_frontmost_source`) and cached in
-// `FRONTMOST_SOURCE` for the process lifetime. The X11, wlr-foreign-toplevel,
-// and gnome-shell backends are all available; see `wayland_candidates`.
+// ── foreground-application observation ──────────────────────────────────────
 
 mod gnome_shell;
 mod wlr_foreign_toplevel;
@@ -552,14 +550,196 @@ mod wlr_foreign_toplevel;
 /// per-app profile created under wlroots will not match under GNOME/X11 and
 /// vice versa. This is a known limitation: reconciling it needs a canonical-id
 /// scheme or per-profile aliases rather than naive normalization, and is
-/// deliberately out of scope for the backends themselves.
-trait FrontmostSource: Send + Sync {
+/// deliberately out of scope for the backends themselves. One selected source
+/// moves between the idle snapshot path and the observer worker; its transport
+/// is never duplicated or independently selected.
+trait FrontmostSource: Send {
     /// Opaque identifier of the frontmost application, or `None` when there is
     /// no frontmost window or it cannot be read.
-    fn frontmost_app_id(&self) -> Option<String>;
+    fn frontmost_app_id(&mut self) -> Option<String>;
+
+    /// Subscribe natively, publish the subscribe-before-snapshot result and
+    /// subsequent changes, and run until `stop` is requested. The source is
+    /// returned so the idle snapshot path regains the same selected backend.
+    fn observe(self: Box<Self>, stop: StopToken, publish: PublishAppId)
+    -> Box<dyn FrontmostSource>;
 
     /// Short backend identifier, for diagnostics / logging only.
     fn name(&self) -> &'static str;
+}
+
+type PublishAppId = Arc<dyn Fn(Option<String>) + Send + Sync>;
+
+/// Delay between reconnect attempts after an already-selected native backend
+/// loses its transport. Normal delivery blocks on native events with no tick.
+pub(super) const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+
+struct StopState {
+    requested: AtomicBool,
+    wait_lock: Mutex<()>,
+    changed: Condvar,
+}
+
+impl StopState {
+    fn new() -> Self {
+        Self {
+            requested: AtomicBool::new(false),
+            wait_lock: Mutex::new(()),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn request(&self) {
+        if self.requested.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let _guard = lock_unpoisoned(&self.wait_lock);
+        self.changed.notify_all();
+    }
+
+    fn is_requested(&self) -> bool {
+        self.requested.load(Ordering::Acquire)
+    }
+
+    fn wait(&self) {
+        let guard = lock_unpoisoned(&self.wait_lock);
+        drop(
+            self.changed
+                .wait_while(guard, |()| !self.is_requested())
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+    }
+
+    fn wait_timeout(&self, timeout: Duration) -> bool {
+        if self.is_requested() {
+            return true;
+        }
+        let guard = lock_unpoisoned(&self.wait_lock);
+        let (_guard, _) = self
+            .changed
+            .wait_timeout_while(guard, timeout, |()| !self.is_requested())
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.is_requested()
+    }
+}
+
+struct StopControl {
+    state: Arc<StopState>,
+    wake: OwnedFd,
+}
+
+impl StopControl {
+    fn request(&self) {
+        self.state.request();
+        signal_pipe(&self.wake);
+    }
+}
+
+pub(super) struct StopToken {
+    state: Arc<StopState>,
+    wake: OwnedFd,
+}
+
+impl StopToken {
+    pub(super) fn is_requested(&self) -> bool {
+        self.state.is_requested()
+    }
+
+    pub(super) fn wait(&self) {
+        self.state.wait();
+    }
+
+    pub(super) fn wait_timeout(&self, timeout: Duration) -> bool {
+        self.state.wait_timeout(timeout)
+    }
+
+    pub(super) fn wake_fd(&self) -> RawFd {
+        self.wake.as_raw_fd()
+    }
+
+    fn state(&self) -> Arc<StopState> {
+        Arc::clone(&self.state)
+    }
+}
+
+fn stop_pair() -> io::Result<(StopControl, StopToken)> {
+    let (read, write) = create_pipe()?;
+    let state = Arc::new(StopState::new());
+    Ok((
+        StopControl {
+            state: Arc::clone(&state),
+            wake: write,
+        },
+        StopToken { state, wake: read },
+    ))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum PollResult {
+    SourceReady,
+    StopRequested,
+    DeadlineReached,
+    Error,
+}
+
+/// Wait for a native display fd, observer teardown, or an optional deadline.
+/// A deadline is used only for targeted reconnect/drain work; steady-state
+/// event delivery passes `None` and blocks indefinitely.
+pub(super) fn poll_source_or_stop(
+    source_fd: Option<RawFd>,
+    stop_fd: RawFd,
+    deadline: Option<Instant>,
+) -> PollResult {
+    let mut fds = [
+        libc::pollfd {
+            fd: stop_fd,
+            events: libc::POLLIN | libc::POLLERR | libc::POLLHUP,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: source_fd.unwrap_or(-1),
+            events: libc::POLLIN | libc::POLLERR | libc::POLLHUP,
+            revents: 0,
+        },
+    ];
+
+    loop {
+        let timeout = deadline.map_or(-1, |deadline| {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                0
+            } else {
+                i32::try_from(remaining.as_millis().max(1).min(i32::MAX as u128))
+                    .unwrap_or(i32::MAX)
+            }
+        });
+        // SAFETY: `fds` is a live two-element pollfd array for the whole call;
+        // poll writes only each element's `revents` field.
+        let result = unsafe { libc::poll(fds.as_mut_ptr(), 2, timeout) };
+        if result > 0 {
+            if fds[0].revents != 0 {
+                return PollResult::StopRequested;
+            }
+            if fds[1].revents != 0 {
+                return PollResult::SourceReady;
+            }
+            continue;
+        }
+        if result == 0 {
+            return PollResult::DeadlineReached;
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            debug!("frontmost: native event poll failed: {error}");
+            return PollResult::Error;
+        }
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Frontmost backend backed by X11 `_NET_ACTIVE_WINDOW` + `WM_CLASS`.
@@ -593,10 +773,80 @@ impl X11Source {
             net_active_window,
         })
     }
+
+    fn subscribe(&self) -> bool {
+        self.set_event_mask(EventMask::PROPERTY_CHANGE)
+            .map_err(|e| debug!("frontmost: failed to subscribe to X11 root changes: {e}"))
+            .is_ok()
+    }
+
+    fn unsubscribe(&self) {
+        if let Err(error) = self.set_event_mask(EventMask::NO_EVENT) {
+            debug!("frontmost: failed to unsubscribe from X11 root changes: {error}");
+        }
+    }
+
+    fn set_event_mask(&self, event_mask: EventMask) -> Result<(), String> {
+        let cookie = self
+            .conn
+            .change_window_attributes(
+                self.root,
+                &ChangeWindowAttributesAux::new().event_mask(event_mask),
+            )
+            .map_err(|error| error.to_string())?;
+        cookie.check().map_err(|error| error.to_string())?;
+        self.conn.flush().map_err(|error| error.to_string())
+    }
+
+    fn run_until_stopped_or_disconnected(
+        &mut self,
+        stop: &StopToken,
+        publish: &PublishAppId,
+    ) -> bool {
+        if !self.subscribe() {
+            return false;
+        }
+
+        // The event mask is installed before this read, so a focus change can
+        // only be represented by the snapshot, a queued PropertyNotify, or both.
+        publish(self.frontmost_app_id());
+
+        loop {
+            match poll_source_or_stop(Some(self.conn.stream().as_raw_fd()), stop.wake_fd(), None) {
+                PollResult::StopRequested => {
+                    self.unsubscribe();
+                    return true;
+                }
+                PollResult::SourceReady => {}
+                PollResult::DeadlineReached => continue,
+                PollResult::Error => return false,
+            }
+
+            let mut active_window_changed = false;
+            loop {
+                match self.conn.poll_for_event() {
+                    Ok(Some(Event::PropertyNotify(event)))
+                        if event.window == self.root && event.atom == self.net_active_window =>
+                    {
+                        active_window_changed = true;
+                    }
+                    Ok(Some(_)) => {}
+                    Ok(None) => break,
+                    Err(error) => {
+                        debug!("frontmost: X11 connection lost: {error}");
+                        return false;
+                    }
+                }
+            }
+            if active_window_changed {
+                publish(self.frontmost_app_id());
+            }
+        }
+    }
 }
 
 impl FrontmostSource for X11Source {
-    fn frontmost_app_id(&self) -> Option<String> {
+    fn frontmost_app_id(&mut self) -> Option<String> {
         // _NET_ACTIVE_WINDOW on the root window holds the focused window's XID.
         let window: Window = self
             .conn
@@ -630,6 +880,26 @@ impl FrontmostSource for X11Source {
             .map(str::to_owned)
     }
 
+    fn observe(
+        mut self: Box<Self>,
+        stop: StopToken,
+        publish: PublishAppId,
+    ) -> Box<dyn FrontmostSource> {
+        loop {
+            if self.run_until_stopped_or_disconnected(&stop, &publish) {
+                return self;
+            }
+            publish(None);
+            if stop.wait_timeout(RECONNECT_DELAY) {
+                return self;
+            }
+            if let Some(reconnected) = Self::connect() {
+                debug!("frontmost: X11 connection restored");
+                *self = reconnected;
+            }
+        }
+    }
+
     fn name(&self) -> &'static str {
         "x11"
     }
@@ -641,8 +911,18 @@ impl FrontmostSource for X11Source {
 struct NullSource;
 
 impl FrontmostSource for NullSource {
-    fn frontmost_app_id(&self) -> Option<String> {
+    fn frontmost_app_id(&mut self) -> Option<String> {
         None
+    }
+
+    fn observe(
+        self: Box<Self>,
+        stop: StopToken,
+        publish: PublishAppId,
+    ) -> Box<dyn FrontmostSource> {
+        publish(None);
+        stop.wait();
+        self
     }
 
     fn name(&self) -> &'static str {
@@ -731,16 +1011,474 @@ fn detect_frontmost_source() -> Box<dyn FrontmostSource> {
     Box::new(NullSource)
 }
 
-static FRONTMOST_SOURCE: LazyLock<Box<dyn FrontmostSource>> =
-    LazyLock::new(detect_frontmost_source);
+struct DeliveryState {
+    active: bool,
+    version: Option<u64>,
+}
+
+struct Subscriber {
+    callback: Box<dyn Fn(Option<ForegroundApp>) + Send + Sync>,
+    delivery: Mutex<DeliveryState>,
+}
+
+impl Subscriber {
+    fn new(callback: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static) -> Self {
+        Self {
+            callback: Box::new(callback),
+            delivery: Mutex::new(DeliveryState {
+                active: true,
+                version: None,
+            }),
+        }
+    }
+
+    fn deliver(&self, version: u64, app: Option<ForegroundApp>) {
+        let mut delivery = lock_unpoisoned(&self.delivery);
+        if !delivery.active || delivery.version.is_some_and(|seen| seen >= version) {
+            return;
+        }
+        delivery.version = Some(version);
+        if catch_unwind(AssertUnwindSafe(|| (self.callback)(app))).is_err() {
+            error!("foreground-application callback panicked");
+        }
+    }
+
+    fn deactivate(&self) {
+        let mut delivery = lock_unpoisoned(&self.delivery);
+        delivery.active = false;
+    }
+}
+
+struct PublicationState {
+    active: bool,
+    initialized: bool,
+    version: u64,
+    current: Option<ForegroundApp>,
+    subscribers: HashMap<u64, Arc<Subscriber>>,
+}
+
+struct Publication {
+    state: Mutex<PublicationState>,
+}
+
+enum ActiveSnapshot {
+    Idle,
+    Active(Option<ForegroundApp>),
+}
+
+impl Publication {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(PublicationState {
+                active: false,
+                initialized: false,
+                version: 0,
+                current: None,
+                subscribers: HashMap::new(),
+            }),
+        }
+    }
+
+    fn begin(&self) {
+        let mut state = lock_unpoisoned(&self.state);
+        state.active = true;
+        state.initialized = false;
+        state.current = None;
+    }
+
+    fn finish(&self) {
+        let mut state = lock_unpoisoned(&self.state);
+        state.active = false;
+        state.initialized = false;
+        state.current = None;
+    }
+
+    fn subscribe(
+        &self,
+        id: u64,
+        subscriber: &Arc<Subscriber>,
+    ) -> Option<(u64, Option<ForegroundApp>)> {
+        let mut state = lock_unpoisoned(&self.state);
+        state.subscribers.insert(id, Arc::clone(subscriber));
+        state
+            .initialized
+            .then(|| (state.version, state.current.clone()))
+    }
+
+    fn unsubscribe(&self, id: u64) {
+        let subscriber = lock_unpoisoned(&self.state).subscribers.remove(&id);
+        if let Some(subscriber) = subscriber {
+            // Wait for an in-flight callback and make any publisher that cloned
+            // this subscriber before removal observe it as inactive.
+            subscriber.deactivate();
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        lock_unpoisoned(&self.state).subscribers.is_empty()
+    }
+
+    fn publish(&self, app_id: Option<String>) {
+        let app = app_id.map(ForegroundApp::unnamed);
+        let (version, subscribers) = {
+            let mut state = lock_unpoisoned(&self.state);
+            if state.initialized && state.current == app {
+                return;
+            }
+            state.initialized = true;
+            state.version += 1;
+            state.current.clone_from(&app);
+            (
+                state.version,
+                state.subscribers.values().cloned().collect::<Vec<_>>(),
+            )
+        };
+        for subscriber in subscribers {
+            subscriber.deliver(version, app.clone());
+        }
+    }
+
+    fn active_snapshot(&self) -> ActiveSnapshot {
+        let state = lock_unpoisoned(&self.state);
+        if state.active {
+            ActiveSnapshot::Active(state.current.clone())
+        } else {
+            ActiveSnapshot::Idle
+        }
+    }
+}
+
+struct ObserverWorker {
+    stop: StopControl,
+    thread: thread::JoinHandle<Box<dyn FrontmostSource>>,
+}
+
+struct FrontmostRuntime {
+    source: Option<Box<dyn FrontmostSource>>,
+    worker: Option<ObserverWorker>,
+    stopping: bool,
+    next_subscriber_id: u64,
+}
+
+struct FrontmostController {
+    runtime: Mutex<FrontmostRuntime>,
+    worker_stopped: Condvar,
+    publication: Arc<Publication>,
+}
+
+impl FrontmostController {
+    fn new(source: Box<dyn FrontmostSource>) -> Arc<Self> {
+        Arc::new(Self {
+            runtime: Mutex::new(FrontmostRuntime {
+                source: Some(source),
+                worker: None,
+                stopping: false,
+                next_subscriber_id: 0,
+            }),
+            worker_stopped: Condvar::new(),
+            publication: Arc::new(Publication::new()),
+        })
+    }
+
+    fn frontmost_app(&self) -> Option<ForegroundApp> {
+        match self.publication.active_snapshot() {
+            ActiveSnapshot::Active(app) => return app,
+            ActiveSnapshot::Idle => {}
+        }
+
+        let mut runtime = lock_unpoisoned(&self.runtime);
+        while runtime.stopping {
+            runtime = self
+                .worker_stopped
+                .wait(runtime)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        match self.publication.active_snapshot() {
+            ActiveSnapshot::Active(app) => app,
+            ActiveSnapshot::Idle => runtime
+                .source
+                .as_mut()
+                .and_then(|source| source.frontmost_app_id())
+                .map(ForegroundApp::unnamed),
+        }
+    }
+
+    fn watch(
+        self: &Arc<Self>,
+        callback: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
+    ) -> ForegroundApplicationObserver {
+        let subscriber = Arc::new(Subscriber::new(callback));
+        let mut runtime = lock_unpoisoned(&self.runtime);
+        while runtime.stopping {
+            runtime = self
+                .worker_stopped
+                .wait(runtime)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+
+        let id = runtime.next_subscriber_id;
+        runtime.next_subscriber_id += 1;
+        if runtime.worker.is_none() {
+            self.publication.begin();
+        }
+        let initial = self.publication.subscribe(id, &subscriber);
+
+        if runtime.worker.is_none() {
+            let source = runtime
+                .source
+                .take()
+                .unwrap_or_else(|| Box::new(NullSource));
+            let (stop, stop_token) = stop_pair()
+                .unwrap_or_else(|error| panic!("failed to create frontmost stop pipe: {error}"));
+            let publication = Arc::clone(&self.publication);
+            let publish: PublishAppId = Arc::new(move |app| publication.publish(app));
+            let thread = thread::Builder::new()
+                .name("openlogi-frontmost".into())
+                .spawn(move || source.observe(stop_token, publish))
+                .unwrap_or_else(|error| panic!("failed to start frontmost observer: {error}"));
+            runtime.worker = Some(ObserverWorker { stop, thread });
+        }
+        drop(runtime);
+
+        // Do not call user code while holding the controller lock. If the
+        // worker published a newer version first, Subscriber::deliver ignores
+        // this older snapshot rather than reversing callback order.
+        if let Some((version, app)) = initial {
+            subscriber.deliver(version, app);
+        }
+
+        ForegroundApplicationObserver {
+            controller: Arc::clone(self),
+            subscriber_id: id,
+        }
+    }
+
+    fn remove_observer(&self, id: u64) {
+        self.publication.unsubscribe(id);
+
+        let worker = {
+            let mut runtime = lock_unpoisoned(&self.runtime);
+            while runtime.stopping {
+                runtime = self
+                    .worker_stopped
+                    .wait(runtime)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+            if !self.publication.is_empty() {
+                return;
+            }
+            let Some(worker) = runtime.worker.take() else {
+                return;
+            };
+            runtime.stopping = true;
+            worker
+        };
+
+        worker.stop.request();
+        let source = worker.thread.join().unwrap_or_else(|panic| {
+            error!("foreground-application worker panicked on shutdown: {panic:?}");
+            Box::new(NullSource)
+        });
+
+        let mut runtime = lock_unpoisoned(&self.runtime);
+        runtime.source = Some(source);
+        self.publication.finish();
+        runtime.stopping = false;
+        self.worker_stopped.notify_all();
+    }
+}
+
+static FRONTMOST: LazyLock<Arc<FrontmostController>> =
+    LazyLock::new(|| FrontmostController::new(detect_frontmost_source()));
+
+/// Linux-native foreground-application observer ownership.
+///
+/// Dropping the final handle synchronously unsubscribes from the selected
+/// backend, wakes and joins its worker, and returns the source to snapshot use.
+#[must_use]
+pub(crate) struct ForegroundApplicationObserver {
+    controller: Arc<FrontmostController>,
+    subscriber_id: u64,
+}
+
+impl Drop for ForegroundApplicationObserver {
+    fn drop(&mut self) {
+        self.controller.remove_observer(self.subscriber_id);
+    }
+}
+
+/// Observe foreground-application changes from the selected native backend.
+pub(crate) fn watch_frontmost_application_activations(
+    callback: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
+) -> ForegroundApplicationObserver {
+    FRONTMOST.watch(callback)
+}
+
+/// Keep this intentionally unwired Linux-internal API type-checked until the
+/// cross-platform facade adopts it.
+const _: fn(fn(Option<ForegroundApp>)) -> ForegroundApplicationObserver =
+    watch_frontmost_application_activations;
 
 #[cfg(test)]
 mod tests {
     use std::assert_matches;
+    use std::sync::mpsc;
 
     use evdev::{EventType, InputEvent, KeyCode, RelativeAxisCode};
 
     use super::*;
+
+    struct FakeFrontmostSource {
+        stopped: Arc<AtomicBool>,
+    }
+
+    impl FrontmostSource for FakeFrontmostSource {
+        fn frontmost_app_id(&mut self) -> Option<String> {
+            Some("org.example.App".into())
+        }
+
+        fn observe(
+            self: Box<Self>,
+            stop: StopToken,
+            publish: PublishAppId,
+        ) -> Box<dyn FrontmostSource> {
+            publish(Some("org.example.App".into()));
+            stop.wait();
+            self.stopped.store(true, Ordering::Release);
+            self
+        }
+
+        fn name(&self) -> &'static str {
+            "fake"
+        }
+    }
+
+    #[test]
+    fn foreground_publication_suppresses_duplicates_and_contains_panics() {
+        let publication = Publication::new();
+        publication.begin();
+        let panic_once = Arc::new(AtomicBool::new(true));
+        let callback_panic_once = Arc::clone(&panic_once);
+        let panicking = Arc::new(Subscriber::new(move |_| {
+            assert!(
+                !callback_panic_once.swap(false, Ordering::AcqRel),
+                "contained callback panic"
+            );
+        }));
+        assert!(publication.subscribe(1, &panicking).is_none());
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let callback_received = Arc::clone(&received);
+        let recording_subscriber = Arc::new(Subscriber::new(move |app| {
+            lock_unpoisoned(&callback_received).push(app.map(|app| app.id));
+        }));
+        assert!(publication.subscribe(2, &recording_subscriber).is_none());
+
+        publication.publish(Some("one".into()));
+        publication.publish(Some("one".into()));
+        publication.publish(Some("two".into()));
+        publication.publish(None);
+
+        assert_eq!(
+            *lock_unpoisoned(&received),
+            vec![Some("one".into()), Some("two".into()), None]
+        );
+        assert!(!panic_once.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn foreground_observer_drop_stops_joins_and_returns_source() {
+        let stopped = Arc::new(AtomicBool::new(false));
+        let controller = FrontmostController::new(Box::new(FakeFrontmostSource {
+            stopped: Arc::clone(&stopped),
+        }));
+        let (tx, rx) = mpsc::channel();
+        let observer = controller.watch(move |app| {
+            tx.send(app).expect("test receiver remains alive");
+        });
+
+        let initial = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("observer publishes its initial snapshot");
+        assert_eq!(
+            initial.map(|app| app.id).as_deref(),
+            Some("org.example.App")
+        );
+
+        drop(observer);
+        assert!(stopped.load(Ordering::Acquire));
+        assert_eq!(
+            controller.frontmost_app().map(|app| app.id).as_deref(),
+            Some("org.example.App")
+        );
+    }
+
+    #[test]
+    fn unsupported_foreground_source_publishes_none_and_stops_cleanly() {
+        let controller = FrontmostController::new(Box::new(NullSource));
+        let (tx, rx) = mpsc::channel();
+        let observer = controller.watch(move |app| {
+            tx.send(app).expect("test receiver remains alive");
+        });
+
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1))
+                .expect("null source publishes an initial snapshot"),
+            None
+        );
+        drop(observer);
+        assert_eq!(controller.frontmost_app(), None);
+    }
+
+    #[test]
+    fn foreground_unsubscribe_waits_for_inflight_callback() {
+        let publication = Arc::new(Publication::new());
+        publication.begin();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let callback_release = Arc::clone(&release);
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let subscriber = Arc::new(Subscriber::new(move |_| {
+            entered_tx.send(()).expect("test receiver remains alive");
+            let (lock, changed) = &*callback_release;
+            let guard = lock_unpoisoned(lock);
+            drop(
+                changed
+                    .wait_while(guard, |released| !*released)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+            );
+        }));
+        assert!(publication.subscribe(1, &subscriber).is_none());
+
+        let publisher = Arc::clone(&publication);
+        let publish_thread = thread::spawn(move || publisher.publish(Some("one".into())));
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("callback starts");
+
+        let unsubscriber = Arc::clone(&publication);
+        let (unsubscribed_tx, unsubscribed_rx) = mpsc::channel();
+        let unsubscribe_thread = thread::spawn(move || {
+            unsubscriber.unsubscribe(1);
+            unsubscribed_tx
+                .send(())
+                .expect("test receiver remains alive");
+        });
+        assert!(
+            unsubscribed_rx
+                .recv_timeout(Duration::from_millis(25))
+                .is_err(),
+            "unsubscribe returned while the callback was in flight"
+        );
+
+        let (lock, changed) = &*release;
+        *lock_unpoisoned(lock) = true;
+        changed.notify_all();
+        unsubscribed_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("unsubscribe returns after callback completion");
+        publish_thread.join().expect("publisher thread exits");
+        unsubscribe_thread.join().expect("unsubscribe thread exits");
+    }
 
     // ── key_to_button ────────────────────────────────────────────────────────
 

--- a/crates/openlogi-hook/src/linux/gnome_shell.rs
+++ b/crates/openlogi-hook/src/linux/gnome_shell.rs
@@ -1,5 +1,6 @@
 //! Frontmost backend for GNOME Shell (Wayland and X11), via a small companion
-//! GNOME Shell extension that exports the focused window's WM_CLASS over D-Bus.
+//! GNOME Shell extension that exports the focused window's WM_CLASS over D-Bus
+//! and signals every focus change.
 //!
 //! GNOME (Mutter) implements neither wlr-foreign-toplevel nor any portal for
 //! the focused window, and `org.gnome.Shell.Eval` is disabled by default, so a
@@ -13,77 +14,238 @@
 //! identifier matches the X11 backend's, keeping per-app profile keys
 //! consistent across X11, XWayland, and GNOME Wayland sessions.
 //!
-//! Only the session-bus connection is held in the backend; a lightweight proxy
-//! is built per poll (no extra D-Bus traffic beyond the method call itself).
+//! The observer subscribes to the signal and name-owner changes before reading
+//! the method snapshot. The method therefore closes startup and extension-
+//! restart races without becoming a periodic polling path.
 
+use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::Duration;
 
-use tracing::debug;
+use futures_lite::{StreamExt as _, future};
+use tracing::{debug, warn};
 use zbus::blocking::Connection;
 use zbus::blocking::connection::Builder;
 use zbus::proxy;
 
-use super::FrontmostSource;
+use super::{FrontmostSource, PublishAppId, RECONNECT_DELAY, StopToken, lock_unpoisoned};
 
 /// Cap on every D-Bus call to the extension. Without it, a stalled GNOME Shell
-/// would block the polling thread forever (the probe runs inside the
-/// `FRONTMOST_SOURCE` initializer, so a stall there would block every thread
-/// that touches it).
+/// could block backend selection or an explicit snapshot read indefinitely.
 const METHOD_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// D-Bus proxy for the OpenLogi GNOME Shell extension. Only the blocking proxy
-/// is generated (`gen_async = false`), matching the synchronous poll contract.
+/// D-Bus proxy for the OpenLogi GNOME Shell extension. The blocking proxy owns
+/// idle snapshots; the async proxy lets one worker select focus and owner
+/// streams without introducing a timer.
 #[proxy(
     interface = "org.openlogi.Frontmost",
     default_service = "org.openlogi.Frontmost",
     default_path = "/org/openlogi/Frontmost",
-    gen_async = false
+    gen_blocking = true
 )]
 trait Frontmost {
     /// WM_CLASS of the focused window, or "" when nothing is focused.
     #[zbus(name = "GetFocusedWmClass")]
     fn get_focused_wm_class(&self) -> zbus::Result<String>;
+
+    /// Emitted whenever GNOME's focused window changes.
+    #[zbus(signal, name = "FocusedWmClassChanged")]
+    fn focused_wm_class_changed(&self, wm_class: &str) -> zbus::Result<()>;
 }
 
 /// Frontmost backend talking to the OpenLogi GNOME Shell extension over the
 /// session bus.
 struct GnomeShellSource {
-    conn: Connection,
+    conn: Option<Connection>,
 }
 
 impl GnomeShellSource {
-    fn connect() -> Option<Self> {
-        let conn = Builder::session()
+    fn connect_bus() -> Option<Connection> {
+        Builder::session()
             .map_err(|e| debug!("gnome-shell: no session bus: {e}"))
             .ok()?
             .method_timeout(METHOD_TIMEOUT)
             .build()
             .map_err(|e| debug!("gnome-shell: connection build failed: {e}"))
-            .ok()?;
+            .ok()
+    }
+
+    fn connect() -> Option<Self> {
+        let conn = Self::connect_bus()?;
         // Probe reachability: a successful call (even an empty result) means the
         // OpenLogi extension is installed and exporting the service. An error
         // means it is absent/disabled, so this backend must not be selected.
-        let proxy = FrontmostProxy::new(&conn)
-            .map_err(|e| debug!("gnome-shell: proxy build failed: {e}"))
-            .ok()?;
-        proxy
-            .get_focused_wm_class()
+        Self::snapshot(&conn)
             .map_err(|e| debug!("gnome-shell: OpenLogi extension not reachable: {e}"))
             .ok()?;
-        Some(Self { conn })
+        Some(Self { conn: Some(conn) })
+    }
+
+    fn snapshot(conn: &Connection) -> zbus::Result<Option<String>> {
+        let proxy = FrontmostProxyBlocking::new(conn)?;
+        proxy.get_focused_wm_class().map(app_id)
+    }
+
+    async fn observe_connection(
+        conn: &Connection,
+        stop: &StopToken,
+        publish: &PublishAppId,
+    ) -> ConnectionOutcome {
+        let proxy = match FrontmostProxy::new(conn.inner()).await {
+            Ok(proxy) => proxy,
+            Err(error) => {
+                debug!("gnome-shell: async proxy build failed: {error}");
+                return ConnectionOutcome::Disconnected;
+            }
+        };
+        // Register both streams before the method read. A focus transition or
+        // extension restart is therefore represented by the snapshot, a queued
+        // signal/owner event, or both (the publication hub suppresses duplicates).
+        let mut focus_changes = match proxy.receive_focused_wm_class_changed().await {
+            Ok(changes) => changes,
+            Err(error) => {
+                debug!("gnome-shell: focus-signal subscription failed: {error}");
+                return ConnectionOutcome::Disconnected;
+            }
+        };
+        let mut owner_changes = match proxy.inner().receive_owner_changed().await {
+            Ok(changes) => changes,
+            Err(error) => {
+                debug!("gnome-shell: owner-change subscription failed: {error}");
+                return ConnectionOutcome::Disconnected;
+            }
+        };
+        match proxy.get_focused_wm_class().await {
+            Ok(wm_class) => publish(app_id(wm_class)),
+            Err(error) => {
+                debug!("gnome-shell: initial snapshot failed: {error}");
+                return ConnectionOutcome::Disconnected;
+            }
+        }
+
+        loop {
+            if stop.is_requested() {
+                return ConnectionOutcome::Stopped;
+            }
+            let event = future::race(
+                async { GnomeEvent::Focus(focus_changes.next().await) },
+                async { GnomeEvent::Owner(owner_changes.next().await) },
+            )
+            .await;
+            match event {
+                GnomeEvent::Focus(Some(signal)) => match signal.args() {
+                    Ok(args) => publish(app_id(args.wm_class().to_string())),
+                    Err(error) => warn!("gnome-shell: malformed focus signal: {error}"),
+                },
+                GnomeEvent::Owner(Some(Some(_))) => {
+                    // A replacement extension owner may not emit a focus signal
+                    // until the next transition, so recover its current snapshot.
+                    match proxy.get_focused_wm_class().await {
+                        Ok(wm_class) => publish(app_id(wm_class)),
+                        Err(error) => debug!("gnome-shell: recovery snapshot failed: {error}"),
+                    }
+                }
+                GnomeEvent::Owner(Some(None)) => publish(None),
+                GnomeEvent::Focus(None) | GnomeEvent::Owner(None) => {
+                    return if stop.is_requested() {
+                        ConnectionOutcome::Stopped
+                    } else {
+                        ConnectionOutcome::Disconnected
+                    };
+                }
+            }
+        }
     }
 }
 
+fn app_id(wm_class: String) -> Option<String> {
+    (!wm_class.is_empty()).then_some(wm_class)
+}
+
+enum GnomeEvent<T, U> {
+    Focus(Option<T>),
+    Owner(Option<U>),
+}
+
+enum ConnectionOutcome {
+    Stopped,
+    Disconnected,
+}
+
 impl FrontmostSource for GnomeShellSource {
-    fn frontmost_app_id(&self) -> Option<String> {
-        let proxy = FrontmostProxy::new(&self.conn)
-            .map_err(|e| debug!("gnome-shell: proxy build failed: {e}"))
-            .ok()?;
-        let wm_class = proxy
-            .get_focused_wm_class()
-            .map_err(|e| debug!("gnome-shell: poll failed (extension gone or bus down?): {e}"))
-            .ok()?;
-        (!wm_class.is_empty()).then_some(wm_class)
+    fn frontmost_app_id(&mut self) -> Option<String> {
+        if self.conn.is_none() {
+            self.conn = Self::connect_bus();
+        }
+        let result = Self::snapshot(self.conn.as_ref()?)
+            .map_err(|e| debug!("gnome-shell: snapshot failed: {e}"));
+        if result.is_err() {
+            self.conn = None;
+        }
+        result.ok().flatten()
+    }
+
+    fn observe(
+        mut self: Box<Self>,
+        stop: StopToken,
+        publish: PublishAppId,
+    ) -> Box<dyn FrontmostSource> {
+        // zbus owns its socket reader internally. A helper closes the worker's
+        // current connection when teardown is requested, waking both streams
+        // so the owning worker can synchronously return and join.
+        let active_connection = Arc::new(Mutex::new(None::<Connection>));
+        let stop_state = stop.state();
+        let connection_to_close = Arc::clone(&active_connection);
+        let stopper = thread::Builder::new()
+            .name("openlogi-frontmost-gnome-stop".into())
+            .spawn(move || {
+                stop_state.wait();
+                if let Some(conn) = lock_unpoisoned(&connection_to_close).take()
+                    && let Err(error) = conn.close()
+                {
+                    debug!("gnome-shell: failed to close observer connection: {error}");
+                }
+            })
+            .unwrap_or_else(|error| panic!("failed to start GNOME stop helper: {error}"));
+
+        loop {
+            if stop.is_requested() {
+                break;
+            }
+            if self.conn.is_none() {
+                self.conn = Self::connect_bus();
+            }
+            let Some(conn) = self.conn.as_ref() else {
+                publish(None);
+                if stop.wait_timeout(RECONNECT_DELAY) {
+                    break;
+                }
+                continue;
+            };
+            *lock_unpoisoned(&active_connection) = Some(conn.clone());
+            let outcome =
+                futures_lite::future::block_on(Self::observe_connection(conn, &stop, &publish));
+            lock_unpoisoned(&active_connection).take();
+            self.conn = None;
+
+            match outcome {
+                ConnectionOutcome::Stopped => break,
+                ConnectionOutcome::Disconnected => {
+                    publish(None);
+                    if stop.wait_timeout(RECONNECT_DELAY) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // The helper is awake whenever the loop exits; joining proves no
+        // connection clone can be closed after this source returns to idle use.
+        if let Err(panic) = stopper.join() {
+            warn!("gnome-shell: stop helper panicked: {panic:?}");
+        }
+        self.conn = None;
+        self
     }
 
     fn name(&self) -> &'static str {
@@ -94,4 +256,18 @@ impl FrontmostSource for GnomeShellSource {
 /// Candidate constructor registered in [`super::wayland_candidates`].
 pub(super) fn candidate() -> Option<Box<dyn FrontmostSource>> {
     GnomeShellSource::connect().map(|s| Box::new(s) as Box<dyn FrontmostSource>)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::app_id;
+
+    #[test]
+    fn empty_wm_class_represents_no_focused_application() {
+        assert_eq!(app_id(String::new()), None);
+        assert_eq!(
+            app_id("org.example.App".into()).as_deref(),
+            Some("org.example.App")
+        );
+    }
 }

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -22,17 +22,18 @@
 //!
 //! ## Dispatch model
 //!
-//! The protocol is event-driven, but the [`super::FrontmostSource`] contract is
-//! a synchronous poll (~1 Hz from the agent's foreground-app watcher). Two primitives
-//! bridge that gap:
+//! While an observer exists, one worker owns the connection and continuously
+//! drives its event queue. A toplevel's pending fields become observable only
+//! on the protocol's `done` commit. `Finished` and transport errors drop the
+//! session and schedule one reconnect attempt at [`super::RECONNECT_DELAY`];
+//! there is no steady-state timer.
 //!
-//! - **`drain_events`** (poll path) — flushes pending writes, then attempts a
+//! The idle snapshot path retains a bounded `drain_events`: it flushes pending
+//! writes, then attempts a
 //!   non-blocking `prepare_read` + `read` with a short 25 ms `poll(2)` cap.
 //!   If nothing arrives in time the last known state is returned unchanged;
-//!   millisecond-stale frontmost data is acceptable by design. A genuine
-//!   connection error here (as opposed to a timeout) marks the session
-//!   finished so the next poll reconnects, the same as an explicit
-//!   `Finished` event.
+//!   this is used only by explicit `frontmost_application()` reads when no
+//!   observer owns the transport.
 //!
 //! - **`timed_roundtrip`** (init path) — sends `wl_display.sync`, then loops
 //!   `flush` → `poll(2)` → `read` → `dispatch_pending` until the sync callback
@@ -45,10 +46,9 @@
 
 use std::collections::HashMap;
 use std::os::unix::io::AsRawFd;
-use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 use wayland_client::backend::ObjectId;
 use wayland_client::protocol::wl_callback;
 use wayland_client::protocol::wl_registry::{self, WlRegistry};
@@ -60,7 +60,9 @@ use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_m
     self, ZwlrForeignToplevelManagerV1,
 };
 
-use super::FrontmostSource;
+use super::{
+    FrontmostSource, PollResult, PublishAppId, RECONNECT_DELAY, StopToken, poll_source_or_stop,
+};
 
 /// Highest protocol version this backend understands. The events it relies on
 /// (`app_id`, `state`, `done`, `closed`) exist since v1, so binding is capped
@@ -68,8 +70,8 @@ use super::FrontmostSource;
 const MANAGER_MAX_VERSION: u32 = 3;
 
 /// Deadline for the two `wl_display.sync` round-trips in `Session::open`.
-/// Mirrors `gnome_shell::METHOD_TIMEOUT`: both guard the `FRONTMOST_SOURCE`
-/// `LazyLock` initializer against a stalled compositor socket.
+/// Mirrors `gnome_shell::METHOD_TIMEOUT`: both keep backend selection and
+/// reconnect attempts from stalling indefinitely on a compositor socket.
 const INIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Maximum time the poll-path drain will wait for new Wayland events. Stale
@@ -106,12 +108,21 @@ impl Toplevel {
 struct State {
     manager: Option<ZwlrForeignToplevelManagerV1>,
     toplevels: HashMap<ObjectId, Toplevel>,
-    /// Set when the compositor sends `finished`; triggers a reconnect on the
-    /// next poll instead of permanently disabling the backend.
+    /// Set when the compositor sends `finished`; the source drops this session
+    /// and reconnects instead of permanently disabling the backend.
     finished: bool,
     /// Flipped to `true` by the `wl_callback::Done` handler; used by
     /// `timed_roundtrip` to detect that the sync echo arrived.
     sync_done: bool,
+}
+
+impl State {
+    fn frontmost_app_id(&self) -> Option<String> {
+        self.toplevels
+            .values()
+            .find(|toplevel| toplevel.activated)
+            .and_then(|toplevel| toplevel.app_id.clone())
+    }
 }
 
 impl Dispatch<WlRegistry, ()> for State {
@@ -153,10 +164,10 @@ impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for State {
             }
             zwlr_foreign_toplevel_manager_v1::Event::Finished => {
                 // The compositor is reloading or restarting. Mark the session
-                // finished; the next poll will reconnect automatically.
+                // finished so the owning source can reconnect.
                 warn!(
                     "wlr-foreign-toplevel: compositor sent Finished — \
-                     will reconnect on next poll"
+                     will reconnect"
                 );
                 state.finished = true;
                 state.manager = None;
@@ -330,17 +341,13 @@ fn timed_roundtrip(
     }
 }
 
-/// Drains pending compositor events without blocking longer than `POLL_CAP_MS`.
-/// Used on every frontmost poll. Stale data within the cap is acceptable by
-/// design; a genuine connection error (e.g. the compositor crashing and
-/// closing the socket, rather than sending a graceful `Finished`) marks
-/// `state.finished` so the caller reconnects on the next poll instead of
-/// returning stale state forever.
+/// Drains pending compositor events without blocking longer than `POLL_CAP_MS`
+/// for an explicit snapshot read while no observer owns the session. Stale data
+/// within the cap is acceptable; a genuine connection error marks the session
+/// finished so its next owner reconnects instead of returning stale state.
 fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
     if queue.flush().is_err() || queue.dispatch_pending(state).is_err() {
-        warn!(
-            "wlr-foreign-toplevel: connection error while draining — will reconnect on next poll"
-        );
+        warn!("wlr-foreign-toplevel: connection error while draining — will reconnect");
         state.finished = true;
         return;
     }
@@ -355,9 +362,7 @@ fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
             if poll_fd(fd, deadline)
                 && (guard.read().is_err() || queue.dispatch_pending(state).is_err())
             {
-                warn!(
-                    "wlr-foreign-toplevel: connection error while draining — will reconnect on next poll"
-                );
+                warn!("wlr-foreign-toplevel: connection error while draining — will reconnect");
                 state.finished = true;
             }
             // If poll timed out, guard is dropped here and we return stale state.
@@ -367,14 +372,19 @@ fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
 
 /// One live Wayland session: connection + event queue + dispatch state.
 ///
-/// Grouping all three behind a single mutex means the whole session can be
-/// dropped and rebuilt atomically when the compositor sends `Finished`.
+/// Keeping all three in the source's single-owner session means they are
+/// dropped and rebuilt together when the compositor sends `Finished`.
 struct Session {
     // Held for RAII — even though `Connection` is Arc-backed, keeping an
     // explicit handle here ensures the connection outlives the queue.
     _conn: Connection,
     queue: EventQueue<State>,
     state: State,
+}
+
+enum SessionOutcome {
+    Stopped,
+    Disconnected,
 }
 
 impl Session {
@@ -405,7 +415,7 @@ impl Session {
         }
 
         // Second round-trip: receive the initial toplevel list and properties,
-        // so the first poll already has the active window.
+        // so the first snapshot already has the active window.
         if !timed_roundtrip(&conn, &mut queue, &mut state, deadline) {
             debug!("wlr-foreign-toplevel: initial toplevel round-trip timed out or failed");
             return None;
@@ -417,53 +427,110 @@ impl Session {
             state,
         })
     }
+
+    /// Continuously dispatch native events until teardown or connection loss.
+    /// `open` subscribed before its synchronized snapshot; changes after that
+    /// snapshot remain queued on this same connection and cannot be missed.
+    fn observe(&mut self, stop: &StopToken, publish: &PublishAppId) -> SessionOutcome {
+        loop {
+            if self.queue.flush().is_err()
+                || self.queue.dispatch_pending(&mut self.state).is_err()
+                || self.state.finished
+            {
+                return SessionOutcome::Disconnected;
+            }
+            publish(self.state.frontmost_app_id());
+
+            let Some(guard) = self.queue.prepare_read() else {
+                continue;
+            };
+            let source_fd = guard.connection_fd().as_raw_fd();
+            match poll_source_or_stop(Some(source_fd), stop.wake_fd(), None) {
+                PollResult::SourceReady => {
+                    if guard.read().is_err() {
+                        return SessionOutcome::Disconnected;
+                    }
+                }
+                PollResult::StopRequested => return SessionOutcome::Stopped,
+                PollResult::Error => return SessionOutcome::Disconnected,
+                PollResult::DeadlineReached => {}
+            }
+        }
+    }
 }
 
-/// Wayland frontmost backend. Holds the session behind a mutex so the whole
-/// connection can be rebuilt on compositor restart without touching callers.
+/// Wayland frontmost backend. The selected session moves onto the observer
+/// worker and is dropped/rebuilt there after compositor restart.
 struct WlrForeignToplevelSource {
-    // Active session, or `None` when the last reconnect attempt failed.
-    // The mutex bridges the event-driven Wayland runtime to the synchronous
-    // poll contract; the session is only ever touched here, at ~1 Hz.
-    session: Mutex<Option<Session>>,
+    session: Option<Session>,
 }
 
 impl WlrForeignToplevelSource {
     fn connect() -> Option<Self> {
-        Session::open().map(|s| Self {
-            session: Mutex::new(Some(s)),
+        Session::open().map(|session| Self {
+            session: Some(session),
         })
     }
 }
 
 impl FrontmostSource for WlrForeignToplevelSource {
-    fn frontmost_app_id(&self) -> Option<String> {
-        let mut guard = self.session.lock().ok()?;
-
-        // Reconnect when the compositor sent `Finished` (compositor reload /
-        // restart) or when a prior reconnect attempt failed.
-        let needs_reconnect = guard.as_ref().is_none_or(|s| s.state.finished);
-        if needs_reconnect {
-            *guard = Session::open();
-            if guard.is_some() {
-                info!("wlr-foreign-toplevel: reconnected");
-            } else {
-                debug!("wlr-foreign-toplevel: reconnect pending, retrying next poll");
-            }
+    fn frontmost_app_id(&mut self) -> Option<String> {
+        if self
+            .session
+            .as_ref()
+            .is_none_or(|session| session.state.finished)
+        {
+            self.session = Session::open();
         }
-
-        let Session { queue, state, .. } = guard.as_mut()?;
+        let Session { queue, state, .. } = self.session.as_mut()?;
         drain_events(queue, state);
         if state.finished {
-            // `Finished` arrived during this drain; reconnect on the next call.
+            self.session = None;
             return None;
         }
+        state.frontmost_app_id()
+    }
 
-        state
-            .toplevels
-            .values()
-            .find(|toplevel| toplevel.activated)
-            .and_then(|toplevel| toplevel.app_id.clone())
+    fn observe(
+        mut self: Box<Self>,
+        stop: StopToken,
+        publish: PublishAppId,
+    ) -> Box<dyn FrontmostSource> {
+        loop {
+            if self.session.is_none() {
+                if stop.is_requested() {
+                    return self;
+                }
+                self.session = Session::open();
+                if self.session.is_none() {
+                    publish(None);
+                    if stop.wait_timeout(RECONNECT_DELAY) {
+                        return self;
+                    }
+                    continue;
+                }
+                debug!("wlr-foreign-toplevel: reconnected");
+            }
+
+            let outcome = self
+                .session
+                .as_mut()
+                .map_or(SessionOutcome::Disconnected, |session| {
+                    session.observe(&stop, &publish)
+                });
+            // Dropping the session is the protocol unsubscribe and also makes
+            // the next idle snapshot/restart establish a fresh connection.
+            self.session = None;
+            match outcome {
+                SessionOutcome::Stopped => return self,
+                SessionOutcome::Disconnected => {
+                    publish(None);
+                    if stop.wait_timeout(RECONNECT_DELAY) {
+                        return self;
+                    }
+                }
+            }
+        }
     }
 
     fn name(&self) -> &'static str {
@@ -499,6 +566,29 @@ mod tests {
         toplevel.commit_latest();
         assert_eq!(toplevel.app_id.as_deref(), Some("org.example.App"));
         assert!(toplevel.activated);
+    }
+
+    #[test]
+    fn activation_changes_only_when_done_commits_pending_state() {
+        let mut toplevel = Toplevel {
+            pending_app_id: Some("org.example.App".into()),
+            pending_activated: true,
+            ..Toplevel::default()
+        };
+
+        assert_eq!(toplevel.app_id, None);
+        assert!(!toplevel.activated);
+        toplevel.commit_latest();
+        assert_eq!(toplevel.app_id.as_deref(), Some("org.example.App"));
+        assert!(toplevel.activated);
+
+        toplevel.pending_activated = false;
+        assert!(
+            toplevel.activated,
+            "pending state must not leak before Done"
+        );
+        toplevel.commit_latest();
+        assert!(!toplevel.activated);
     }
 
     #[test]

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -33,6 +33,12 @@ use crate::{
     KeyEvent, KeyModifiers, MouseEvent, ScrollDelta,
 };
 
+#[expect(
+    dead_code,
+    reason = "Windows-internal observer API awaits the cross-platform public facade"
+)]
+pub(crate) mod foreground;
+
 const WHEEL_DELTA: f64 = 120.0;
 
 thread_local! {
@@ -275,7 +281,7 @@ fn hook_thread(
 
     worker.transition(WorkerEvent::Started);
     let _ = ready.send(Ok(thread_id));
-    let exit = message_loop();
+    let exit = message_loop(|_| false);
 
     let failure = match exit {
         MessageLoopExit::Quit => {
@@ -307,7 +313,7 @@ enum MessageLoopExit {
     Failed(u32),
 }
 
-fn message_loop() -> MessageLoopExit {
+fn message_loop(mut handle_thread_message: impl FnMut(&MSG) -> bool) -> MessageLoopExit {
     let mut msg = MSG::default();
     loop {
         // SAFETY: `msg` is a live, owned MSG; a null window handle retrieves
@@ -320,6 +326,9 @@ fn message_loop() -> MessageLoopExit {
             // SAFETY: GetLastError reads the calling thread's last-error code
             // immediately after the failed GetMessageW call.
             return MessageLoopExit::Failed(unsafe { GetLastError() });
+        }
+        if handle_thread_message(&msg) {
+            continue;
         }
         // SAFETY: `msg` was just populated by GetMessageW and outlives the call.
         unsafe { TranslateMessage(&raw const msg) };

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -33,10 +33,6 @@ use crate::{
     KeyEvent, KeyModifiers, MouseEvent, ScrollDelta,
 };
 
-#[expect(
-    dead_code,
-    reason = "Windows-internal observer API awaits the cross-platform public facade"
-)]
 pub(crate) mod foreground;
 
 const WHEEL_DELTA: f64 = 120.0;

--- a/crates/openlogi-hook/src/windows/foreground.rs
+++ b/crates/openlogi-hook/src/windows/foreground.rs
@@ -1,0 +1,412 @@
+//! Native Windows foreground-application activation observer.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError, TryLockError, mpsc};
+use std::thread;
+
+use thiserror::Error;
+use windows_sys::Win32::Foundation::{GetLastError, HWND};
+use windows_sys::Win32::System::Threading::GetCurrentThreadId;
+use windows_sys::Win32::UI::Accessibility::{HWINEVENTHOOK, SetWinEventHook, UnhookWinEvent};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    EVENT_SYSTEM_FOREGROUND, MSG, PM_NOREMOVE, PeekMessageW, PostQuitMessage, PostThreadMessageW,
+    WINEVENT_OUTOFCONTEXT, WM_APP, WM_QUIT, WM_USER,
+};
+
+use super::{Backend, MessageLoopExit, message_loop};
+use crate::windows_worker::{
+    ForegroundChanges, NotificationLatch, WorkerEvent, WorkerPhase, WorkerStatus,
+};
+use crate::{ForegroundApp, HookBackend};
+
+/// Thread message asking the observer pump to take an authoritative foreground
+/// snapshot. No `HWND` is carried: events queued before the initial snapshot
+/// must not replay stale window identities after it.
+const WM_FOREGROUND_CHANGED: u32 = WM_APP + 1;
+
+type ActivationCallback = Box<dyn Fn(Option<ForegroundApp>) + Send + Sync + 'static>;
+
+/// Typed setup and worker failures for the Windows foreground observer.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub(crate) enum ForegroundApplicationObserverError {
+    /// The dedicated message-pump thread could not be spawned.
+    #[error("could not spawn Windows foreground observer thread: {0}")]
+    ThreadSpawn(String),
+    /// The setup thread exited without reporting a setup result.
+    #[error("Windows foreground observer thread exited during setup")]
+    ThreadExitedDuringSetup,
+    /// Only one process-global WinEvent callback owner can be installed.
+    #[error("another Windows foreground observer is already installed")]
+    AlreadyInstalled,
+    /// The process-global callback ownership mutex was poisoned.
+    #[error("Windows foreground observer callback ownership is poisoned")]
+    CallbackOwnershipPoisoned,
+    /// `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` failed.
+    #[error("SetWinEventHook(EVENT_SYSTEM_FOREGROUND) failed with GetLastError={code}")]
+    HookSetup { code: u32 },
+    /// The WinEvent callback could not queue delivery on its owning thread.
+    #[error("Windows foreground observer could not queue an event: GetLastError={code}")]
+    EventDelivery { code: u32 },
+    /// The owning thread's Win32 message loop failed.
+    #[error("Windows foreground observer message loop failed with GetLastError={code}")]
+    MessageLoop { code: u32 },
+    /// The worker stopped without a typed native failure or a stop request.
+    #[error("Windows foreground observer stopped unexpectedly")]
+    WorkerStopped,
+}
+
+/// The non-blocking state the native WinEvent callback is allowed to touch.
+struct CallbackTarget {
+    thread_id: u32,
+    pending: NotificationLatch,
+    /// Zero means no failure. A set bit above the Win32 error-code range makes
+    /// even GetLastError=0 representable as a recorded failure.
+    delivery_failure: AtomicU64,
+}
+
+impl CallbackTarget {
+    fn new(thread_id: u32) -> Self {
+        Self {
+            thread_id,
+            pending: NotificationLatch::new(),
+            delivery_failure: AtomicU64::new(0),
+        }
+    }
+
+    fn queue_snapshot(&self) {
+        if !self.pending.claim() {
+            return;
+        }
+        // SAFETY: `thread_id` names the observer thread, whose message queue is
+        // created before callback ownership is published; this message carries
+        // no pointers and only asks that thread to take a fresh snapshot.
+        if unsafe { PostThreadMessageW(self.thread_id, WM_FOREGROUND_CHANGED, 0, 0) } != 0 {
+            return;
+        }
+
+        // SAFETY: GetLastError immediately follows the failed Win32 call and
+        // has no preconditions.
+        let code = unsafe { GetLastError() };
+        let encoded = (1_u64 << 32) | u64::from(code);
+        let _ =
+            self.delivery_failure
+                .compare_exchange(0, encoded, Ordering::AcqRel, Ordering::Acquire);
+        self.pending.delivered();
+
+        // Out-of-context WinEvents are delivered on the SetWinEventHook caller
+        // thread. Ending that pump makes the failure terminal rather than
+        // silently leaving per-app profiles stale.
+        // SAFETY: this callback runs on the observer thread; PostQuitMessage
+        // posts WM_QUIT to the calling thread and takes no pointers.
+        unsafe { PostQuitMessage(0) };
+    }
+
+    fn delivered(&self) {
+        self.pending.delivered();
+    }
+
+    fn delivery_failure(&self) -> Option<u32> {
+        let encoded = self.delivery_failure.load(Ordering::Acquire);
+        let bytes = encoded.to_le_bytes();
+        (encoded != 0).then_some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+}
+
+static CALLBACK_TARGET: Mutex<Option<Arc<CallbackTarget>>> = Mutex::new(None);
+
+/// RAII owner of a native `HWINEVENTHOOK` on its installing thread.
+struct WinEventHook(HWINEVENTHOOK);
+
+impl Drop for WinEventHook {
+    fn drop(&mut self) {
+        // SAFETY: this guard remains on the thread that installed the live
+        // handle, and Drop runs exactly once for that owned handle.
+        if unsafe { UnhookWinEvent(self.0) } == 0 {
+            // SAFETY: GetLastError immediately follows the failed unhook.
+            let code = unsafe { GetLastError() };
+            tracing::warn!(code, "could not unhook Windows foreground observer");
+        }
+    }
+}
+
+/// Worker-owned registration. Callback ownership is always cleared before the
+/// native hook is released, including unwinding and setup-channel failure.
+struct Registration {
+    target: Arc<CallbackTarget>,
+    hook: Option<WinEventHook>,
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        clear_callback_target(&self.target);
+        drop(self.hook.take());
+    }
+}
+
+struct Ready {
+    thread_id: u32,
+    target: Arc<CallbackTarget>,
+}
+
+/// RAII owner of the independent Windows foreground-observer worker.
+///
+/// Dropping it first prevents further callback queueing, then posts `WM_QUIT`
+/// and synchronously joins the owning thread. The thread unhooks its WinEvent
+/// registration before the join completes.
+#[must_use]
+pub(crate) struct ForegroundApplicationObserver {
+    thread_id: u32,
+    join: Option<thread::JoinHandle<()>>,
+    worker: Arc<WorkerStatus>,
+    failure: Arc<Mutex<Option<ForegroundApplicationObserverError>>>,
+    target: Arc<CallbackTarget>,
+}
+
+impl ForegroundApplicationObserver {
+    /// Return a typed failure if the worker can no longer deliver changes.
+    pub(crate) fn check_health(&self) -> Result<(), ForegroundApplicationObserverError> {
+        if let Some(code) = self.target.delivery_failure() {
+            return Err(ForegroundApplicationObserverError::EventDelivery { code });
+        }
+        if let Some(error) = self
+            .failure
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+        {
+            return Err(error);
+        }
+        if self.worker.phase().is_running() {
+            Ok(())
+        } else {
+            Err(ForegroundApplicationObserverError::WorkerStopped)
+        }
+    }
+}
+
+impl Drop for ForegroundApplicationObserver {
+    fn drop(&mut self) {
+        clear_callback_target(&self.target);
+        let previous = self.worker.transition(WorkerEvent::StopRequested);
+        if previous == WorkerPhase::Running {
+            // SAFETY: `thread_id` came from the observer thread after it created
+            // its queue. The message carries no pointers.
+            if unsafe { PostThreadMessageW(self.thread_id, WM_QUIT, 0, 0) } == 0 {
+                // SAFETY: GetLastError immediately follows the failed post.
+                let code = unsafe { GetLastError() };
+                tracing::warn!(
+                    code,
+                    "could not post WM_QUIT to Windows foreground observer"
+                );
+            }
+        }
+        if let Some(join) = self.join.take()
+            && let Err(error) = join.join()
+        {
+            tracing::warn!(
+                ?error,
+                "Windows foreground observer panicked while stopping"
+            );
+        }
+    }
+}
+
+/// Subscribe to native foreground changes and publish an initial snapshot.
+///
+/// Registration happens before the initial authoritative read. Native bursts
+/// are coalesced into a fresh [`Backend::frontmost_app`] read on the owning
+/// message-pump thread, so startup events cannot replay a stale HWND after the
+/// initial snapshot. `on_activation` runs on that worker and must return
+/// quickly.
+pub(crate) fn watch_frontmost_application_activations(
+    on_activation: impl Fn(Option<ForegroundApp>) + Send + Sync + 'static,
+) -> Result<ForegroundApplicationObserver, ForegroundApplicationObserverError> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let worker = Arc::new(WorkerStatus::new());
+    let failure = Arc::new(Mutex::new(None));
+    let thread_worker = Arc::clone(&worker);
+    let thread_failure = Arc::clone(&failure);
+    let join = thread::Builder::new()
+        .name("openlogi-windows-foreground".into())
+        .spawn(move || {
+            let callback: ActivationCallback = Box::new(on_activation);
+            observer_thread(&callback, &ready_tx, &thread_worker, &thread_failure);
+        })
+        .map_err(|error| ForegroundApplicationObserverError::ThreadSpawn(error.to_string()))?;
+
+    match ready_rx.recv() {
+        Ok(Ok(ready)) => Ok(ForegroundApplicationObserver {
+            thread_id: ready.thread_id,
+            join: Some(join),
+            worker,
+            failure,
+            target: ready.target,
+        }),
+        Ok(Err(error)) => {
+            let _ = join.join();
+            Err(error)
+        }
+        Err(_) => {
+            let _ = join.join();
+            Err(ForegroundApplicationObserverError::ThreadExitedDuringSetup)
+        }
+    }
+}
+
+fn observer_thread(
+    callback: &ActivationCallback,
+    ready: &mpsc::Sender<Result<Ready, ForegroundApplicationObserverError>>,
+    worker: &WorkerStatus,
+    failure: &Mutex<Option<ForegroundApplicationObserverError>>,
+) {
+    // SAFETY: GetCurrentThreadId has no preconditions.
+    let thread_id = unsafe { GetCurrentThreadId() };
+    let mut bootstrap_msg = MSG::default();
+    // SAFETY: this live MSG and null HWND inspect this thread's queue. The call
+    // creates the queue before callback ownership becomes visible to WinEvent.
+    unsafe {
+        PeekMessageW(
+            &raw mut bootstrap_msg,
+            std::ptr::null_mut(),
+            WM_USER,
+            WM_USER,
+            PM_NOREMOVE,
+        );
+    }
+
+    let target = Arc::new(CallbackTarget::new(thread_id));
+    if let Err(error) = claim_callback_target(&target) {
+        let _ = ready.send(Err(error));
+        return;
+    }
+
+    // SAFETY: `foreground_event_proc` has the exact WINEVENTPROC ABI. A null
+    // module with WINEVENT_OUTOFCONTEXT is documented, and zero process/thread
+    // ids subscribe to this event from every process on the current desktop.
+    let hook = unsafe {
+        SetWinEventHook(
+            EVENT_SYSTEM_FOREGROUND,
+            EVENT_SYSTEM_FOREGROUND,
+            std::ptr::null_mut(),
+            Some(foreground_event_proc),
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT,
+        )
+    };
+    if hook.is_null() {
+        // Read last-error before callback cleanup can call another Win32 API.
+        // SAFETY: GetLastError immediately follows the failed setup call.
+        let code = unsafe { GetLastError() };
+        clear_callback_target(&target);
+        let _ = ready.send(Err(ForegroundApplicationObserverError::HookSetup { code }));
+        return;
+    }
+    let registration = Registration {
+        target: Arc::clone(&target),
+        hook: Some(WinEventHook(hook)),
+    };
+
+    worker.transition(WorkerEvent::Started);
+    let mut changes = ForegroundChanges::default();
+    publish_current(callback, &mut changes);
+    if ready
+        .send(Ok(Ready {
+            thread_id,
+            target: Arc::clone(&target),
+        }))
+        .is_err()
+    {
+        worker.transition(WorkerEvent::StopRequested);
+        worker.transition(WorkerEvent::MessageLoopQuit);
+        drop(registration);
+        return;
+    }
+
+    let exit = message_loop(|msg| {
+        if msg.message != WM_FOREGROUND_CHANGED {
+            return false;
+        }
+        target.delivered();
+        publish_current(callback, &mut changes);
+        true
+    });
+
+    let error = match exit {
+        MessageLoopExit::Quit => target
+            .delivery_failure()
+            .map(|code| ForegroundApplicationObserverError::EventDelivery { code }),
+        MessageLoopExit::Failed(code) => {
+            Some(ForegroundApplicationObserverError::MessageLoop { code })
+        }
+    };
+    if let Some(error) = error {
+        *failure.lock().unwrap_or_else(PoisonError::into_inner) = Some(error.clone());
+        worker.transition(WorkerEvent::MessageLoopFailed);
+        tracing::error!(%error, "Windows foreground observer stopped");
+    } else {
+        worker.transition(WorkerEvent::MessageLoopQuit);
+    }
+    drop(registration);
+}
+
+fn publish_current(callback: &ActivationCallback, changes: &mut ForegroundChanges) {
+    let current = Backend::frontmost_app();
+    if !changes.observe(current.as_ref()) {
+        return;
+    }
+    if catch_unwind(AssertUnwindSafe(|| callback(current))).is_err() {
+        tracing::error!("Windows foreground-application callback panicked");
+    }
+}
+
+fn claim_callback_target(
+    target: &Arc<CallbackTarget>,
+) -> Result<(), ForegroundApplicationObserverError> {
+    let mut slot = CALLBACK_TARGET
+        .lock()
+        .map_err(|_| ForegroundApplicationObserverError::CallbackOwnershipPoisoned)?;
+    if slot.is_some() {
+        return Err(ForegroundApplicationObserverError::AlreadyInstalled);
+    }
+    *slot = Some(Arc::clone(target));
+    Ok(())
+}
+
+fn clear_callback_target(target: &Arc<CallbackTarget>) {
+    let mut slot = CALLBACK_TARGET
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    if slot
+        .as_ref()
+        .is_some_and(|current| Arc::ptr_eq(current, target))
+    {
+        *slot = None;
+    }
+}
+
+/// Win32 callback: coalesce and enqueue only. Process lookup, deduplication,
+/// and user delivery stay outside this native boundary on the owning pump.
+unsafe extern "system" fn foreground_event_proc(
+    _hook: HWINEVENTHOOK,
+    _event: u32,
+    _hwnd: HWND,
+    _object_id: i32,
+    _child_id: i32,
+    _event_thread: u32,
+    _event_time: u32,
+) {
+    // No Rust panic may unwind into user32. try_lock keeps teardown contention
+    // from blocking the native callback; contention only occurs while callback
+    // ownership is being installed or cleared.
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        let target = match CALLBACK_TARGET.try_lock() {
+            Ok(slot) => slot.clone(),
+            Err(TryLockError::WouldBlock | TryLockError::Poisoned(_)) => None,
+        };
+        if let Some(target) = target {
+            target.queue_snapshot();
+        }
+    }));
+}

--- a/crates/openlogi-hook/src/windows_worker.rs
+++ b/crates/openlogi-hook/src/windows_worker.rs
@@ -1,7 +1,10 @@
 //! Pure lifecycle state for the Windows hook worker.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(target_os = "windows")]
 use std::sync::{Mutex, PoisonError};
+
+use crate::ForegroundApp;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum WorkerPhase {
@@ -40,6 +43,61 @@ pub(super) const fn worker_transition(phase: WorkerPhase, event: WorkerEvent) ->
     }
 }
 
+/// Coalesces a burst of native notifications until their queued snapshot has
+/// been delivered by the owning message pump.
+pub(super) struct NotificationLatch {
+    pending: AtomicBool,
+}
+
+impl NotificationLatch {
+    pub(super) const fn new() -> Self {
+        Self {
+            pending: AtomicBool::new(false),
+        }
+    }
+
+    /// Claim responsibility for queueing the next delivery.
+    pub(super) fn claim(&self) -> bool {
+        !self.pending.swap(true, Ordering::AcqRel)
+    }
+
+    /// Allow a later native notification to queue another delivery.
+    pub(super) fn delivered(&self) {
+        self.pending.store(false, Ordering::Release);
+    }
+}
+
+/// The last semantic foreground snapshot delivered by the Windows observer.
+pub(super) struct ForegroundChanges {
+    published: PublishedForeground,
+}
+
+enum PublishedForeground {
+    NotYet,
+    Value(Option<ForegroundApp>),
+}
+
+impl Default for ForegroundChanges {
+    fn default() -> Self {
+        Self {
+            published: PublishedForeground::NotYet,
+        }
+    }
+}
+
+impl ForegroundChanges {
+    pub(super) fn observe(&mut self, current: Option<&ForegroundApp>) -> bool {
+        if matches!(
+            &self.published,
+            PublishedForeground::Value(published) if published.as_ref() == current
+        ) {
+            return false;
+        }
+        self.published = PublishedForeground::Value(current.cloned());
+        true
+    }
+}
+
 #[cfg(target_os = "windows")]
 pub(super) struct WorkerStatus {
     phase: Mutex<WorkerPhase>,
@@ -69,6 +127,10 @@ impl WorkerStatus {
 mod tests {
     use super::*;
 
+    fn app(id: &str) -> ForegroundApp {
+        ForegroundApp::unnamed(id.to_owned())
+    }
+
     #[test]
     fn worker_stop_has_an_explicit_terminal_path() {
         let running = worker_transition(WorkerPhase::Starting, WorkerEvent::Started);
@@ -96,5 +158,30 @@ mod tests {
                 "teardown must not revive a failed worker"
             );
         }
+    }
+
+    #[test]
+    fn notification_bursts_queue_one_delivery_until_observed() {
+        let latch = NotificationLatch::new();
+
+        assert!(latch.claim());
+        assert!(!latch.claim());
+        assert!(!latch.claim());
+        latch.delivered();
+        assert!(latch.claim());
+    }
+
+    #[test]
+    fn foreground_changes_publish_the_initial_snapshot_and_semantic_changes() {
+        let mut changes = ForegroundChanges::default();
+
+        assert!(changes.observe(None));
+        assert!(!changes.observe(None));
+        let one = app("c:\\apps\\one.exe");
+        assert!(changes.observe(Some(&one)));
+        assert!(!changes.observe(Some(&one)));
+        let two = app("c:\\apps\\two.exe");
+        assert!(changes.observe(Some(&two)));
+        assert!(changes.observe(None));
     }
 }


### PR DESCRIPTION
## Summary

Replace steady-state foreground-app and HID inventory polling with native lifecycle invalidations while retaining bounded recovery for missed events, unsupported firmware, and transport failures.

## Changes

- **openlogi-hook**
  - Add `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` observation on Windows.
  - Add X11, wlroots foreign-toplevel, and GNOME D-Bus focus observation on Linux.
  - Expose one cross-platform invalidation facade while keeping `frontmost_application()` as the authoritative state reader.
- **openlogi-device / openlogi-hidpp / openlogi-hid**
  - Subscribe inventory-owned channels to receiver connection, wireless status, and unified-battery events before probing.
  - Keep channels persistent across reconciliations and coalesce lifecycle invalidations.
  - Convert capture liveness ping into an inactivity watchdog and distinguish silent replies from transport failures.
- **openlogi-agent-core / openlogi-agent**
  - Reconcile inventory from hotplug, HID++, and native resume events.
  - Add Linux logind, Windows power, and macOS workspace resume delivery through a bounded directional channel.
  - Restrict the two-second cadence to bounded repair and settings confirmation; retain a 30-second inactivity recovery scan.
  - Use `Armed -> Running` state transfer to make resume-stream ownership structural.
- **GNOME extension**
  - Emit focused-window changes over D-Bus instead of requiring periodic reads.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo test -p openlogi-agent-core watchers::inventory`
- `cargo test -p openlogi-agent-core watchers::foreground_app`
- `cargo test -p openlogi-device session::gesture::liveness`
- `cargo test -p openlogi-agent resume_linux`
- `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-hook -p openlogi-agent-core -p openlogi-agent -p openlogi-device --all-targets -- -D warnings`
- `cargo clippy --target x86_64-apple-darwin -p openlogi-hook -p openlogi-agent-core -p openlogi-agent -p openlogi-device --all-targets -- -D warnings`
- `cargo xtask ci wasm cargo-deny`
- `node --check crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/extension.js`

Not runtime-tested against a Linux compositor, Windows/macOS desktop session, or Logitech hardware in the Linux orb. Hardware verification should cover receiver reconnect, suspend/resume, foreground profile switching, battery updates, and capture recovery.

Follow-up to #1136.