### PR TITLE
fix(ci): align agent guidance with current contracts

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -90,7 +90,8 @@ cargo clippy --target aarch64-unknown-linux-musl \
 `openlogi-camera`'s Linux backend needs kernel headers and does not
 cross-compile from macOS. Details: `.claude/rules/cross-platform.md`.
 
-Linux CI tests **exclude** `openlogi-desktop`, so i18n locale-parity tests run
+Linux CI tests **exclude** `openlogi-desktop`, but still run `openlogi-ui`'s
+portable locale-parity test. The desktop end-to-end key-resolution tests run
 only on macOS CI (`cargo test -p openlogi-desktop i18n`).
 
 ## If you changed X, run Y
@@ -106,7 +107,7 @@ only on macOS CI (`cargo test -p openlogi-desktop i18n`).
 | `rust-version` or a newly stabilized API | `MSRV` |
 | rustdoc / moved trait impls / hidpp derive | `rustdoc` |
 | `crates/openlogi-ipc/**` or wire types | `cargo test -p openlogi-ipc --test wire_format` |
-| `crates/openlogi-ui/locales/**` | `cargo test -p openlogi-desktop i18n` (macOS; Linux CI does not run this) |
+| `crates/openlogi-ui/locales/**` | `cargo test -p openlogi-ui locale`; also `cargo test -p openlogi-desktop i18n` when binary wiring or desktop resolution changed |
 | `devenv.nix` / `.envrc` / `devenv.lock` | devenv CI: `nix fmt -- --check devenv.nix` and `devenv --no-tui shell -- true` |
 | `flake.nix` / `flake.lock` / `packaging/linux/**` | Nix CI: `nix fmt -- --check flake.nix devenv.nix packaging/linux/package.nix packaging/linux/nixos-module.nix` and `nix flake check --all-systems --no-build --show-trace` |
 | `xtask/**` / `packaging/**` | unsigned `cargo xtask` package for that platform; the Build workflow is not part of `cargo xtask ci` |

--- a/.claude/rules/cross-platform.md
+++ b/.claude/rules/cross-platform.md
@@ -3,6 +3,9 @@ paths:
   - "crates/openlogi-hook/**"
   - "crates/openlogi-inject/**"
   - "crates/openlogi-hid/**"
+  - "crates/openlogi-agent/src/autostart/**"
+  - "crates/openlogi-agent/src/resume_windows.rs"
+  - "crates/openlogi-camera/**"
 ---
 
 # Platform / cfg-gated code — macOS-green is a trap

--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -62,9 +62,11 @@ paths:
   style refinement with the caller's, so a bare `Icon` falls through to the current
   font size instead of the 16px `Default` sets. Any icon meant to line up with a
   neighbouring `svg().size_4()` needs an explicit `.size_4()`.
-- Config panels/tabs gate on `Capabilities` (derived from the HID++ feature table),
-  **never** on device `kind` — kind is identity-only (icon/label). A new panel means a
-  new capability in `Capabilities::from_feature_ids` plus a `tabs_for` arm.
+- Config panels/tabs gate on measured or last-good `Capabilities`, not directly on
+  device `kind` — kind is identity-only (icon/label). The sole kind-derived fallback
+  is `Capabilities::presumed_from_kind` in `tabs_for` for a never-probed offline
+  device; keep it centralized. A new panel means a new capability in
+  `Capabilities::from_feature_ids` plus a `tabs_for` arm.
 - Mouse-diagram hotspots come from Logi metadata; if the metadata omits a button
   marker, omit the button — never synthesize hotspot positions.
 - Keep render helpers statically typed (`impl IntoElement` or a concrete element) until
@@ -100,3 +102,8 @@ paths:
 - Verifying UI changes needs the running app: re-`cargo run -p openlogi-desktop` (a plain
   `cargo build` leaves the dev bundle stale) after quitting the previous instance
   (singleton lock). The GUI shows only the empty state unless the agent is running.
+- A visible UI change is not accepted from compile/tests alone. Run the real app through
+  each representative affected state, inspect a fresh screenshot, and attach it for
+  review. State any OS or hardware state that was not exercised. Screenshots catch
+  layout/theme regressions; an exercised behavior or focused test is still the proof
+  of behavior.

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -3,7 +3,10 @@ paths:
   - "crates/openlogi-ui/locales/**"
   - "crates/openlogi-ui/src/catalog_parity.rs"
   - "crates/openlogi-core/src/locale.rs"
