### PR TITLE
fix(ci): repair focused i18n gate and agent guidance

### DIFF
--- a/.claude/rules/cross-platform.md
+++ b/.claude/rules/cross-platform.md
@@ -3,9 +3,11 @@ paths:
   - "crates/openlogi-hook/**"
   - "crates/openlogi-inject/**"
   - "crates/openlogi-hid/**"
+  - "crates/openlogi-agent/src/autostart.rs"
   - "crates/openlogi-agent/src/autostart/**"
   - "crates/openlogi-agent/src/resume_windows.rs"
   - "crates/openlogi-camera/**"
+  - "crates/openlogi-permissions/**"
 ---
 
 # Platform / cfg-gated code — macOS-green is a trap
@@ -23,10 +25,11 @@ When the diff touches any of:
 
 - `crates/openlogi-hook/src/linux.rs` / `windows.rs`
 - `crates/openlogi-inject/src/inject/linux.rs` / `windows.rs`
-- `crates/openlogi-agent/src/autostart/linux.rs` / `windows.rs`
+- `crates/openlogi-agent/src/autostart/linux.rs` / `windows.rs`, or
+  `crates/openlogi-agent/src/resume_windows.rs`
 - `crates/openlogi-camera/src/capture_linux.rs`, `capture_windows.rs`,
   `com_windows.rs`, `uvc_windows.rs`, `uvc_linux.rs`, `linux.rs`
-- `crates/openlogi-hid/src/channel/transport.rs` (has `#[cfg]` branches)
+- `crates/openlogi-hid/src/transport.rs` or `transport/windows.rs`
 - any `#[cfg(target_os = …)]` block, in any crate
 
 you MUST either:

--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -53,11 +53,9 @@ changes day to day:
 ### `expect` by default, `allow` only when `expect` would break
 
 `#[allow]` goes quiet the day it stops suppressing anything, so suppressions rot in
-place — an audit in 2026-08 found 20 dead ones, including three module-wide `dead_code`
-blankets that had been inert since their modules went `pub`. `#[expect]` reports itself
-unfulfilled instead, which `-D warnings` turns into a failure. `allow_attributes`
-enforces this — but only for outer `#[allow]`; a module-wide `#![allow(…)]`, the shape
-that rots worst, is invisible to it and is on you.
+place. `#[expect]` reports itself unfulfilled instead, which `-D warnings` turns into a
+failure. `allow_attributes` enforces this — but only for outer `#[allow]`; a module-wide
+`#![allow(…)]`, the shape that rots worst, is invisible to it and is on you.
 
 Three cases where `expect` is wrong and `allow` is correct. Each keeps its `allow` plus
 an `#[expect(clippy::allow_attributes, reason = "see above")]` and a comment saying which
@@ -171,11 +169,10 @@ House style:
   not lift the cross-platform rule: the non-host files are only ever compiled by
   that platform's CI or a cross-lint, so `.claude/rules/cross-platform.md` applies
   with full force.
-- Keep files reasonably sized (split around ~500 lines) into real modules — never
-  simulate structure with `// ---- section ----` banner comments. But don't
-  over-extract either: inline single-use helpers. File size, coverage, and complexity
-  metrics are investigation signals, not abstraction targets; extract a reusable
-  responsibility or invariant, never a single-use layer solely to improve a number.
+- File size, coverage percentage, and complexity scores are investigation signals, not
+  goals. Split a large file when it contains a coherent responsibility that deserves a
+  real module; never manufacture a single-use abstraction only to improve a metric.
+  Do not simulate structure with `// ---- section ----` banner comments.
 - rustdoc every public item. Comments state non-obvious constraints only.
 - Tests cover failure and edge paths, not just the happy path (state machines
   especially). No tautological tests that mirror the implementation; never weaken an

--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -6,8 +6,8 @@ description: Decide whether a macOS problem is a privacy-permission (TCC) proble
 # macOS permissions (TCC) in OpenLogi
 
 One sentence to keep: **TCC does not authorize processes, it authorizes