+  - "crates/openlogi-desktop/src/main.rs"
   - "crates/openlogi-desktop/src/services/i18n.rs"
+  - "crates/openlogi-overlay/src/main.rs"
+  - "crates/openlogi-agent/src/main.rs"
   - ".config/crowdin.yml"
   - ".github/scripts/i18n/**"
   - ".github/workflows/crowdin.yml"
@@ -14,7 +17,7 @@ paths:
 - **`locales/en.yml` is the English source of truth** (the English text IS the
   key). When adding or changing copy, add the **same key to every**
   `locales/<code>.yml` in the same change, at the **same position** — position is
-  a convention (it keeps the 20 catalogs diff-aligned), the key set is what the
+  a convention (it keeps all catalogs diff-aligned), the key set is what the
   parity test enforces.
 - Values for non-English locales may be a best-effort translation (or temporarily
   match English when no better string is ready). Crowdin improves them later;

--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -137,6 +137,10 @@ Encode invariants in the type system instead of checking them at runtime:
 - Caches and leases do not extend a lifecycle they merely borrow. Their cleanup is
   RAII, and reusable leases return only after dependent workers and OS handles have
   shut down.
+- Native events improve freshness but are not completeness proofs. When an event source
+  can be unavailable, coalesced, or dropped, keep bounded reconciliation, a timeout or
+  watchdog, or last-good replay as the liveness path; the reconciled probe remains the
+  authority.
 - Libraries return `thiserror` types; binaries may use `anyhow`.
 
 House style:
@@ -169,7 +173,9 @@ House style:
   with full force.
 - Keep files reasonably sized (split around ~500 lines) into real modules — never
   simulate structure with `// ---- section ----` banner comments. But don't
-  over-extract either: inline single-use helpers.
+  over-extract either: inline single-use helpers. File size, coverage, and complexity
+  metrics are investigation signals, not abstraction targets; extract a reusable
+  responsibility or invariant, never a single-use layer solely to improve a number.
 - rustdoc every public item. Comments state non-obvious constraints only.
 - Tests cover failure and edge paths, not just the happy path (state machines
   especially). No tautological tests that mirror the implementation; never weaken an

--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -27,9 +27,11 @@ All of these lines are `debug`-level except the open failure, which is a
 middle row — in such a log, the absence of the other lines is not evidence
 of anything.
 
-`openlogi list` showing the device while the GUI does not is **not** evidence
-either way: the CLI is a separate code-signing identity running its own HID
-stack, so it can succeed where the agent fails, for either reason.
+`openlogi list` first asks the running agent. When it prints
+`(inventory read from the running agent)`, it observes the same device-I/O owner
+as the GUI. Only `(no agent reachable — reading hardware directly...)` means
+the CLI is using its separate TCC identity. Record that provenance before
+drawing a permission conclusion.
 
 If there is no log at all, go to §3 — getting a log is the whole job.
 
@@ -42,7 +44,7 @@ permissions.
 |---|---|---|
 | `org.openlogi.agent` | `…/Contents/Library/LoginItems/OpenLogi Agent.app` | **Input Monitoring** (opens HID) and **Accessibility** (owns the event tap) |
 | `org.openlogi.openlogi` | `…/Contents/MacOS/openlogi-desktop` | Camera only. It is a pure IPC client and needs neither of the above. |
-| `openlogi` | `…/Contents/MacOS/openlogi` (embedded CLI) | Input Monitoring, because it opens HID directly today |
+| `openlogi` | `…/Contents/MacOS/openlogi` (embedded CLI) | Input Monitoring only for direct fallback and hardware diagnostic commands |
 | `org.openlogi.overlay` | `…/LoginItems/OpenLogiOverlay.app` | Nothing |
 
 Two consequences that drive most reports:
@@ -142,9 +144,11 @@ every grant on that machine is being ignored.
 
 ## 6. Invariants — do not break these
 
-1. **Only the agent holds device permissions.** Any UI that reports permission
-   state must read it from the agent over IPC, never by querying its own
-   process. The GUI never opens a HID device, so its own grant means nothing.
+1. **Only the agent holds the app runtime's device permissions.** Any UI that
+   reports permission state must read it from the agent over IPC, never by
+   querying its own process. The GUI never opens a HID device, so its own grant
+   means nothing. A CLI direct fallback or diagnostic uses the CLI's separate
+   identity and says nothing about the agent's grant.
 2. **Every helper launch establishes its own responsible process** (§4), and the
    spawn result is checked — a silently failed `disclaim` leaves the agent
    running under the GUI's identity, which is invisible until a user reports it.
@@ -159,13 +163,13 @@ every grant on that machine is being ignored.
    process happens to be running. A TCC grant is scoped to the identity that
    asked.
 
-## 7. Known-broken right now
+## 7. Check current evidence
 
-Nothing in the launch, permission-reporting, or diagnosis path is known
-broken right now: the Settings row reads the agent's own grant over IPC
-(#606), the agent writes a log file (§3), open failures classify themselves
-(§1), and the `open -g -n` handoff checks its exit status. This is a
-snapshot — re-check the tracker before telling anyone a gap is still open.
+Do not carry a "currently fixed/broken" snapshot in this skill. Search the
+current tracker and identify the reporter's release before answering. An open
+report is a claim, not a root cause: classify it with §1 logs and the actual
+running identity. Re-check the current state of linked upstream transport
+issues before attributing a probe timeout to them.
 
 ## 8. What this cannot fix
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,12 @@ touching an area.
 
 ## Architecture
 
-Three tiers ship in one install: the **GUI** is a pure IPC client, the **agent** is a
-background server owning the input hook and ALL device I/O, and shared orchestration
-sits beneath both.
+The long-lived app has three tiers: the **GUI** is a pure IPC client, the **agent** is
+the background server owning the input hook and runtime device I/O, and shared
+orchestration sits beneath both. The CLI is the explicit diagnostic exception:
+`openlogi list` reads the running agent first and falls back to direct enumeration
+only when no compatible agent answers, while hardware diagnostic commands may access
+devices directly.
 
 | Crate | Role |
 |---|---|
@@ -24,10 +27,12 @@ sits beneath both.
 | `crates/openlogi-core` | Pure types: TOML config, device model, action catalog, locale negotiation. No I/O, no async (feature-gated host reads: `fs`, `locale`) |
 | `crates/openlogi-device-registry` | Pure hardware identity registry: receiver protocols and standalone-device driver metadata |
 | `crates/openlogi-hidpp` | Vendored fork of the `hidpp` protocol crate (**lib name `hidpp`**, 0BSD) |
+| `crates/openlogi-hidpp-derive` | Derive macros used by the HID++ hard fork; changes share the hidpp lint and rustdoc contract |
 | `crates/openlogi-device` | The HID++ device layer: enumeration, probing, writes, sessions, pairing. Knows no host — expressed against `HidBackend` |
 | `crates/openlogi-hid` | That layer wired to this host: `async-hid` transport, macOS Input Monitoring, the on-disk probe cache |
 | `crates/openlogi-assets` | Device-render registry + cached fetch from OpenLogi asset mirrors |
-| `crates/openlogi-cli` | `clap` command tree: `list`, `assets`, `diag` |
+| `crates/openlogi-camera` | Camera enumeration, capture, and UVC controls through platform-native backends |
+| `crates/openlogi-cli` | The `clap` command tree: inventory, diagnostics, device control, cameras, and assets |
 | `crates/openlogi-hook` | OS input capture: CGEventTap / evdev+uinput / WH_MOUSE_LL |
 | `crates/openlogi-inject` | OS input synthesis: CGEvent / uinput+MPRIS / SendInput |
 | `crates/openlogi-agent-core` | Shared agent orchestration: hook runtime, HID++ writes, DPI cycle, Actions Ring session state |
@@ -48,9 +53,20 @@ sits beneath both.
   added there lands in the overlay too (`.claude/rules/gui.md` has the rule).
 - Platform code is cfg-gated per crate (`[target.'cfg(target_os = …)'.dependencies]`).
   `.claude/rules/objc-ffi.md` is the contract for the workspace's macOS native FFI and
-  indexes every file that carries any — read it before editing one. That surface spans
-  seven crates: the agent's tray, the camera backends, the hook, the injector, the
-  overlay, `openlogi-permissions`, and one file in the GUI.
+  the canonical inventory of every file that carries any — read it before editing one
+  and keep that table in sync instead of duplicating a crate count here.
+
+## Decision and external-state discipline
+
+- Treat issue reports and review findings as claims. Verify them against the current
+  head and the most direct available evidence before changing code or replying; do not
+  implement a stale or inapplicable diagnosis.
+- Fix the verified root cause. Do not add compatibility shims, fallback state, or
+  abstractions that merely hide a broken owner or lifecycle.
+- External writes require explicit authorization for that specific step: pushes and
+  force-pushes, workflow approvals or re-runs, merges, releases, issue or PR comments,
+  and infrastructure or data writes. Read-only inspection and authorization for an
+  earlier step do not authorize the next one.
 
 ## Build, run, verify
 
@@ -199,8 +215,10 @@ backstop, not a substitute for running the gate yourself after a rebase.
    `cargo test -p openlogi-ipc --test wire_format` green — see
    `crates/openlogi-ipc/AGENTS.md`.
 6. If locales changed: every `crates/openlogi-ui/locales/*.yml` carries the same keys
-   as `en.yml` (new keys at the same position); run
-   `cargo test -p openlogi-desktop i18n` — see `.claude/rules/i18n.md`.
+   as `en.yml` (new keys at the same position) and
+   `cargo test -p openlogi-ui locale` is green. If catalog wiring or desktop key
+   resolution changed, also run `cargo test -p openlogi-desktop i18n` — see
+   `.claude/rules/i18n.md`.
 7. Only then `git push` / force-push to the PR branch.
 
 ### Running the app
@@ -302,14 +320,14 @@ before editing that area.
 | any `*.rs` / `Cargo.toml` (workspace Rust standards) | `.claude/rules/rust.md` |
 | `crates/openlogi-desktop/**`, `crates/openlogi-ui/**`, `crates/openlogi-overlay/**` (GPUI) | `.claude/rules/gui.md` |
 | `crates/openlogi-desktop/**` (that crate's own contract and map) | `crates/openlogi-desktop/AGENTS.md` |
-| `crates/openlogi-ui/locales/**`, `openlogi-ui/src/locale.rs`, `openlogi-desktop/src/services/i18n.rs` | `.claude/rules/i18n.md` |
+| locale catalogs/negotiation and each binary's `rust_i18n::i18n!` wiring | `.claude/rules/i18n.md` |
 | `crates/openlogi-ipc/**`, plus every crate whose serde types ride the wire (`openlogi-agent-core`, `openlogi-agent`, `openlogi-core`, `openlogi-hid`) | `crates/openlogi-ipc/AGENTS.md` |
-| `crates/openlogi-hook/**`, `crates/openlogi-inject/**`, `crates/openlogi-hid/**` (cfg-gated platform code) | `.claude/rules/cross-platform.md` |
+| cfg-gated platform code, including hook/inject/hid, camera, and agent autostart/resume | `.claude/rules/cross-platform.md` |
 | `crates/openlogi-hidpp/**` (hard fork of `hidpp`) | `crates/openlogi-hidpp/AGENTS.md` |
 | `crates/openlogi-device/**`, `crates/openlogi-hid/**` (the HID++ layer seam) | `crates/openlogi-device/AGENTS.md` |
 | `crates/openlogi-hook/**` (event taps) | `crates/openlogi-hook/AGENTS.md` |
 | `xtask/**`, `packaging/**`, `.github/scripts/**` | `xtask/AGENTS.md` (+ `xtask/README.md`) |
-| macOS native FFI wherever it lives — `openlogi-{agent,camera,hook,inject,overlay,permissions}` + `openlogi-desktop/src/platform/**` | `.claude/rules/objc-ffi.md` |
+| macOS native FFI (the rule carries the canonical path inventory) | `.claude/rules/objc-ffi.md` |
 
 ## Task skills — invoke when the task matches, not when a path matches
 

--- a/crates/openlogi-desktop/AGENTS.md
+++ b/crates/openlogi-desktop/AGENTS.md
@@ -41,14 +41,15 @@ Two more things this crate is not:
 | `runtime.rs` | Everything the app does that isn't a render: one task, one `select!` arm per source that can change long-lived state (agent updates, camera scan, asset commands, finished downloads, `openlogi://` deeplinks). |
 | `app.rs`, `app/` | The main window's shell — home gallery, device detail, menu bar, status line, deeplink handling. |
 | `windows.rs`, `windows/` | The windows themselves plus the registry that keeps each a singleton. About and Updates are **pages inside Settings**, not windows of their own. |
-| `features/` | One module per device-feature panel: `mouse`, `pointer`, `keyboard`, `lighting`, `camera`, `action_ring`, `profile_scope`. |
+| `features/` | One module per device-feature panel: `mouse`, `pointer`, `keyboard`, `lighting`, `camera`, `action_ring`, `profiles`. |
 | `state.rs`, `state/` | `AppState`, the GPUI global every view reads. Anything two views share belongs here; per-component scratch (hover index, open popover) stays in the owning entity. |
 | `services/` | Infrastructure, not UI: the IPC client, asset resolution and download, device reads, diagnostics, i18n. |
 | `ui/` | Shared components and the hand-painted `Palette` (`theme.rs`). |
 | `platform/` | OS integration — app icon, OS facts, updater. |
 | `app_assets.rs` | The GPUI asset source, composed in order: embedded logo → `openlogi-ui`'s `action-icons/` → gpui-component's bundled lucide set. A new icon path that resolves nowhere renders blank rather than failing to build. |
 
-Panels gate on `Capabilities`, never on device `kind`; commits go through
+Panels gate on measured or last-good `Capabilities`; the sole kind-derived fallback
+for a never-probed offline device stays centralized in `tabs_for`. Commits go through
 `AppState`, never straight to `Config`. Both rules are spelled out in
 `.claude/rules/gui.md`.
 

--- a/crates/openlogi-device/AGENTS.md
+++ b/crates/openlogi-device/AGENTS.md
@@ -16,16 +16,20 @@ owns the layer. `crates/openlogi-hid/AGENTS.md` points back here.
 - `openlogi-hidpp` (lib name `hidpp`, 0BSD) is a **hard fork**, not a tracked vendor
   copy — read `crates/openlogi-hidpp/AGENTS.md` before touching that crate. Its own
   rules (protocol facts from official specs, typed wire values end to end) live there
-  now, not here, to keep this file to the `openlogi-hid` side only.
+  now, not here, to keep this file to the device-layer seam only.
 - Device "kind" flows through four incompatible vocabularies (Bolt pairing register,
   feature `0x0005` `DeviceType` — defined in `openlogi-hidpp` — the assets-registry
   string, and `openlogi_core::device::DeviceKind`) — the same small integers mean
   different things in each. Never cross them by raw value; convert at the boundary.
-  `kind` is identity-only; capability decisions come from the feature table.
+  `kind` is identity-only. Capability decisions use a live feature-table probe or the
+  last-good capabilities retained by the cache. The sole kind-derived fallback is
+  `Capabilities::presumed_from_kind` for a device that has never been probed and is
+  currently offline; keep it centralized and do not add new `kind` gates.
 - The Agent's persistent enumerator is event-first: OS hotplug and HID++ lifecycle
-  notifications request authoritative reconciliation, while a named low-frequency
-  recovery scan covers missed/unsupported events and non-broadcast battery features.
-  Cache/ledger grace keeps sleeping or briefly unreachable devices visible. Changes to
-  probing must preserve last-good replay, bounded repair, and channel retirement/reopen
-  ordering — run the inventory/watcher tests and inspect partial-failure paths, not just
-  clean enumeration.
+  notifications are identity-free hints that request authoritative full
+  re-enumeration. A named low-frequency recovery scan covers missed/unsupported events
+  and non-broadcast battery features. Cache/ledger grace keeps sleeping or briefly
+  unreachable devices visible. Changes to probing must preserve last-good replay,
+  bounded repair, and channel retirement/reopen ordering — run the inventory/watcher
+  tests and cover event bursts or loss, partial failure, and recovery, not just clean
+  enumeration.

--- a/crates/openlogi-hidpp/AGENTS.md
+++ b/crates/openlogi-hidpp/AGENTS.md
@@ -23,10 +23,9 @@ about licensing or attribution:
   crate's protocol knowledge came from even as the code itself moves away from
   upstream's structure.
 - `[lib] name = "hidpp"` in `Cargo.toml`. Every consumer imports it as
-  `use hidpp::...` — as of this writing that's 30+ files, all in
-  `crates/openlogi-hid/src/**`, plus a doctest in this crate's own `src/lib.rs`.
-  Renaming the lib target is not a documentation-only change: it means touching
-  every one of those call sites in the same commit. Don't do it as a drive-by.
+  `use hidpp::...` across `openlogi-device`, `openlogi-hid`, and doctests. Renaming
+  the lib target is not a documentation-only change: derive the current call-site
+  set with `rg` and update all of it in the same commit. Don't do it as a drive-by.
 
 ## Rules that hold regardless of fork/vendor status
 

--- a/xtask/src/commands/ci/jobs.rs
+++ b/xtask/src/commands/ci/jobs.rs
@@ -29,8 +29,7 @@ pub(crate) enum Job {
     CargoDeny,
     ClippyWindows,
     Wasm,
-    /// Locale parity. Part of `tests (macos)`, and the suite Linux CI cannot
-    /// run because it excludes `openlogi-desktop`.
+    /// Portable locale parity plus the desktop end-to-end key-resolution tests.
     I18n,
     /// The bincode/tarpc golden wire format. Part of the test jobs.
     Wire,
@@ -146,7 +145,7 @@ impl Job {
                 prefix: None,
                 hosts: &[Host::Linux],
                 in_default_run: true,
-                caveat: "Excludes openlogi-desktop, so the i18n locale-parity tests never run on Linux CI.",
+                caveat: "Excludes openlogi-desktop, but still runs openlogi-ui's portable locale-parity test. Only the desktop end-to-end key-resolution tests are absent.",
             },
             Self::TestsMacos => Spec {
                 name: "tests (macos)",
@@ -185,7 +184,7 @@ impl Job {
             Self::I18n => focused_spec(
                 "i18n",
                 &[],
-                "Locale parity. Part of tests (macos), and the suite Linux CI cannot run because it excludes openlogi-desktop.",
+                "Portable catalog parity plus desktop end-to-end key resolution. Linux CI runs the first through openlogi-ui; macOS CI runs both.",
             ),
             Self::Wire => focused_spec(
                 "wire_format",

--- a/xtask/src/commands/ci/jobs/steps.rs
+++ b/xtask/src/commands/ci/jobs/steps.rs
@@ -160,7 +160,10 @@ pub(super) fn plan(job: Job, sh: &Shell, host: Host) -> Result<Plan> {
         Job::Wasm => wasm(job, sh),
         Job::I18n => Ok(Plan::run(
             job,
-            [Step::new("cargo").args(["test", "-p", "openlogi-desktop", "i18n"])],
+            [
+                Step::new("cargo").args(["test", "-p", "openlogi-ui", "locale"]),
+                Step::new("cargo").args(["test", "-p", "openlogi-desktop", "i18n"]),
+            ],
         )),
         Job::Wire => Ok(Plan::run(
             job,

--- a/xtask/src/commands/ci/jobs/tests.rs
+++ b/xtask/src/commands/ci/jobs/tests.rs
@@ -189,6 +189,25 @@ fn the_default_run_is_the_ci_jobs_only() {
     }
 }
 
+#[test]
+fn i18n_runs_portable_parity_before_desktop_resolution() {
+    let sh = Shell::new().expect("a shell");
+    let plan = Job::I18n
+        .plan(&sh, Host::Linux)
+        .expect("the focused i18n plan");
+    let Action::Run(steps) = plan.action else {
+        panic!("i18n planned no steps");
+    };
+    let commands: Vec<String> = steps.iter().map(super::super::Step::argv_line).collect();
+    assert_eq!(
+        commands,
+        [
+            "cargo test -p openlogi-ui locale",
+            "cargo test -p openlogi-desktop i18n",
+        ]
+    );
+}
+
 /// The host lists are what decides a skip, so they are worth stating: on a
 /// `cfg!` these were only ever evaluated on the host that made them true.
 #[test]


### PR DESCRIPTION
## Summary

- align repository agent guidance with the current architecture, lifecycle, capability, permission, and review contracts
- make the focused i18n gate prove portable catalog parity before desktop key resolution

## Changes

- **Agent guidance:** clarify device-I/O ownership and CLI exceptions, live/last-good capability authority, event-driven reconciliation and recovery, GUI evidence requirements, and per-step external-write authorization
- **Scoped rules:** update i18n and cross-platform path coverage, remove volatile snapshots, and correct stale crate/path facts
- **CI tooling:** run the portable `openlogi-ui` locale test in the focused i18n plan before the desktop test, with a regression test for the exact command order

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo test -p xtask`
- `cargo xtask ci --dry-run i18n`
- `cargo xtask ci i18n`
- `cargo run -p xtask -- linux package` with nfpm 2.47.0 on `PATH` (produced `.deb`, `.rpm`, and `.pkg.tar.zst`)
- not runtime-tested on hardware; this changes guidance and CI orchestration only