-identities.** Almost every "permission bug" here is an identity bug — the user
-ticked a box, but not for the identity that actually opens the device.
+identities.** A permission report is a claim, not a root cause. Identify the
+failing layer and the identity that performed the operation before diagnosing it.
 
 ## 1. First decide whether it is TCC at all
 
@@ -20,40 +20,45 @@ list). Classify before doing anything else. The discriminator is one log line:
 | `HID++ candidate interfaces count=0` | enumeration | **No.** The device's HID++ collection never matched — unsupported device, or not connected. |
 | `failed to open HID++ channel … Failed to open device: Input Monitoring is NOT granted to this process…` | open | **Yes.** The message classifies itself — grant Input Monitoring to the identity named in §2. |
 | `… Failed to open device: Input Monitoring is granted to this process — another app may hold the device exclusively, or macOS is serving a stale permission session (log out and back in)` | open | **The grant is fine.** Quit the other app (usually Logi Options+), or log out and back in. See §5. |
-| `opened HID++ channel` … then `Device::new failed` / `enumerate_features failed` with `Channel(Timeout)` or `report writer callback error: 0xE00002D6` | probe | **No.** The open succeeded, so permissions are fine. This is the async-hid macOS write bug (upstream `sidit77/async-hid#45`). |
+| `opened HID++ channel` … then `Device::new failed` / `enumerate_features failed` with `Channel(Timeout)` or `report writer callback error: 0xE00002D6` | probe | **No.** The open succeeded, so investigate the probe/transport path, including the current status of upstream `sidit77/async-hid#45`. |
 
 All of these lines are `debug`-level except the open failure, which is a
 `warn`. A log captured without `OPENLOGI_LOG=debug` can only ever show the
 middle row — in such a log, the absence of the other lines is not evidence
 of anything.
 
-`openlogi list` first asks the running agent. When it prints
-`(inventory read from the running agent)`, it observes the same device-I/O owner
-as the GUI. Only `(no agent reachable — reading hardware directly...)` means
-the CLI is using its separate TCC identity. Record that provenance before
-drawing a permission conclusion.
+Read `openlogi list`'s stderr provenance before using its result:
+
+- `(inventory read from the running agent)` means the HID++ rows came from the
+  same agent snapshot the GUI consumes.
+- `(no agent reachable — reading hardware directly; …)` or the protocol-version
+  note means the CLI used its own code-signing identity and HID stack because no
+  usable compatible agent snapshot was available.
+
+Camera enumeration is direct in both cases. Without the provenance, a device in
+`openlogi list` is not evidence for or against the agent's TCC grant.
 
 If there is no log at all, go to §3 — getting a log is the whole job.
 
 ## 2. The identity map
 
-One install ships four TCC identities. Only one of them may hold device
-permissions.
+The long-running app's HID and input grants belong to the agent. Direct CLI
+operations use the CLI's identity instead.
 
 | Identity | Binary | Needs |
 |---|---|---|
 | `org.openlogi.agent` | `…/Contents/Library/LoginItems/OpenLogi Agent.app` | **Input Monitoring** (opens HID) and **Accessibility** (owns the event tap) |
 | `org.openlogi.openlogi` | `…/Contents/MacOS/openlogi-desktop` | Camera only. It is a pure IPC client and needs neither of the above. |
-| `openlogi` | `…/Contents/MacOS/openlogi` (embedded CLI) | Input Monitoring only for direct fallback and hardware diagnostic commands |
+| `openlogi` | `…/Contents/MacOS/openlogi` (embedded CLI) | Input Monitoring only when `list` falls back to direct HID or a hardware diagnostic accesses HID directly |
 | `org.openlogi.overlay` | `…/LoginItems/OpenLogiOverlay.app` | Nothing |
 
-Two consequences that drive most reports:
+Rules that drive most reports:
 
 - The identity the user must grant is **OpenLogi Agent**, which lives inside the
   app bundle. Bundles built before the rename spell that directory
   `OpenLogiAgent.app`; both are the same identity (`org.openlogi.agent`), and
-  the grant survived the rename because TCC keys on the identifier, not the
-  path. The System Settings `+` picker will not browse into a bundle, so
+  the grant survived the rename because the path is not part of the designated
+  requirement. The System Settings `+` picker will not browse into a bundle, so
   they have to use Go-to-Folder. Say this explicitly; do not tell someone to
   "grant OpenLogi permission".
 - A grant to the GUI does nothing for the agent, and vice versa. There is no
@@ -104,8 +109,8 @@ child process is the parent. An agent spawned directly by the GUI therefore asks
 with the **GUI's** identity, and the user's grant to `OpenLogi Agent` appears
 to do nothing.
 
-Three ways to break the chain, all in the tree
-(`openlogi-desktop/src/services/ipc.rs`), tried in this order:
+The launch paths that break the chain live in
+`openlogi-desktop/src/services/ipc/launch.rs` and run in this order:
 
 - registered login item → `launchctl kickstart gui/<uid>/<service label>`
   (launchd spawns it directly: its own responsible process, plus crash
@@ -144,18 +149,17 @@ every grant on that machine is being ignored.
 
 ## 6. Invariants — do not break these
 
-1. **Only the agent holds the app runtime's device permissions.** Any UI that
-   reports permission state must read it from the agent over IPC, never by
-   querying its own process. The GUI never opens a HID device, so its own grant
-   means nothing. A CLI direct fallback or diagnostic uses the CLI's separate
-   identity and says nothing about the agent's grant.
+1. **Only the agent holds the long-running app's HID/input permissions.** Any UI
+   that reports permission state must read it from the agent over IPC, never by
+   querying its own process. Direct CLI diagnostics are a separate, explicit
+   identity and must not be used to infer the agent's grant.
 2. **Every helper launch establishes its own responsible process** (§4), and the
    spawn result is checked — a silently failed `disclaim` leaves the agent
    running under the GUI's identity, which is invisible until a user reports it.
-3. **Bundle identifiers are the TCC primary key.** Changing one voids every
-   existing user grant. Releases 0.6.24–0.6.26 shipped `.dev` identifiers and
-   did exactly that. The `Verify production bundle identities` step in
-   `.github/workflows/build.yml` is load-bearing; do not weaken it.
+3. **TCC matches the full designated requirement.** A bundle-identifier or
+   signing-identity change can invalidate every existing grant. The
+   `Verify production bundle identities` step in `.github/workflows/build.yml`
+   is load-bearing; do not weaken it.
 4. **Sign inside-out.** The helper needs its own stable designated requirement
    so its grant survives updates; `--deep` cannot give it one. See
    `xtask/src/commands/macos/bundle/signing.rs`.
@@ -165,11 +169,11 @@ every grant on that machine is being ignored.
 
 ## 7. Check current evidence
 
-Do not carry a "currently fixed/broken" snapshot in this skill. Search the
-current tracker and identify the reporter's release before answering. An open
-report is a claim, not a root cause: classify it with §1 logs and the actual
-running identity. Re-check the current state of linked upstream transport
-issues before attributing a probe timeout to them.
+Do not carry a "currently fixed/broken" snapshot in this skill. Query the current
+tracker and latest release notes, identify the reporter's release, and read the
+matching report, comments, current code, and logs. Treat the report's diagnosis as a
+claim until the provenance and direct evidence in §§1–4 establish the root cause.
+Re-check linked upstream transport issues before attributing a probe timeout to them.
 
 ## 8. What this cannot fix
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,6 @@ node_modules/
 # macOS finder metadata
 .DS_Store
 
-# Bundle-time asset payload — fetched fresh from OpenLogi's asset mirrors by
-# the macOS bundle task before `cargo bundle`, not checked in.
-/crates/openlogi-gui/assets/
-
 # Compiled icons — `cargo xtask macos icon` rebuilds them from the Icon
 # Composer documents in `design/icon` on every bundle build. `AppIcon.icns` is
 # the exception: `cargo bundle` reads it straight from the manifest, so it stays

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,59 +14,52 @@ touching an area.
 
 ## Architecture
 
-The long-lived app has three tiers: the **GUI** is a pure IPC client, the **agent** is
-the background server owning the input hook and runtime device I/O, and shared
-orchestration sits beneath both. The CLI is the explicit diagnostic exception:
-`openlogi list` reads the running agent first and falls back to direct enumeration
-only when no compatible agent answers, while hardware diagnostic commands may access
-devices directly.
+For runtime HID and input state, the long-running **GUI** and **overlay** are pure IPC
+clients; the **agent** owns the input hook and HID I/O. The CLI is a diagnostic
+exception: `openlogi list` prefers a compatible agent snapshot and falls back to
+direct enumeration when none is available, while hardware-diagnostic subcommands
+access devices directly.
 
 | Crate | Role |
 |---|---|
 | `crates/openlogi` | The CLI binary — thin wrapper over `openlogi-cli` |
 | `crates/openlogi-core` | Pure types: TOML config, device model, action catalog, locale negotiation. No I/O, no async (feature-gated host reads: `fs`, `locale`) |
 | `crates/openlogi-device-registry` | Pure hardware identity registry: receiver protocols and standalone-device driver metadata |
-| `crates/openlogi-hidpp` | Vendored fork of the `hidpp` protocol crate (**lib name `hidpp`**, 0BSD) |
-| `crates/openlogi-hidpp-derive` | Derive macros used by the HID++ hard fork; changes share the hidpp lint and rustdoc contract |
+| `crates/openlogi-hidpp` | Hard fork of the `hidpp` protocol crate (**lib name `hidpp`**, 0BSD) |
+| `crates/openlogi-hidpp-derive` | Private derive macro for `openlogi-hidpp` feature boilerplate |
 | `crates/openlogi-device` | The HID++ device layer: enumeration, probing, writes, sessions, pairing. Knows no host — expressed against `HidBackend` |
 | `crates/openlogi-hid` | That layer wired to this host: `async-hid` transport, macOS Input Monitoring, the on-disk probe cache |
+| `crates/openlogi-camera` | Cross-platform Logitech UVC enumeration, capture, controls, and Camera-permission APIs |
 | `crates/openlogi-assets` | Device-render registry + cached fetch from OpenLogi asset mirrors |
-| `crates/openlogi-camera` | Camera enumeration, capture, and UVC controls through platform-native backends |
-| `crates/openlogi-cli` | The `clap` command tree: inventory, diagnostics, device control, cameras, and assets |
+| `crates/openlogi-cli` | CLI dispatch: agent-backed inventory when available, plus direct hardware diagnostics |
 | `crates/openlogi-hook` | OS input capture: CGEventTap / evdev+uinput / WH_MOUSE_LL |
 | `crates/openlogi-inject` | OS input synthesis: CGEvent / uinput+MPRIS / SendInput |
 | `crates/openlogi-agent-core` | Shared agent orchestration: hook runtime, HID++ writes, DPI cycle, Actions Ring session state |
-| `crates/openlogi-ipc` | The tarpc IPC contract (`src/ipc.rs`) + its local-socket transport, shared by agent and GUI |
-| `crates/openlogi-agent` | The `openlogi-agent` binary — hook + device I/O server |
+| `crates/openlogi-ipc` | The tarpc IPC contract (`src/ipc.rs`) + its local-socket transport, shared by the agent and its clients |
+| `crates/openlogi-agent` | The `openlogi-agent` binary — runtime HID/input server |
 | `crates/openlogi-permissions` | Privacy-permission status + System-Settings deep links: macOS TCC reads, Linux device-file probes. Reads only — never prompts |
 | `crates/openlogi-ui` | Presentation shared by the two GPUI processes: ring geometry/icons, the GPUI asset source, the shared locale catalogs. Depends on `gpui` but **not** `gpui-component` |
-| `crates/openlogi-desktop` | GPUI + gpui-component desktop app — polls the agent, no device I/O |
+| `crates/openlogi-desktop` | GPUI + gpui-component desktop app — polls the agent, no HID/input I/O |
 | `crates/openlogi-overlay` | The `openlogi-overlay` binary — cursor-centred Actions Ring, a pure IPC client |
 | `xtask` | `cargo xtask` maintenance: bundling, packaging, release manifest |
 
-- GUI ↔ agent speak tarpc/bincode over an `interprocess` local socket. The wire format
-  is versioned and **append-only** — read `crates/openlogi-ipc/AGENTS.md` before touching
-  it.
+- IPC clients ↔ agent speak tarpc/bincode over an `interprocess` local socket. The wire
+  format is versioned and **append-only** — read `crates/openlogi-ipc/AGENTS.md` before
+  touching it.
 - Three processes ship in the bundle — GUI, agent, overlay — and the overlay is a
   *sibling* of the GUI, not a part of it: it links `openlogi-ui`, never
   `openlogi-desktop`. Anything both need goes in `openlogi-ui`, and every dependency
   added there lands in the overlay too (`.claude/rules/gui.md` has the rule).
 - Platform code is cfg-gated per crate (`[target.'cfg(target_os = …)'.dependencies]`).
   `.claude/rules/objc-ffi.md` is the contract for the workspace's macOS native FFI and
-  the canonical inventory of every file that carries any — read it before editing one
-  and keep that table in sync instead of duplicating a crate count here.
+  maintains the canonical file-by-file inventory — read it before editing that surface.
 
-## Decision and external-state discipline
+## Evidence and root-cause discipline
 
-- Treat issue reports and review findings as claims. Verify them against the current
-  head and the most direct available evidence before changing code or replying; do not
-  implement a stale or inapplicable diagnosis.
-- Fix the verified root cause. Do not add compatibility shims, fallback state, or
-  abstractions that merely hide a broken owner or lifecycle.
-- External writes require explicit authorization for that specific step: pushes and
-  force-pushes, workflow approvals or re-runs, merges, releases, issue or PR comments,
-  and infrastructure or data writes. Read-only inspection and authorization for an
-  earlier step do not authorize the next one.
+- Treat every issue, user report, and review finding as a claim. Verify it against the
+  current head and the most direct available evidence before accepting its diagnosis.
+- Fix the verified root cause at its owning module and lifecycle boundary. Do not hide
+  a broken owner or lifecycle behind a shim, fallback, or one-use abstraction.
 
 ## Build, run, verify
 
@@ -215,10 +208,9 @@ backstop, not a substitute for running the gate yourself after a rebase.
    `cargo test -p openlogi-ipc --test wire_format` green — see
    `crates/openlogi-ipc/AGENTS.md`.
 6. If locales changed: every `crates/openlogi-ui/locales/*.yml` carries the same keys
-   as `en.yml` (new keys at the same position) and
-   `cargo test -p openlogi-ui locale` is green. If catalog wiring or desktop key
-   resolution changed, also run `cargo test -p openlogi-desktop i18n` — see
-   `.claude/rules/i18n.md`.
+   as `en.yml` (new keys at the same position); run `cargo test -p openlogi-ui locale`
+   for catalog parity and `cargo test -p openlogi-desktop i18n` for catalog wiring and
+   desktop resolution — see `.claude/rules/i18n.md`.
 7. Only then `git push` / force-push to the PR branch.
 
 ### Running the app

--- a/crates/openlogi-hidpp/AGENTS.md
+++ b/crates/openlogi-hidpp/AGENTS.md
@@ -23,9 +23,12 @@ about licensing or attribution:
   crate's protocol knowledge came from even as the code itself moves away from
   upstream's structure.
 - `[lib] name = "hidpp"` in `Cargo.toml`. Every consumer imports it as
-  `use hidpp::...` across `openlogi-device`, `openlogi-hid`, and doctests. Renaming
-  the lib target is not a documentation-only change: derive the current call-site
-  set with `rg` and update all of it in the same commit. Don't do it as a drive-by.
+  `hidpp`, not by the package name. Before changing the lib target or its public
+  surface, derive the current consumer set with
+  `rg -l '\bhidpp::|use hidpp::' crates --glob '*.rs'` and
+  `rg -n 'hidpp\s*=' --glob 'Cargo.toml' .`. Renaming the target is not a
+  documentation-only change: update every current consumer in the same commit.
+  Do not do it as a drive-by.
 
 ## Rules that hold regardless of fork/vendor status
 
@@ -58,13 +61,11 @@ So `clippy::pedantic`, `unwrap_used`, and `expect_used` apply here exactly as
 they do elsewhere. There is no "it's vendored" excuse for a bare `unwrap`, and a
 suppression needs the same `reason = "…"` any other crate would need.
 
-## Known loose end
+## Optional serde surface
 
-The optional `serde` dependency and the ~40 files' worth of
-`#[cfg_attr(feature = "serde", derive(serde::Serialize))]` it gates are inherited
-library surface that **nothing in this workspace enables** — no crate depends on
-`hidpp` with `features = ["serde"]`, and types crossing the IPC boundary are
-converted to `openlogi-core`'s own structs first. Dropping it would be a large
-mechanical diff; keeping it costs a feature-combination nobody builds. Decide it
-deliberately (does this crate stay a general-purpose library, or is it strictly
-OpenLogi-internal?) rather than by drive-by.
+The optional `serde` dependency gates widespread
+`#[cfg_attr(feature = "serde", derive(serde::Serialize))]` library surface. Before
+changing it, derive the current feature consumers from the manifests and source.
+Types crossing OpenLogi's IPC boundary are converted to `openlogi-core` structs first.
+Decide deliberately whether this crate remains general-purpose or strictly internal;
+do not remove the feature as a drive-by.

--- a/crates/openlogi-permissions/src/macos.rs
+++ b/crates/openlogi-permissions/src/macos.rs
@@ -64,7 +64,7 @@ pub fn camera() -> PermissionStatus {
 /// For Accessibility the pane is all this offers — the agent owns the
 /// CGEventTap, so the prompt must run there. When the row is missing from the
 /// list entirely, see the TCC rules in
-/// `crates/openlogi-desktop/src/platform/AGENTS.md`.
+/// `.claude/skills/openlogi-macos-permissions/SKILL.md`.
 pub fn open_pane(permission: Permission) {
     let anchor = match permission {
         Permission::Accessibility => "Privacy_Accessibility",


### PR DESCRIPTION
## Summary

- Fix the focused i18n false-green by making `openlogi-ui` catalog parity the first gate and retaining the desktop catalog-wiring/key-resolution gate.
- Refresh repository AI guidance against current ownership, lifecycle, platform, permission, and capability behavior.
- Replace stale snapshots and paths with durable invariants or commands that derive the current state.

## Changes

- **xtask:** run `cargo test -p openlogi-ui locale` before `cargo test -p openlogi-desktop i18n`, correct CI caveats, and lock the focused plan with a regression test.
- **repository guidance:** document the agent's runtime HID/input ownership and the CLI's explicit direct-diagnostic exception; add claim/evidence and owner-level root-cause discipline; add missing camera and HID++ derive owners.
- **device/GUI guidance:** make fresh enumeration authoritative after hotplug hints, preserve polling and last-good state through stream/probe failures, constrain kind-derived capabilities to the centralized never-probed offline fallback, and strengthen real-app UI verification requirements.
- **platform/i18n guidance:** cover the current agent, camera, permission, and catalog-wiring paths and make catalog rules independent of a fixed catalog count.
- **permission/HID++ cleanup:** interpret `openlogi list` provenance correctly, require current tracker/release verification, derive HID++ consumers with `rg`, and remove stale paths/counts and obsolete ignore entries.

## Testing

- `cargo xtask ci --dry-run i18n`
- `cargo xtask ci i18n`
  - `catalog_parity::locale_files_have_the_same_keys` passed
  - `services::i18n::tests::locale_file_resolves_keys` passed
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `prek run typos --all-files`
- `prek run --files $(git diff --name-only)` (all applicable hooks passed; shell hooks had no changed files)
- `cargo xtask linux package` built all release binaries, then stopped before package creation because `nfpm` is not installed in the Linux orb.

Not runtime-tested on macOS or physical Logitech hardware. This PR changes no visible UI behavior; the macOS permission and hardware paths were audited from current source and provenance output, not exercised on those platforms.
