### PR TITLE
fix(macos): prevent HID activity from promoting DarkWake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,6 +5060,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.1",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
@@ -5388,6 +5389,7 @@ dependencies = [
  "interprocess",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "opener",
  "openlogi-agent-core",

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 
 use openlogi_core::config::Lighting;
 use openlogi_hid::{
-    CaptureChannel, ChannelRegistry, DeviceRoute, Dpi, HidppOperation, ScrollResolution,
-    SharedChannel, SmartShiftStatus, WriteError,
+    CaptureChannel, ChannelRegistry, DeviceIoGate, DeviceRoute, Dpi, HidppOperation,
+    ScrollResolution, SharedChannel, SmartShiftStatus, WriteError,
 };
 use tokio::time::error::Elapsed;
 use tracing::{debug, warn};
@@ -79,6 +79,7 @@ pub struct DeviceOp<'a> {
     capture: &'a CaptureChannel,
     registry: &'a ChannelRegistry,
     receiver_access: &'a ReceiverAccess,
+    device_io: &'a DeviceIoGate,
     route: DeviceRoute,
 }
 
@@ -87,12 +88,14 @@ impl<'a> DeviceOp<'a> {
         capture: &'a CaptureChannel,
         registry: &'a ChannelRegistry,
         receiver_access: &'a ReceiverAccess,
+        device_io: &'a DeviceIoGate,
         route: &DeviceRoute,
     ) -> Self {
         Self {
             capture,
             registry,
             receiver_access,
+            device_io,
             route: route.clone(),
         }
     }
@@ -102,6 +105,9 @@ impl<'a> DeviceOp<'a> {
     /// more than one write (the volatile-settings reapply sequence) resolve
     /// once up front through this instead of [`Self::run`]/[`Self::detach`].
     fn resolve(&self) -> Result<SharedChannel, WriteError> {
+        if !self.device_io.allows_io() {
+            return Err(WriteError::DeviceNotFound);
+        }
         authoritative_channel(Some(self.capture), self.registry, &self.route)
     }
 
@@ -123,6 +129,9 @@ impl<'a> DeviceOp<'a> {
         F: FnOnce(SharedChannel) -> Fut,
         Fut: Future<Output = Result<T, WriteError>>,
     {
+        if !self.device_io.allows_io() {
+            return Err(WriteError::DeviceNotFound);
+        }
         let _lease = self.receiver_access.acquire_for_io().await;
         let shared = self.resolve()?;
         timed(op, f(shared)).await
@@ -178,15 +187,26 @@ impl<'a> DeviceOp<'a> {
             return;
         };
         let receiver_access = self.receiver_access.clone();
+        let device_io = self.device_io.clone();
         std::thread::spawn(move || {
             let Some(rt) = one_shot_runtime(label) else {
                 return;
             };
             let result = rt.block_on(async {
                 let _lease = receiver_access.acquire_for_io().await;
-                tokio::time::timeout(WRITE_BUDGET, f(shared)).await
+                if !device_io.allows_io() {
+                    return None;
+                }
+                Some(tokio::time::timeout(WRITE_BUDGET, f(shared)).await)
             });
-            log(result);
+            if let Some(result) = result {
+                log(result);
+            } else {
+                debug!(
+                    label,
+                    "host device I/O suspended — background write skipped"
+                );
+            }
         });
     }
 }
@@ -215,6 +235,7 @@ pub fn toggle_smartshift_in_background(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
     receiver_access: &ReceiverAccess,
+    device_io: &DeviceIoGate,
     target: Option<DeviceRoute>,
 ) {
     let Some(target) = target else {
@@ -222,7 +243,7 @@ pub fn toggle_smartshift_in_background(
         return;
     };
     let index = target.device_index();
-    DeviceOp::new(capture, registry, receiver_access, &target).spawn_write(
+    DeviceOp::new(capture, registry, receiver_access, device_io, &target).spawn_write(
         "SmartShift toggle",
         |c| async move { openlogi_hid::toggle_smartshift_on(&c).await },
         move |result| match result {
@@ -282,6 +303,7 @@ pub fn reapply_mouse_volatile_in_background(
         return;
     };
     let receiver_access = op.receiver_access.clone();
+    let device_io = op.device_io.clone();
     let index = op.route.device_index();
     std::thread::spawn(move || {
         let Some(rt) = one_shot_runtime("volatile reapply") else {
@@ -289,6 +311,13 @@ pub fn reapply_mouse_volatile_in_background(
         };
         rt.block_on(async {
             let _lease = receiver_access.acquire_for_io().await;
+            if !device_io.allows_io() {
+                debug!(
+                    index,
+                    "host device I/O suspended — volatile reapply skipped"
+                );
+                return;
+            }
             if resolution.is_some() || inverted.is_some() {
                 let result = tokio::time::timeout(WRITE_BUDGET, async {
                     apply_wheel_mode(&shared, resolution, inverted).await
@@ -386,6 +415,7 @@ pub fn write_dpi_in_background(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
     receiver_access: &ReceiverAccess,
+    device_io: &DeviceIoGate,
     target: Option<DeviceRoute>,
     dpi: Dpi,
 ) {
@@ -394,7 +424,7 @@ pub fn write_dpi_in_background(
         return;
     };
     let index = target.device_index();
-    DeviceOp::new(capture, registry, receiver_access, &target).spawn_write(
+    DeviceOp::new(capture, registry, receiver_access, device_io, &target).spawn_write(
         "DPI write",
         move |c| async move { openlogi_hid::set_dpi_on(&c, dpi).await },
         move |result| match result {
@@ -520,6 +550,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
+    use openlogi_hid::device_io_channel;
 
     #[test]
     fn current_capture_wins_without_consulting_the_registry_again() {
@@ -569,11 +600,12 @@ mod tests {
         let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
         let registry = ChannelRegistry::default();
         let receiver_access = ReceiverAccess::default();
+        let (_device_io_signal, device_io) = device_io_channel();
         let route = unresolvable_route();
         let called = std::sync::Arc::new(AtomicBool::new(false));
         let called_for_closure = std::sync::Arc::clone(&called);
 
-        let result = DeviceOp::new(&capture, &registry, &receiver_access, &route)
+        let result = DeviceOp::new(&capture, &registry, &receiver_access, &device_io, &route)
             .run(HidppOperation::WriteDpi, move |_shared| {
                 called_for_closure.store(true, Ordering::SeqCst);
                 async move { Ok::<(), WriteError>(()) }
@@ -587,6 +619,40 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn run_while_device_io_is_suspended_does_not_wait_for_a_receiver_or_call_f() {
+        let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
+        let registry = ChannelRegistry::default();
+        let receiver_access = ReceiverAccess::default();
+        let (device_io_signal, device_io) = device_io_channel();
+        let route = unresolvable_route();
+        let called = std::sync::Arc::new(AtomicBool::new(false));
+        let called_for_closure = std::sync::Arc::clone(&called);
+        let _exclusive = receiver_access
+            .acquire_exclusive(crate::receiver_access::ExclusiveAccessReason::Pairing)
+            .await;
+        assert!(device_io_signal.suspend());
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(10),
+            DeviceOp::new(&capture, &registry, &receiver_access, &device_io, &route).run(
+                HidppOperation::WriteDpi,
+                move |_shared| {
+                    called_for_closure.store(true, Ordering::SeqCst);
+                    async move { Ok::<(), WriteError>(()) }
+                },
+            ),
+        )
+        .await
+        .expect("a suspended operation must fail before waiting for receiver access");
+
+        assert!(matches!(result, Err(WriteError::DeviceNotFound)));
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "the write closure must not run while host device I/O is suspended",
+        );
+    }
+
     /// `DeviceOp::detach` resolves before spawning, so a registry miss must
     /// return synchronously (no thread, no lease wait) and never call `f`.
     #[tokio::test]
@@ -594,11 +660,12 @@ mod tests {
         let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
         let registry = ChannelRegistry::default();
         let receiver_access = ReceiverAccess::default();
+        let (_device_io_signal, device_io) = device_io_channel();
         let route = unresolvable_route();
         let called = std::sync::Arc::new(AtomicBool::new(false));
         let called_for_closure = std::sync::Arc::clone(&called);
 
-        DeviceOp::new(&capture, &registry, &receiver_access, &route).detach(
+        DeviceOp::new(&capture, &registry, &receiver_access, &device_io, &route).detach(
             "test write",
             move |_shared| {
                 called_for_closure.store(true, Ordering::SeqCst);

--- a/crates/openlogi-agent-core/src/hardware/light.rs
+++ b/crates/openlogi-agent-core/src/hardware/light.rs
@@ -8,8 +8,8 @@ use std::thread;
 use openlogi_core::config::LightSettings;
 use openlogi_core::device::LightCapabilities;
 use openlogi_hid::{
-    DeviceRoute, HidppOperation, LightCommand, WriteError, commands_for_light_settings,
-    litra_model_for_route,
+    DeviceIoGate, DeviceRoute, HidppOperation, LightCommand, WriteError,
+    commands_for_light_settings, litra_model_for_route,
 };
 use tracing::{debug, info, warn};
 
@@ -17,6 +17,7 @@ struct LightApplyRequest {
     settings: LightSettings,
     capabilities: LightCapabilities,
     generation: u64,
+    device_io: DeviceIoGate,
 }
 
 #[derive(Clone)]
@@ -44,6 +45,7 @@ static LIGHT_WRITE_LOCKS: LazyLock<Mutex<HashMap<String, LightWriteLock>>> =
 /// Failures are logged because this path is best-effort; an explicit IPC
 /// command returns the typed error to the caller instead.
 pub fn set_light_in_background(
+    device_io: &DeviceIoGate,
     target: Option<DeviceRoute>,
     light: &LightSettings,
     capabilities: LightCapabilities,
@@ -63,6 +65,7 @@ pub fn set_light_in_background(
             settings: *light,
             capabilities,
             generation,
+            device_io: device_io.clone(),
         })
         .is_err()
     {
@@ -152,12 +155,17 @@ fn light_worker_loop(
             debug!(route = %target, "skipping superseded light re-apply");
             continue;
         }
+        if !request.device_io.allows_io() {
+            debug!(route = %target, "host device I/O suspended — light re-apply skipped");
+            continue;
+        }
         let result = rt.block_on(apply_light_settings(
             &target,
             &request.settings,
             request.capabilities,
             &generation,
             request.generation,
+            &request.device_io,
         ));
         match result {
             Ok(true) => info!(
@@ -179,6 +187,7 @@ async fn apply_light_settings(
     capabilities: LightCapabilities,
     generation: &AtomicU64,
     expected_generation: u64,
+    device_io: &DeviceIoGate,
 ) -> Result<bool, WriteError> {
     let lock = light_write_lock(target);
     let _guard = lock.lock().await;
@@ -189,15 +198,28 @@ async fn apply_light_settings(
         return Ok(false);
     }
     for command in commands_for_light_settings(*light, capabilities) {
+        if !device_io.allows_io() {
+            return Ok(false);
+        }
         apply_light_unlocked(target, command).await?;
     }
     Ok(true)
 }
 
 /// Apply a semantic command to a supported standalone light.
-pub async fn apply_light(route: &DeviceRoute, command: LightCommand) -> Result<(), WriteError> {
+pub async fn apply_light(
+    device_io: &DeviceIoGate,
+    route: &DeviceRoute,
+    command: LightCommand,
+) -> Result<(), WriteError> {
+    if !device_io.allows_io() {
+        return Err(WriteError::DeviceNotFound);
+    }
     let lock = light_write_lock(route);
     let _guard = lock.lock().await;
+    if !device_io.allows_io() {
+        return Err(WriteError::DeviceNotFound);
+    }
     apply_light_unlocked(route, command).await
 }
 

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -23,7 +23,7 @@ use openlogi_core::device::{
 };
 use openlogi_core::device_order::{DeviceIdentity, DeviceStableId, PhysicalDeviceKey};
 use openlogi_hid::{
-    CaptureChannel, ChannelPool, ChannelRegistry, DIRECT_DEVICE_INDEX, DeviceRoute,
+    CaptureChannel, ChannelPool, ChannelRegistry, DIRECT_DEVICE_INDEX, DeviceIoGate, DeviceRoute,
     KEYBOARD_KEY_CIDS,
 };
 use openlogi_ipc::InventoryHealth;
@@ -89,6 +89,8 @@ pub struct SharedRuntime {
     pub capture_channel: CaptureChannel,
     /// Exact-route channels owned and published by the inventory enumerator.
     pub channel_registry: ChannelRegistry,
+    /// Host-lifecycle gate shared by every producer of proactive device I/O.
+    pub device_io: DeviceIoGate,
     /// Shared transport pool used by long-running host-switch sessions.
     pub channel_pool: ChannelPool,
     /// The keyboard key-capture watcher's target + bindings, `None` while no
@@ -118,6 +120,7 @@ impl SharedRuntime {
             &self.capture_channel,
             &self.channel_registry,
             &self.receiver_access,
+            &self.device_io,
             route,
         )
     }
@@ -131,6 +134,7 @@ impl SharedRuntime {
             &self.keyboard_channel,
             &self.channel_registry,
             &self.receiver_access,
+            &self.device_io,
             route,
         )
     }
@@ -221,6 +225,7 @@ impl Orchestrator {
             capture_plans,
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: ChannelRegistry::default(),
+            device_io: openlogi_hid::host::device_io_gate(),
             channel_pool: openlogi_hid::host::channel_pool(),
             keyboard_spec,
             keyboard_channel: Arc::new(RwLock::new(None)),
@@ -580,7 +585,12 @@ impl Orchestrator {
         if let Some(capabilities) = dev.light_capabilities
             && let Some(light) = self.effective_light_settings(key)
         {
-            crate::hardware::set_light_in_background(Some(route), &light, capabilities);
+            crate::hardware::set_light_in_background(
+                &self.shared.device_io,
+                Some(route),
+                &light,
+                capabilities,
+            );
         }
     }
 
@@ -610,7 +620,12 @@ impl Orchestrator {
                 continue;
             };
             light.enabled = active;
-            crate::hardware::set_light_in_background(dev.route.clone(), &light, capabilities);
+            crate::hardware::set_light_in_background(
+                &self.shared.device_io,
+                dev.route.clone(),
+                &light,
+                capabilities,
+            );
             applied += 1;
         }
         info!(previous = ?previous, active, lights = applied, "applied camera-linked light state");
@@ -865,7 +880,12 @@ impl Orchestrator {
                 self.effective_light_settings(&dev.config_key),
                 dev.light_capabilities,
             ) {
-                crate::hardware::set_light_in_background(dev.route.clone(), &light, capabilities);
+                crate::hardware::set_light_in_background(
+                    &self.shared.device_io,
+                    dev.route.clone(),
+                    &light,
+                    capabilities,
+                );
             }
         }
     }

--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{Action, Binding, ButtonId};
-use openlogi_hid::{CaptureChannel, ChannelRegistry};
+use openlogi_hid::{CaptureChannel, ChannelRegistry, DeviceIoGate};
 use tracing::{info, warn};
 
 use self::button::{
@@ -62,6 +62,7 @@ struct ActionExecutor {
     capture: CaptureChannel,
     registry: ChannelRegistry,
     receiver_access: ReceiverAccess,
+    device_io: DeviceIoGate,
     action_ring: tokio::sync::mpsc::UnboundedSender<Option<String>>,
 }
 
@@ -106,6 +107,7 @@ impl ActionExecutor {
                     &self.capture,
                     &self.registry,
                     &self.receiver_access,
+                    &self.device_io,
                     target,
                 );
                 return;
@@ -135,6 +137,7 @@ impl ActionExecutor {
                 &self.capture,
                 &self.registry,
                 &self.receiver_access,
+                &self.device_io,
                 target,
                 dpi,
             );
@@ -217,6 +220,7 @@ impl ActionRuntime {
         capture: CaptureChannel,
         registry: ChannelRegistry,
         receiver_access: ReceiverAccess,
+        device_io: DeviceIoGate,
         action_ring: tokio::sync::mpsc::UnboundedSender<Option<String>>,
     ) -> io::Result<Self> {
         let executor = ActionExecutor {
@@ -224,6 +228,7 @@ impl ActionRuntime {
             capture,
             registry,
             receiver_access,
+            device_io,
             action_ring,
         };
         let mut button_handler = ButtonEventHandler::new(executor.clone());

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 use openlogi_core::device_order::PhysicalDeviceKey;
 use openlogi_core::scroll::ScrollDelta;
 use openlogi_hid::{
-    CaptureChannel, CaptureSessionOutcome, CapturedInput, PendingCaptureRestore,
+    CaptureChannel, CaptureSessionOutcome, CapturedInput, DeviceIoGate, PendingCaptureRestore,
     run_capture_session_with_registry_spec,
 };
 use tokio::sync::{mpsc, oneshot, watch};
@@ -82,6 +82,7 @@ pub fn spawn(
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
     channel_registry: openlogi_hid::ChannelRegistry,
+    device_io: DeviceIoGate,
     outputs: GestureOutputs,
 ) {
     let plans = capture_plans.clone();
@@ -103,6 +104,7 @@ pub fn spawn(
             receiver_access,
             receiver_requests,
             channel_registry,
+            device_io,
             outputs,
         ));
     });
@@ -145,6 +147,7 @@ struct SessionChannels {
     events: mpsc::UnboundedSender<SessionEvent>,
     capture: CaptureChannel,
     registry: openlogi_hid::ChannelRegistry,
+    device_io: DeviceIoGate,
 }
 
 /// Forward one capture session's inputs onto the manager's ordered event
@@ -297,10 +300,11 @@ async fn retry_pending_restores(
 
 fn next_deadline(
     requests: ReceiverRequestState,
+    device_io_allowed: bool,
     pending_restores: &HashMap<PhysicalDeviceKey, PendingRestore>,
     restart_after: &HashMap<PhysicalDeviceKey, Instant>,
 ) -> Option<Instant> {
-    if requests.any() {
+    if requests.any() || !device_io_allowed {
         return None;
     }
     pending_restores
@@ -325,8 +329,13 @@ impl GestureManagerState {
         }
     }
 
-    fn deadline(&self, requests: ReceiverRequestState) -> Option<Instant> {
-        next_deadline(requests, &self.pending_restores, &self.restart_after)
+    fn deadline(&self, requests: ReceiverRequestState, device_io_allowed: bool) -> Option<Instant> {
+        next_deadline(
+            requests,
+            device_io_allowed,
+            &self.pending_restores,
+            &self.restart_after,
+        )
     }
 
     fn expedite_pending_restores(&mut self) {
@@ -339,10 +348,18 @@ impl GestureManagerState {
     async fn reconcile(
         &mut self,
         requests: ReceiverRequestState,
+        device_io_allowed: bool,
         published: &Arc<Vec<DeviceCapturePlan>>,
         receiver_access: &ReceiverAccess,
         channels: &SessionChannels,
     ) {
+        // Keep existing passive listeners and their firmware ownership intact
+        // while the display/session is asleep. Retiring them here would issue
+        // restoration writes during DarkWake; retries and successors wait for
+        // the user-visible resume instead.
+        if !device_io_allowed {
+            return;
+        }
         let now = Instant::now();
         let wanted = if requests.any() {
             &[][..]
@@ -400,6 +417,76 @@ impl GestureManagerState {
             self.sessions.insert(key.clone(), session);
         }
     }
+
+    fn handle_session_event(
+        &mut self,
+        event: SessionEvent,
+        device_io_allowed: bool,
+        receiver_requests: &watch::Receiver<ReceiverRequestState>,
+        capture_plans: &watch::Receiver<Arc<Vec<DeviceCapturePlan>>>,
+    ) -> bool {
+        match event {
+            SessionEvent::Input(event) => {
+                let key = &event.physical_key;
+                if device_io_allowed && let Some(session) = self.sessions.get_mut(key) {
+                    reconcile_published_session(
+                        key,
+                        session,
+                        receiver_requests,
+                        capture_plans,
+                        &mut self.input_dispatcher,
+                    );
+                }
+                let live = self.sessions.get(key);
+                let dispatch_context = dispatch_context_for(&event.session, live);
+                if let Some((session, plan)) = dispatch_context {
+                    self.input_dispatcher.dispatch(session, plan, event.input);
+                } else {
+                    self.input_dispatcher.cancel_session(&event.session);
+                    debug!(
+                        key = key.as_str(),
+                        epoch = event.session.epoch(),
+                        "input from a stale capture session — ignored"
+                    );
+                }
+                false
+            }
+            SessionEvent::Done(done) => {
+                let key = &done.physical_key;
+                // Completion is queued behind every input the listener
+                // accepted during restoration, so cancellation cannot
+                // overtake the last diverted edge.
+                let Some((CompletionAction::Remove { unexpected }, dispatch_session)) = self
+                    .sessions
+                    .get(key)
+                    .map(|session| (session.completion(&done.session), session.id().clone()))
+                else {
+                    return false;
+                };
+                if let Some(pending) = done.pending_restore {
+                    self.pending_restores.insert(
+                        key.clone(),
+                        PendingRestore {
+                            token: pending,
+                            retry_at: Instant::now() + RETRY_DELAY,
+                        },
+                    );
+                }
+                self.input_dispatcher.cancel_session(&dispatch_session);
+                if device_io_allowed
+                    && let Some(deadline) = restart_deadline(unexpected, Instant::now())
+                {
+                    self.restart_after.insert(key.clone(), deadline);
+                    warn!(
+                        key = key.as_str(),
+                        "capture session ended unexpectedly, delaying re-arm"
+                    );
+                }
+                self.sessions.remove(key);
+                true
+            }
+        }
+    }
 }
 
 /// Keep one capture session alive per online device, restarting a session when
@@ -411,6 +498,7 @@ async fn manage(
     receiver_access: ReceiverAccess,
     mut receiver_requests: watch::Receiver<ReceiverRequestState>,
     channel_registry: openlogi_hid::ChannelRegistry,
+    mut device_io: DeviceIoGate,
     outputs: GestureOutputs,
 ) {
     let (events, mut event_rx) = mpsc::unbounded_channel::<SessionEvent>();
@@ -426,6 +514,7 @@ async fn manage(
         events,
         capture: capture_channel,
         registry: channel_registry,
+        device_io: device_io.clone(),
     };
     let mut state = GestureManagerState::new(outputs);
     let mut reconcile = true;
@@ -433,15 +522,24 @@ async fn manage(
     loop {
         if reconcile {
             reconcile = false;
-            let requests = *receiver_requests.borrow_and_update();
-            let published = Arc::clone(&capture_plans.borrow_and_update());
-            state
-                .reconcile(requests, &published, &receiver_access, &channels)
-                .await;
+            let device_io_allowed = device_io.allows_io();
+            if device_io_allowed {
+                let requests = *receiver_requests.borrow_and_update();
+                let published = Arc::clone(&capture_plans.borrow_and_update());
+                state
+                    .reconcile(
+                        requests,
+                        device_io_allowed,
+                        &published,
+                        &receiver_access,
+                        &channels,
+                    )
+                    .await;
+            }
         }
 
         let requests = *receiver_requests.borrow();
-        let deadline = state.deadline(requests);
+        let deadline = state.deadline(requests, device_io.allows_io());
         if deadline.is_some_and(|deadline| deadline <= Instant::now()) {
             reconcile = true;
             continue;
@@ -449,56 +547,12 @@ async fn manage(
 
         tokio::select! {
             Some(event) = event_rx.recv() => {
-                match event {
-                    SessionEvent::Input(event) => {
-                        let key = &event.physical_key;
-                        if let Some(session) = state.sessions.get_mut(key) {
-                            reconcile_published_session(
-                                key,
-                                session,
-                                &receiver_requests,
-                                &capture_plans,
-                                &mut state.input_dispatcher,
-                            );
-                        }
-                        let live = state.sessions.get(key);
-                        let dispatch_context = dispatch_context_for(&event.session, live);
-                        if let Some((session, plan)) = dispatch_context {
-                            state.input_dispatcher.dispatch(session, plan, event.input);
-                        } else {
-                            state.input_dispatcher.cancel_session(&event.session);
-                            debug!(key = key.as_str(), epoch = event.session.epoch(), "input from a stale capture session — ignored");
-                        }
-                    }
-                    SessionEvent::Done(done) => {
-                        let key = &done.physical_key;
-                        // Completion is queued behind every input the listener
-                        // accepted during restoration, so cancellation cannot
-                        // overtake the last diverted edge.
-                        if let Some((CompletionAction::Remove { unexpected }, dispatch_session)) =
-                            state.sessions.get(key).map(|session| {
-                                (session.completion(&done.session), session.id().clone())
-                            })
-                        {
-                            if let Some(pending) = done.pending_restore {
-                                state.pending_restores.insert(
-                                    key.clone(),
-                                    PendingRestore {
-                                        token: pending,
-                                        retry_at: Instant::now() + RETRY_DELAY,
-                                    },
-                                );
-                            }
-                            state.input_dispatcher.cancel_session(&dispatch_session);
-                            if let Some(deadline) = restart_deadline(unexpected, Instant::now()) {
-                                state.restart_after.insert(key.clone(), deadline);
-                                warn!(key = key.as_str(), "capture session ended unexpectedly, delaying re-arm");
-                            }
-                            state.sessions.remove(key);
-                            reconcile = true;
-                        }
-                    }
-                }
+                reconcile |= state.handle_session_event(
+                    event,
+                    device_io.allows_io(),
+                    &receiver_requests,
+                    &capture_plans,
+                );
             }
             result = capture_plans.changed() => match result {
                 Ok(()) => reconcile = true,
@@ -508,6 +562,11 @@ async fn manage(
                 Ok(()) => reconcile = true,
                 Err(_) => return,
             },
+            allowed = device_io.changed() => match allowed {
+                Some(true) => reconcile = true,
+                Some(false) => {}
+                None => return,
+            },
             open = wait_for_registry_change(
                 &mut registry_changes,
                 !state.pending_restores.is_empty(),
@@ -515,8 +574,10 @@ async fn manage(
                 if !open {
                     return;
                 }
-                state.expedite_pending_restores();
-                reconcile = true;
+                if device_io.allows_io() {
+                    state.expedite_pending_restores();
+                    reconcile = true;
+                }
             }
             () = wait_for_deadline(deadline) => {
                 reconcile = true;
@@ -554,6 +615,7 @@ fn spawn_session(
     let session_spec = target.spec.clone();
     let slot = Arc::clone(&channels.capture);
     let registry = channels.registry.clone();
+    let device_io = channels.device_io.clone();
     tokio::spawn(async move {
         let _lease = lease;
         let pending_restore = match run_capture_session_with_registry_spec(
@@ -563,6 +625,7 @@ fn spawn_session(
             stop_rx,
             slot,
             &registry,
+            device_io,
         )
         .await
         {

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -98,6 +98,32 @@ async fn retry_deadline_is_not_postponed_by_ready_input() {
     );
 }
 
+#[test]
+fn suspended_device_io_disables_retry_deadlines() {
+    let retry_at = Instant::now() + RETRY_DELAY;
+    let restart_after = HashMap::from([(physical_key(), retry_at)]);
+
+    assert_eq!(
+        next_deadline(
+            ReceiverRequestState::default(),
+            true,
+            &HashMap::new(),
+            &restart_after,
+        ),
+        Some(retry_at),
+    );
+    assert_eq!(
+        next_deadline(
+            ReceiverRequestState::default(),
+            false,
+            &HashMap::new(),
+            &restart_after,
+        ),
+        None,
+        "capture retries must stay dormant until visible resume",
+    );
+}
+
 #[tokio::test]
 async fn input_accepted_during_restoration_precedes_session_done() {
     let id = session_id(7);

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -4,7 +4,8 @@ use std::thread;
 use std::time::Duration;
 
 use openlogi_hid::{
-    ChannelPool, DeviceRoute, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
+    ChannelPool, DeviceIoGate, DeviceRoute, HostSwitchStopReason, run_host_switch_session,
+    switch_linked_hosts,
 };
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::Instant;
@@ -29,7 +30,12 @@ pub struct HostSwitchLink {
 pub type HostSwitchLinks = watch::Receiver<std::sync::Arc<Vec<HostSwitchLink>>>;
 
 /// Spawn the host switch session manager.
-pub fn spawn(links: &HostSwitchLinks, channel_pool: ChannelPool, receiver_access: ReceiverAccess) {
+pub fn spawn(
+    links: &HostSwitchLinks,
+    channel_pool: ChannelPool,
+    receiver_access: ReceiverAccess,
+    device_io: DeviceIoGate,
+) {
     let links = links.clone();
     let receiver_requests = receiver_access.subscribe_requests();
     thread::spawn(move || {
@@ -48,6 +54,7 @@ pub fn spawn(links: &HostSwitchLinks, channel_pool: ChannelPool, receiver_access
             channel_pool,
             receiver_access,
             receiver_requests,
+            device_io,
         ));
     });
 }
@@ -67,8 +74,8 @@ impl HostSwitchManagerState {
         }
     }
 
-    fn deadline(&self, requests: ReceiverRequestState) -> Option<Instant> {
-        if requests.any() {
+    fn deadline(&self, requests: ReceiverRequestState, device_io_allowed: bool) -> Option<Instant> {
+        if requests.any() || !device_io_allowed {
             return None;
         }
         self.restart_after
@@ -84,7 +91,14 @@ impl HostSwitchManagerState {
         receiver_access: &ReceiverAccess,
         channel_pool: &ChannelPool,
         done: &mpsc::UnboundedSender<SessionCompletion>,
+        device_io: &DeviceIoGate,
     ) {
+        // Keep armed listeners passive while sleeping. A reconcile to an
+        // empty/changed link set would restore firmware controls and a retry
+        // would reopen the HID transport during DarkWake.
+        if !device_io.allows_io() {
+            return;
+        }
         let now = Instant::now();
         let wanted = if requests.any() {
             &[][..]
@@ -115,6 +129,7 @@ impl HostSwitchManagerState {
                 receiver_lease,
                 channel_pool.clone(),
                 done.clone(),
+                device_io.clone(),
             ));
         }
     }
@@ -125,6 +140,7 @@ async fn manage(
     channel_pool: ChannelPool,
     receiver_access: ReceiverAccess,
     mut receiver_requests: watch::Receiver<ReceiverRequestState>,
+    mut device_io: DeviceIoGate,
 ) {
     let (done_tx, mut done_rx) = mpsc::unbounded_channel::<SessionCompletion>();
     let mut state = HostSwitchManagerState::new();
@@ -133,21 +149,25 @@ async fn manage(
     loop {
         if reconcile {
             reconcile = false;
-            let requests = *receiver_requests.borrow_and_update();
-            let published = std::sync::Arc::clone(&links.borrow_and_update());
-            state
-                .reconcile(
-                    requests,
-                    &published,
-                    &receiver_access,
-                    &channel_pool,
-                    &done_tx,
-                )
-                .await;
+            let device_io_allowed = device_io.allows_io();
+            if device_io_allowed {
+                let requests = *receiver_requests.borrow_and_update();
+                let published = std::sync::Arc::clone(&links.borrow_and_update());
+                state
+                    .reconcile(
+                        requests,
+                        &published,
+                        &receiver_access,
+                        &channel_pool,
+                        &done_tx,
+                        &device_io,
+                    )
+                    .await;
+            }
         }
 
         let requests = *receiver_requests.borrow();
-        let deadline = state.deadline(requests);
+        let deadline = state.deadline(requests, device_io.allows_io());
         if deadline.is_some_and(|deadline| deadline <= Instant::now()) {
             reconcile = true;
             continue;
@@ -162,9 +182,19 @@ async fn manage(
                     let completed = state.sessions.remove(index);
                     let _ = completed.task.await;
                     if let Some((link, host)) = completion.request {
+                        if !device_io.wait_until_allowed().await {
+                            return;
+                        }
                         stop_all(&mut state.sessions, HostSwitchStopReason::Graceful).await;
-                        run_transition(&mut links, &channel_pool, &receiver_access, link, host).await;
-                    } else {
+                        run_transition(
+                            &mut links,
+                            &channel_pool,
+                            &receiver_access,
+                            link,
+                            host,
+                        )
+                        .await;
+                    } else if device_io.allows_io() {
                         state.restart_after.push((completed.link, Instant::now() + RETRY_DELAY));
                     }
                     reconcile = true;
@@ -182,6 +212,11 @@ async fn manage(
                 }
                 reconcile = true;
             }
+            allowed = device_io.changed() => match allowed {
+                Some(true) => reconcile = true,
+                Some(false) => {}
+                None => return,
+            },
             () = wait_for_deadline(deadline) => {
                 reconcile = true;
             }
@@ -203,6 +238,7 @@ fn spawn_session(
     receiver_lease: crate::receiver_access::SessionReceiverLease,
     pool: ChannelPool,
     done: mpsc::UnboundedSender<SessionCompletion>,
+    device_io: DeviceIoGate,
 ) -> RunningSession {
     let (stop, stop_rx) = oneshot::channel();
     let session_link = link.clone();
@@ -210,7 +246,9 @@ fn spawn_session(
         let _receiver_lease = receiver_lease;
         let keyboard = session_link.keyboard.clone();
         let request =
-            match run_host_switch_session(session_link.keyboard.clone(), stop_rx, pool).await {
+            match run_host_switch_session(session_link.keyboard.clone(), stop_rx, pool, device_io)
+                .await
+            {
                 Ok(host) => host.map(|host| (session_link, host)),
                 Err(error) => {
                     debug!(%error, route = %keyboard, "host switch session ended");
@@ -323,6 +361,29 @@ mod tests {
             receiver_uid: "cafe".to_owned(),
             slot,
         }
+    }
+
+    #[test]
+    fn suspended_device_io_disables_retry_deadlines() {
+        let retry_at = Instant::now() + RETRY_DELAY;
+        let mut state = HostSwitchManagerState::new();
+        state.restart_after.push((
+            HostSwitchLink {
+                keyboard: route(1),
+                targets: vec![route(2)],
+            },
+            retry_at,
+        ));
+
+        assert_eq!(
+            state.deadline(ReceiverRequestState::default(), true),
+            Some(retry_at),
+        );
+        assert_eq!(
+            state.deadline(ReceiverRequestState::default(), false),
+            None,
+            "host-switch retries must stay dormant until visible resume",
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -14,7 +14,7 @@ use std::time::{Instant, SystemTime};
 
 use futures_lite::StreamExt as _;
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
-use openlogi_hid::ChannelRegistry;
+use openlogi_hid::{ChannelRegistry, DeviceIoGate};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -61,41 +61,6 @@ pub enum InventoryEvent {
     /// set/route/online state looks unchanged across the gap, so the agent
     /// re-applies volatile settings on the next snapshot (#189).
     SystemWake,
-}
-
-/// Non-blocking producer for native OS resume callbacks.
-#[derive(Clone)]
-pub struct ResumeSignal {
-    sender: mpsc::Sender<()>,
-}
-
-/// Single-consumer stream of coalesced native OS resume transitions.
-pub struct ResumeEvents {
-    receiver: mpsc::Receiver<()>,
-}
-
-/// Create the directional native-resume channel.
-///
-/// Capacity one intentionally coalesces the equivalent wake, screen-wake, and
-/// session-active bursts some operating systems emit for one resume.
-#[must_use]
-pub fn resume_channel() -> (ResumeSignal, ResumeEvents) {
-    let (sender, receiver) = mpsc::channel(1);
-    (ResumeSignal { sender }, ResumeEvents { receiver })
-}
-
-impl ResumeSignal {
-    /// Publish one native resume transition without blocking the OS callback.
-    pub fn notify(&self) {
-        let _ = self.sender.try_send(());
-    }
-}
-
-impl ResumeEvents {
-    /// Wait for one resume transition. `None` means every producer was dropped.
-    pub async fn recv(&mut self) -> Option<()> {
-        self.receiver.recv().await
-    }
 }
 
 /// The watcher's cross-pass memory, factored out of the I/O loop so the
@@ -277,23 +242,17 @@ enum RefreshRequest {
 /// Spawn a watcher without publishing channels into a registry.
 #[must_use]
 pub fn spawn() -> InventoryWatcher {
-    spawn_inner(None, None)
+    spawn_inner(None, openlogi_hid::host::device_io_gate())
 }
 
 /// Spawn the persistent watcher, publish its already-open HID++ channels into
-/// `registry`, and consume a coalesced native-resume signal.
+/// `registry`, and stop active reconciliation while host device I/O is gated.
 #[must_use]
-pub fn spawn_with_registry(
-    registry: ChannelRegistry,
-    resume_events: ResumeEvents,
-) -> InventoryWatcher {
-    spawn_inner(Some(registry), Some(resume_events))
+pub fn spawn_with_registry(registry: ChannelRegistry, device_io: DeviceIoGate) -> InventoryWatcher {
+    spawn_inner(Some(registry), device_io)
 }
 
-fn spawn_inner(
-    registry: Option<ChannelRegistry>,
-    resume_events: Option<ResumeEvents>,
-) -> InventoryWatcher {
+fn spawn_inner(registry: Option<ChannelRegistry>, device_io: DeviceIoGate) -> InventoryWatcher {
     let (event_tx, event_rx) = mpsc::unbounded_channel();
     let worker_tx = event_tx.clone();
     let (refresh_tx, refresh_rx) = mpsc::channel(1);
@@ -310,7 +269,7 @@ fn spawn_inner(
                     return;
                 }
             };
-            rt.block_on(run_watcher(worker_tx, refresh_rx, registry, resume_events));
+            rt.block_on(run_watcher(worker_tx, refresh_rx, registry, device_io));
         });
     if let Err(e) = spawn_result {
         // OS thread / fork limits are non-fatal for the agent as a whole, but
@@ -330,7 +289,7 @@ async fn run_watcher(
     events: mpsc::UnboundedSender<InventoryEvent>,
     refresh_requests: mpsc::Receiver<RefreshRequest>,
     registry: Option<ChannelRegistry>,
-    resume_events: Option<ResumeEvents>,
+    device_io: DeviceIoGate,
 ) {
     // The listener is attached to each inventory-owned channel before its
     // first probe, and its bounded queue is subscribed before every snapshot.
@@ -360,7 +319,7 @@ async fn run_watcher(
         hid_events,
         schedule: Schedule::new(now),
         wake_detector: WakeDetector::new(SystemTime::now(), now),
-        resume_events,
+        device_io,
         refresh_open: true,
     }
     .run()
@@ -376,7 +335,7 @@ struct InventoryWorker {
     hid_events: openlogi_hid::inventory::events::EventReceiver,
     schedule: Schedule,
     wake_detector: WakeDetector,
-    resume_events: Option<ResumeEvents>,
+    device_io: DeviceIoGate,
     refresh_open: bool,
 }
 
@@ -384,8 +343,17 @@ impl InventoryWorker {
     async fn run(&mut self) {
         let mut trigger = ReconcileTrigger::Initial;
         loop {
+            if !self.device_io.allows_io() {
+                if !self.device_io.wait_until_allowed().await {
+                    return;
+                }
+                trigger = ReconcileTrigger::SystemResume;
+            }
             if !self.settle_trigger(trigger).await || !self.reconcile(trigger).await {
                 return;
+            }
+            if !self.device_io.allows_io() {
+                continue;
             }
             trigger = self.next_trigger().await;
         }
@@ -441,6 +409,13 @@ impl InventoryWorker {
             }
             Err(error) => (self.state.classify(Err(error)), true),
         };
+        if !self.device_io.allows_io() {
+            debug!(
+                ?trigger,
+                "device I/O suspended during inventory reconciliation — result discarded"
+            );
+            return true;
+        }
         if let Some(event) = event
             && self.events.send(event).is_err()
         {
@@ -473,16 +448,13 @@ impl InventoryWorker {
                 Some(source) = self.hid_events.recv() => {
                     break ReconcileTrigger::HidEvent(source);
                 }
-                resumed = async {
-                    match self.resume_events.as_mut() {
-                        Some(events) => events.recv().await,
-                        None => pending().await,
-                    }
-                } => {
-                    if resumed.is_some() {
+                allowed = self.device_io.changed() => {
+                    if allowed == Some(false) && self.device_io.wait_until_allowed().await {
                         break ReconcileTrigger::SystemResume;
                     }
-                    self.resume_events = None;
+                    if allowed == Some(true) {
+                        break ReconcileTrigger::SystemResume;
+                    }
                 }
                 request = async {
                     if self.refresh_open {
@@ -517,7 +489,8 @@ impl InventoryWorker {
         // unavailable without restoring a dedicated wake-check timer. A
         // SystemResume reconciliation is already authoritative, so replacing
         // another trigger loses no inventory work.
-        if trigger != ReconcileTrigger::SystemResume
+        if !cfg!(target_os = "macos")
+            && trigger != ReconcileTrigger::SystemResume
             && self
                 .wake_detector
                 .observe(SystemTime::now(), Instant::now())
@@ -532,26 +505,11 @@ impl InventoryWorker {
 #[cfg(test)]
 mod tests {
     use std::assert_matches;
-    use std::time::Duration;
 
     use openlogi_core::device::{DeviceKind, RawDeviceAddress, StandaloneDevice};
     use openlogi_hid::{BackendError, InventoryError};
 
-    use super::{INITIAL_FAILURE_LIMIT, InventoryEvent, WatchState, resume_channel};
-
-    #[tokio::test]
-    async fn resume_signal_retains_and_coalesces_native_callbacks() {
-        let (signal, mut events) = resume_channel();
-        signal.notify();
-        signal.notify();
-        tokio::time::timeout(Duration::from_secs(1), events.recv())
-            .await
-            .expect("a callback before the waiter is retained")
-            .expect("the signal producer remains alive");
-        tokio::time::timeout(Duration::from_millis(10), events.recv())
-            .await
-            .expect_err("equivalent callbacks coalesce into one resume");
-    }
+    use super::{INITIAL_FAILURE_LIMIT, InventoryEvent, WatchState};
 
     /// A transport-level enumerate failure — what the watcher's `Err` arm now
     /// sees (a partial per-node read is replayed by the hid ledger as `Ok`).

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -18,8 +18,8 @@ use std::time::Duration;
 
 use openlogi_core::binding::{Binding, ButtonId};
 use openlogi_hid::{
-    CaptureChannel, CaptureSessionOutcome, CapturedInput, ChannelRegistry, DeviceRoute,
-    PendingCaptureRestore, run_keyboard_capture_session_with_registry,
+    CaptureChannel, CaptureSessionOutcome, CapturedInput, ChannelRegistry, DeviceIoGate,
+    DeviceRoute, PendingCaptureRestore, run_keyboard_capture_session_with_registry,
 };
 use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, info, warn};
@@ -102,6 +102,7 @@ struct KeyboardManagerState {
 struct KeyboardSessionChannels {
     capture: CaptureChannel,
     registry: ChannelRegistry,
+    device_io: DeviceIoGate,
     events: mpsc::UnboundedSender<KeyboardSessionEvent>,
 }
 
@@ -115,6 +116,7 @@ pub fn spawn(
     keyboard_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
     registry: ChannelRegistry,
+    device_io: DeviceIoGate,
     dispatcher: ActionDispatcher,
 ) {
     let spec = spec.clone();
@@ -136,6 +138,7 @@ pub fn spawn(
             receiver_access,
             receiver_requests,
             registry,
+            device_io,
             dispatcher,
         ));
     });
@@ -222,16 +225,19 @@ impl KeyboardManagerState {
         }
     }
 
-    fn deadline(&self, requests: ReceiverRequestState) -> Option<tokio::time::Instant> {
-        if requests.any() {
-            return None;
-        }
-        self.pending_restore
-            .as_ref()
-            .map(|pending| pending.retry_at)
-            .into_iter()
-            .chain(self.restart_at)
-            .min()
+    fn deadline(
+        &self,
+        requests: ReceiverRequestState,
+        device_io_allowed: bool,
+    ) -> Option<tokio::time::Instant> {
+        next_deadline(
+            requests,
+            device_io_allowed,
+            self.pending_restore
+                .as_ref()
+                .map(|pending| pending.retry_at),
+            self.restart_at,
+        )
     }
 
     fn expedite_pending_restore(&mut self) {
@@ -243,11 +249,18 @@ impl KeyboardManagerState {
     async fn reconcile(
         &mut self,
         requests: ReceiverRequestState,
+        device_io_allowed: bool,
         published: bool,
         wanted: Option<(KeyboardTarget, KeyboardDispatchPlan)>,
         receiver_access: &ReceiverAccess,
         channels: &KeyboardSessionChannels,
     ) {
+        // Preserve the passive listener and diverted-key ownership across
+        // display sleep. Stopping or retrying it while suspended would issue
+        // the same proactive HID writes that can promote macOS DarkWake.
+        if !device_io_allowed {
+            return;
+        }
         let now = tokio::time::Instant::now();
         if !published {
             self.restart_at = None;
@@ -295,6 +308,81 @@ impl KeyboardManagerState {
             self.restart_at = Some(now + RETRY_DELAY);
         }
     }
+
+    fn handle_session_event(
+        &mut self,
+        event: KeyboardSessionEvent,
+        device_io_allowed: bool,
+        receiver_requests: &watch::Receiver<ReceiverRequestState>,
+        spec: &watch::Receiver<Option<Arc<KeyboardSpec>>>,
+    ) -> bool {
+        match event {
+            KeyboardSessionEvent::Input(input) => {
+                if device_io_allowed {
+                    let wanted = wanted_session(*receiver_requests.borrow(), spec);
+                    if let Some(running) = self.current.as_mut() {
+                        reconcile_session(running, wanted.as_ref(), &self.dispatcher);
+                    }
+                }
+
+                let Some(running) = self
+                    .current
+                    .as_ref()
+                    .filter(|running| running.owns(&input.session))
+                else {
+                    self.dispatcher.cancel_hidpp_session(&input.session);
+                    debug!(
+                        epoch = input.session.epoch(),
+                        "input from a stale keyboard session — ignored"
+                    );
+                    return false;
+                };
+                dispatch_input(
+                    running.id(),
+                    input.input,
+                    running.dispatch(),
+                    &self.dispatcher,
+                );
+                false
+            }
+            KeyboardSessionEvent::Done(done) => {
+                // Input and Done share this queue, and the forwarding task is
+                // drained before Done is sent. A tracked draining session
+                // therefore remains the sole input owner until firmware
+                // restoration is complete.
+                let Some((CompletionAction::Remove { unexpected }, dispatch_session)) = self
+                    .current
+                    .as_ref()
+                    .map(|running| (running.completion(&done.session), running.id().clone()))
+                else {
+                    return false;
+                };
+                self.dispatcher.cancel_hidpp_session(&dispatch_session);
+                self.pending_restore = done.pending_restore.map(|token| PendingRestore {
+                    token,
+                    retry_at: tokio::time::Instant::now() + RETRY_DELAY,
+                });
+                if unexpected && device_io_allowed {
+                    self.restart_at = Some(tokio::time::Instant::now() + RETRY_DELAY);
+                    warn!("keyboard capture session ended unexpectedly, delaying re-arm");
+                }
+                self.current = None;
+                true
+            }
+        }
+    }
+}
+
+fn next_deadline(
+    requests: ReceiverRequestState,
+    device_io_allowed: bool,
+    pending_restore: Option<tokio::time::Instant>,
+    restart_at: Option<tokio::time::Instant>,
+) -> Option<tokio::time::Instant> {
+    if requests.any() || !device_io_allowed {
+        return None;
+    }
+    pending_restore.into_iter().chain(restart_at).min()
 }
 
 /// Keep one keyboard capture session alive for the published spec, restarting
@@ -306,6 +394,7 @@ async fn manage(
     receiver_access: ReceiverAccess,
     mut receiver_requests: watch::Receiver<ReceiverRequestState>,
     registry: ChannelRegistry,
+    mut device_io: DeviceIoGate,
     dispatcher: ActionDispatcher,
 ) {
     let (events, mut event_rx) = mpsc::unbounded_channel::<KeyboardSessionEvent>();
@@ -313,6 +402,7 @@ async fn manage(
     let channels = KeyboardSessionChannels {
         capture: keyboard_channel,
         registry,
+        device_io: device_io.clone(),
         events,
     };
     let mut state = KeyboardManagerState::new(dispatcher);
@@ -321,22 +411,26 @@ async fn manage(
     loop {
         if reconcile {
             reconcile = false;
-            let requests = *receiver_requests.borrow_and_update();
-            let published = spec.borrow_and_update().clone();
-            let want = wanted_session_for(requests, published.as_deref());
-            state
-                .reconcile(
-                    requests,
-                    published.is_some(),
-                    want,
-                    &receiver_access,
-                    &channels,
-                )
-                .await;
+            let device_io_allowed = device_io.allows_io();
+            if device_io_allowed {
+                let requests = *receiver_requests.borrow_and_update();
+                let published = spec.borrow_and_update().clone();
+                let want = wanted_session_for(requests, published.as_deref());
+                state
+                    .reconcile(
+                        requests,
+                        device_io_allowed,
+                        published.is_some(),
+                        want,
+                        &receiver_access,
+                        &channels,
+                    )
+                    .await;
+            }
         }
 
         let requests = *receiver_requests.borrow();
-        let deadline = state.deadline(requests);
+        let deadline = state.deadline(requests, device_io.allows_io());
         if deadline.is_some_and(|deadline| deadline <= tokio::time::Instant::now()) {
             reconcile = true;
             continue;
@@ -344,52 +438,12 @@ async fn manage(
 
         tokio::select! {
             Some(event) = event_rx.recv() => {
-                match event {
-                    KeyboardSessionEvent::Input(input) => {
-                        let want = wanted_session(*receiver_requests.borrow(), &spec);
-                        if let Some(running) = state.current.as_mut() {
-                            reconcile_session(running, want.as_ref(), &state.dispatcher);
-                        }
-
-                        let Some(running) = state.current
-                            .as_ref()
-                            .filter(|running| running.owns(&input.session))
-                        else {
-                            state.dispatcher.cancel_hidpp_session(&input.session);
-                            debug!(epoch = input.session.epoch(), "input from a stale keyboard session — ignored");
-                            continue;
-                        };
-                        dispatch_input(
-                            running.id(),
-                            input.input,
-                            running.dispatch(),
-                            &state.dispatcher,
-                        );
-                    }
-                    KeyboardSessionEvent::Done(done) => {
-                        // Input and Done share this queue, and the forwarding
-                        // task is drained before Done is sent. A tracked
-                        // draining session therefore remains the sole input
-                        // owner until firmware restoration is complete.
-                        if let Some((CompletionAction::Remove { unexpected }, dispatch_session)) =
-                            state.current.as_ref().map(|running| {
-                                (running.completion(&done.session), running.id().clone())
-                            })
-                        {
-                            state.dispatcher.cancel_hidpp_session(&dispatch_session);
-                            state.pending_restore = done.pending_restore.map(|token| PendingRestore {
-                                token,
-                                retry_at: tokio::time::Instant::now() + RETRY_DELAY,
-                            });
-                            if unexpected {
-                                state.restart_at = Some(tokio::time::Instant::now() + RETRY_DELAY);
-                                warn!("keyboard capture session ended unexpectedly, delaying re-arm");
-                            }
-                            state.current = None;
-                            reconcile = true;
-                        }
-                    }
-                }
+                reconcile |= state.handle_session_event(
+                    event,
+                    device_io.allows_io(),
+                    &receiver_requests,
+                    &spec,
+                );
             }
             result = spec.changed() => match result {
                 Ok(()) => reconcile = true,
@@ -399,6 +453,11 @@ async fn manage(
                 Ok(()) => reconcile = true,
                 Err(_) => return,
             },
+            allowed = device_io.changed() => match allowed {
+                Some(true) => reconcile = true,
+                Some(false) => {}
+                None => return,
+            },
             open = wait_for_registry_change(
                 &mut registry_changes,
                 state.pending_restore.is_some(),
@@ -406,8 +465,10 @@ async fn manage(
                 if !open {
                     return;
                 }
-                state.expedite_pending_restore();
-                reconcile = true;
+                if device_io.allows_io() {
+                    state.expedite_pending_restore();
+                    reconcile = true;
+                }
             }
             () = wait_for_deadline(deadline) => {
                 reconcile = true;
@@ -459,6 +520,7 @@ fn spawn_session(
     let done_id = id.clone();
     let route = target.route.clone();
     let wanted = target.wanted.clone();
+    let device_io = channels.device_io.clone();
     tokio::spawn(async move {
         let _receiver_lease = receiver_lease;
         let pending_restore = match run_keyboard_capture_session_with_registry(
@@ -468,6 +530,7 @@ fn spawn_session(
             stop_rx,
             slot,
             &session_registry,
+            device_io,
         )
         .await
         {

--- a/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
@@ -128,3 +128,18 @@ fn target_changes_freeze_dispatch_until_teardown_finishes() {
     assert!(!session.is_active());
     assert_eq!(session.dispatch(), &old_dispatch);
 }
+
+#[test]
+fn suspended_device_io_disables_retry_deadlines() {
+    let retry_at = tokio::time::Instant::now() + RETRY_DELAY;
+
+    assert_eq!(
+        next_deadline(ReceiverRequestState::default(), true, None, Some(retry_at)),
+        Some(retry_at),
+    );
+    assert_eq!(
+        next_deadline(ReceiverRequestState::default(), false, None, Some(retry_at)),
+        None,
+        "keyboard retries must stay dormant until visible resume",
+    );
+}

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -48,6 +48,7 @@ embed-resource = "3.0.9"
 dispatch2 = "0.3.1"
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSRunningApplication", "NSWorkspace"] }
+objc2-core-graphics = { workspace = true, features = ["CGDirectDisplay", "CGDisplayConfiguration", "libc"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSData", "NSArray", "NSNotification"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -28,7 +28,7 @@ use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::runtime::hook;
 use openlogi_agent_core::watchers::foreground_app::ForegroundUpdate;
-use openlogi_agent_core::watchers::inventory::{InventoryEvent, InventoryRefresh, ResumeEvents};
+use openlogi_agent_core::watchers::inventory::{InventoryEvent, InventoryRefresh};
 use openlogi_core::config::Config;
 use openlogi_hook::Hook;
 use tokio::sync::Mutex;
@@ -54,7 +54,6 @@ const DORMANT_DEADLINE: Duration = Duration::from_secs(60);
 /// core's entry point; `main` only decides which thread it runs on.
 pub(crate) async fn run(
     config: Config,
-    resume_events: ResumeEvents,
     uninstalled: UnboundedReceiver<()>,
     #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
 ) {
@@ -64,7 +63,6 @@ pub(crate) async fn run(
 
     let Some(booted) = Booted::bootstrap(
         config,
-        resume_events,
         uninstalled,
         #[cfg(target_os = "macos")]
         armed_tx,
@@ -97,13 +95,11 @@ struct Booted {
     /// Releases the main thread's tray loop once the agent arms.
     #[cfg(target_os = "macos")]
     armed_tx: std::sync::mpsc::Sender<()>,
-    resume_events: ResumeEvents,
 }
 
 impl Booted {
     async fn bootstrap(
         config: Config,
-        resume_events: ResumeEvents,
         uninstalled: UnboundedReceiver<()>,
         #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
     ) -> Option<Self> {
@@ -121,7 +117,6 @@ impl Booted {
             launch_at_login,
             #[cfg(target_os = "macos")]
             armed_tx,
-            resume_events,
         })
     }
 
@@ -191,7 +186,6 @@ impl Wanted {
             capture_mouse_events,
             #[cfg(target_os = "macos")]
             armed_tx,
-            resume_events,
             ..
         } = self.0;
         #[cfg(target_os = "macos")]
@@ -212,7 +206,6 @@ impl Wanted {
         // the server's `declare_client` handler.
         drop(demand);
         Armed {
-            resume_events,
             running: Running {
                 orchestrator,
                 shared,
@@ -229,17 +222,14 @@ impl Wanted {
     }
 }
 
-/// An armed agent whose one-shot resume stream has not yet been handed to the
-/// inventory watcher.
+/// An armed agent ready to start its watcher fleets.
 struct Armed {
-    resume_events: ResumeEvents,
     running: Running,
 }
 
 /// The live agent state into which the select loop folds events.
-///
-/// Separate from [`Armed`] so starting the watcher structurally consumes the
-/// single-owner resume stream; no optional or already-consumed state exists.
+/// Separate from [`Armed`] so watcher startup and the steady-state event loop
+/// remain distinct lifecycle phases.
 struct Running {
     orchestrator: Arc<Mutex<Orchestrator>>,
     shared: SharedRuntime,
@@ -259,17 +249,13 @@ impl Armed {
     /// Start the watcher fleets, then drain every control-plane source until
     /// told to leave (low-frequency by contract — [`startup::WatcherEvent`]).
     async fn run(self) {
-        let Self {
-            resume_events,
-            mut running,
-        } = self;
+        let Self { mut running } = self;
         #[cfg(target_os = "macos")]
         request_input_monitoring().await;
 
         // HID++ watchers need no Accessibility — start them up front.
         startup::spawn_hidpp_watchers(&running.shared, &running.inputs);
-        let (mut watchers, inventory_refresh) =
-            startup::spawn_state_watchers(&running.shared, resume_events);
+        let (mut watchers, inventory_refresh) = startup::spawn_state_watchers(&running.shared);
 
         info!("openlogi-agent started");
         loop {

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -107,6 +107,11 @@ fn main() {
     let device_io_signal = openlogi_hid::host::device_io_signal();
     #[cfg(target_os = "macos")]
     {
+        // Fail closed before the core thread can enumerate or open HID devices.
+        // AppKit releases this startup hold only after its workspace observers
+        // have received the initial session state and Core Graphics has
+        // reported whether the display is already asleep.
+        let _ = device_io_signal.suspend();
         // Read the menu-bar preference before `config` moves into the core
         // thread; the main thread hosts the tray.
         let show_in_menu_bar = config.app_settings.show_in_menu_bar;

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -41,7 +41,6 @@ mod tray;
 #[cfg(target_os = "windows")]
 mod tray_windows;
 
-use openlogi_agent_core::watchers::inventory::resume_channel;
 use openlogi_core::config::Config;
 use tracing::{info, warn};
 
@@ -105,7 +104,7 @@ fn main() {
     // the process main thread — so the async core (orchestrator, IPC, watchers,
     // hook) runs on the tokio runtime on a dedicated thread, and the main thread
     // runs AppKit. Elsewhere there is no tray, so just block on the core.
-    let (resume_signal, resume_events) = resume_channel();
+    let device_io_signal = openlogi_hid::host::device_io_signal();
     #[cfg(target_os = "macos")]
     {
         // Read the menu-bar preference before `config` moves into the core
@@ -121,14 +120,14 @@ fn main() {
         if let Err(e) = std::thread::Builder::new()
             .name("openlogi-agent-core".into())
             .spawn(move || {
-                runtime.block_on(lifecycle::run(config, resume_events, uninstalled, armed_tx));
+                runtime.block_on(lifecycle::run(config, uninstalled, armed_tx));
             })
         {
             warn!(error = %e, "could not spawn the agent core thread; exiting");
             return;
         }
         if armed_rx.recv().is_ok() {
-            tray::run_app_loop(show_in_menu_bar, app_icon, resume_signal);
+            tray::run_app_loop(show_in_menu_bar, app_icon, device_io_signal);
         }
     }
     #[cfg(not(target_os = "macos"))]
@@ -141,13 +140,13 @@ fn main() {
             // Native resume notifications feed the same event seam as macOS
             // and Linux: inventory wakes immediately and replays volatile
             // settings on its settled authoritative snapshot.
-            resume_windows::register(resume_signal.clone());
+            resume_windows::register(device_io_signal.clone());
         }
         #[cfg(target_os = "linux")]
-        resume_linux::register(resume_signal.clone());
+        resume_linux::register(device_io_signal.clone());
         #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-        drop(resume_signal);
-        runtime.block_on(lifecycle::run(config, resume_events, uninstalled));
+        drop(device_io_signal);
+        runtime.block_on(lifecycle::run(config, uninstalled));
     }
 }
 

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -163,6 +163,9 @@ impl PairingManager {
 
     /// Begin a session: forget the previous discovery, pause capture, then start.
     pub async fn start(&self, selector: ReceiverSelector) -> Result<(), PairingCommandError> {
+        if !self.shared.device_io.allows_io() {
+            return Err(PairingCommandError::ReceiverBusy);
+        }
         let admission = match SessionAdmission::new(Arc::clone(&self.session)) {
             Ok(admission) => admission,
             Err(error) => {
@@ -411,6 +414,7 @@ mod tests {
             capture_plans,
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: openlogi_hid::ChannelRegistry::default(),
+            device_io: openlogi_hid::device_io_channel().1,
             channel_pool: openlogi_hid::host::channel_pool(),
             keyboard_spec,
             keyboard_channel: Arc::new(RwLock::new(None)),

--- a/crates/openlogi-agent/src/resume_linux.rs
+++ b/crates/openlogi-agent/src/resume_linux.rs
@@ -1,13 +1,14 @@
 //! Native Linux suspend/resume notifications from systemd-logind.
 //!
-//! `PrepareForSleep(false)` is emitted once the system has resumed. The
-//! process-lifetime listener reconnects only after D-Bus failure; steady state
-//! blocks on the native signal and performs no timed inventory work.
+//! `PrepareForSleep(true)` closes the device-I/O gate before suspend and
+//! `PrepareForSleep(false)` reopens it after resume. The process-lifetime
+//! listener reconnects only after D-Bus failure; steady state blocks on the
+//! native signal and performs no timed inventory work.
 
 use std::thread;
 use std::time::Duration;
 
-use openlogi_agent_core::watchers::inventory::ResumeSignal;
+use openlogi_hid::DeviceIoSignal;
 use tracing::{debug, info, warn};
 use zbus::blocking::Connection;
 use zbus::proxy;
@@ -28,7 +29,7 @@ trait LoginManager {
 
 /// Start a process-lifetime logind listener. Failure is non-fatal: the
 /// inventory recovery scan still detects long suspend gaps from the clocks.
-pub fn register(signal: ResumeSignal) {
+pub fn register(signal: DeviceIoSignal) {
     let spawned = thread::Builder::new()
         .name("openlogi-linux-resume".into())
         .spawn(move || {
@@ -60,22 +61,20 @@ pub fn register(signal: ResumeSignal) {
     }
 }
 
-fn listen(signal: &ResumeSignal) -> zbus::Result<()> {
+fn listen(signal: &DeviceIoSignal) -> zbus::Result<()> {
     let connection = Connection::system()?;
     let proxy = LoginManagerProxyBlocking::new(&connection)?;
     let changes = proxy.receive_prepare_for_sleep()?;
     info!("logind suspend/resume notifications registered");
     for change in changes {
         let args = change.args()?;
-        if is_resume_edge(*args.sleeping()) {
-            signal.notify();
+        if *args.sleeping() {
+            let _ = signal.suspend();
+        } else {
+            let _ = signal.resume();
         }
     }
     Ok(())
-}
-
-fn is_resume_edge(sleeping: bool) -> bool {
-    !sleeping
 }
 
 fn next_reconnect_delay(current: Duration) -> Duration {
@@ -84,13 +83,7 @@ fn next_reconnect_delay(current: Duration) -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_RECONNECT_DELAY, RECONNECT_DELAY, is_resume_edge, next_reconnect_delay};
-
-    #[test]
-    fn only_the_post_sleep_edge_is_resume() {
-        assert!(!is_resume_edge(true));
-        assert!(is_resume_edge(false));
-    }
+    use super::{MAX_RECONNECT_DELAY, RECONNECT_DELAY, next_reconnect_delay};
 
     #[test]
     fn reconnect_backoff_is_bounded() {

--- a/crates/openlogi-agent/src/resume_windows.rs
+++ b/crates/openlogi-agent/src/resume_windows.rs
@@ -20,7 +20,7 @@
 
 use std::ffi::c_void;
 
-use openlogi_agent_core::watchers::inventory::ResumeSignal;
+use openlogi_hid::DeviceIoSignal;
 use tracing::{info, warn};
 use windows_sys::Win32::System::Power::{
     DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS, RegisterSuspendResumeNotification,
@@ -30,10 +30,10 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 };
 
 /// Register for suspend/resume notifications for the process lifetime; the
-/// system invokes [`on_power_event`] and each resume notifies `signal`. Failure
-/// is logged, never fatal — the clock-gap heuristic still covers long
-/// sleeps.
-pub fn register(signal: ResumeSignal) {
+/// system invokes [`on_power_event`] and updates the process-wide device-I/O
+/// gate. Failure is logged, never fatal — the clock-gap heuristic still covers
+/// long sleeps.
+pub fn register(signal: DeviceIoSignal) {
     // Retained for the process lifetime on successful registration: the
     // callback may notify the signal until process exit.
     let context = Box::into_raw(Box::new(signal));
@@ -44,7 +44,7 @@ pub fn register(signal: ResumeSignal) {
         Callback: Some(on_power_event),
         Context: context.cast::<c_void>(),
     }));
-    // SAFETY: `params` and the `ResumeSignal` behind its context remain valid
+    // SAFETY: `params` and the `DeviceIoSignal` behind its context remain valid
     // for the call, and the callback matches
     // `PDEVICE_NOTIFY_CALLBACK_ROUTINE`. A successful subscription keeps both
     // allocations for the process lifetime below.
@@ -67,23 +67,28 @@ pub fn register(signal: ResumeSignal) {
 /// Whether a `PBT_*` power event means the system just resumed.
 /// `PBT_APMRESUMEAUTOMATIC` fires on every wake, `PBT_APMRESUMESUSPEND`
 /// additionally once user input confirms it — both can arrive for one wake,
-/// and the bounded resume channel coalesces them.
+/// and the latest-state device-I/O channel coalesces them.
 fn is_resume_event(event: u32) -> bool {
     matches!(event, PBT_APMRESUMEAUTOMATIC | PBT_APMRESUMESUSPEND)
 }
 
-/// Invoked by the system on an arbitrary thread; only attempts a non-blocking
-/// send to the bounded resume channel.
+/// Invoked by the system on an arbitrary thread; only updates the non-blocking
+/// latest-state device-I/O channel.
 unsafe extern "system" fn on_power_event(
     context: *const c_void,
     event: u32,
     _setting: *const c_void,
 ) -> u32 {
     if is_resume_event(event) {
-        // SAFETY: `context` is the `ResumeSignal` this module leaked at
+        // SAFETY: `context` is the `DeviceIoSignal` this module leaked at
         // registration, alive for the process lifetime.
-        let signal = unsafe { &*context.cast::<ResumeSignal>() };
-        signal.notify();
+        let signal = unsafe { &*context.cast::<DeviceIoSignal>() };
+        let _ = signal.resume();
+    } else if event == windows_sys::Win32::UI::WindowsAndMessaging::PBT_APMSUSPEND {
+        // SAFETY: `context` is the `DeviceIoSignal` this module leaked at
+        // registration, alive for the process lifetime.
+        let signal = unsafe { &*context.cast::<DeviceIoSignal>() };
+        let _ = signal.suspend();
     }
     0
 }
@@ -91,27 +96,22 @@ unsafe extern "system" fn on_power_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlogi_agent_core::watchers::inventory::resume_channel;
+    use openlogi_hid::device_io_channel;
     use windows_sys::Win32::UI::WindowsAndMessaging::PBT_APMSUSPEND;
 
-    #[tokio::test]
-    async fn resume_events_notify_and_a_suspend_does_not() {
-        let (signal, mut events) = resume_channel();
+    #[test]
+    fn suspend_and_resume_events_update_the_device_io_gate() {
+        let (signal, gate) = device_io_channel();
         let context = (&raw const signal).cast::<c_void>();
         // SAFETY: `context` points at the signal above, live for this test;
         // the callback executes synchronously.
         unsafe { on_power_event(context, PBT_APMSUSPEND, std::ptr::null()) };
-        tokio::time::timeout(std::time::Duration::from_millis(10), events.recv())
-            .await
-            .expect_err("a suspend edge does not notify inventory");
+        assert!(!gate.allows_io());
 
         // SAFETY: `context` points at the signal above, live for this test;
         // the callback executes synchronously.
         unsafe { on_power_event(context, PBT_APMRESUMEAUTOMATIC, std::ptr::null()) };
-        tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
-            .await
-            .expect("resume callback notifies the inventory signal")
-            .expect("the signal producer remains alive");
+        assert!(gate.allows_io());
         assert!(is_resume_event(PBT_APMRESUMESUSPEND));
     }
 }

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -252,7 +252,7 @@ impl Agent for AgentServer {
         command: LightCommand,
     ) -> Result<(), WriteError> {
         hardware::cancel_light_reapply(&route);
-        hardware::apply_light(&route, command).await
+        hardware::apply_light(&self.shared.device_io, &route, command).await
     }
 
     async fn set_light_manual_power(
@@ -262,7 +262,7 @@ impl Agent for AgentServer {
         enabled: bool,
     ) -> Result<(), WriteError> {
         hardware::cancel_light_reapply(&route);
-        hardware::apply_light(&route, LightCommand::Power(enabled)).await?;
+        hardware::apply_light(&self.shared.device_io, &route, LightCommand::Power(enabled)).await?;
         if !self
             .orchestrator
             .lock()

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -16,7 +16,6 @@ use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::runtime::scroll::{ScrollInputHandle, ScrollRuntime};
 use openlogi_agent_core::runtime::{ActionDispatcher, ActionRuntime};
-use openlogi_agent_core::watchers::inventory::ResumeEvents;
 use openlogi_agent_core::watchers::{self, gesture::GestureOutputs};
 use openlogi_core::config::Config;
 #[cfg(target_os = "macos")]
@@ -135,6 +134,7 @@ impl InputServices {
             shared.capture_channel.clone(),
             shared.channel_registry.clone(),
             shared.receiver_access.clone(),
+            shared.device_io.clone(),
             sender,
         ) {
             Ok(runtime) => runtime,
@@ -175,18 +175,21 @@ pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputService
         shared.capture_channel.clone(),
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
+        shared.device_io.clone(),
         GestureOutputs::new(inputs.dispatcher.clone(), inputs.scroll_input.clone()),
     );
     watchers::host_switch::spawn(
         &shared.host_switch_links,
         shared.channel_pool.clone(),
         shared.receiver_access.clone(),
+        shared.device_io.clone(),
     );
     watchers::keyboard::spawn(
         &shared.keyboard_spec,
         shared.keyboard_channel.clone(),
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
+        shared.device_io.clone(),
         inputs.dispatcher.clone(),
     );
 }
@@ -226,7 +229,6 @@ pub(crate) enum Watcher {
 /// stream.
 pub(crate) fn spawn_state_watchers(
     shared: &SharedRuntime,
-    resume_events: ResumeEvents,
 ) -> (
     impl Stream<Item = WatcherEvent> + Unpin + use<>,
     watchers::inventory::InventoryRefresh,
@@ -243,8 +245,10 @@ pub(crate) fn spawn_state_watchers(
         .chain(stream::iter([WatcherEvent::Lost(source)]))
         .boxed()
     }
-    let inventory =
-        watchers::inventory::spawn_with_registry(shared.channel_registry.clone(), resume_events);
+    let inventory = watchers::inventory::spawn_with_registry(
+        shared.channel_registry.clone(),
+        shared.device_io.clone(),
+    );
     let streams = stream::select_all([
         tagged(
             inventory.events,

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -36,6 +36,7 @@ use objc2_app_kit::{
     NSWorkspaceSessionDidBecomeActiveNotification, NSWorkspaceSessionDidResignActiveNotification,
     NSWorkspaceWillSleepNotification,
 };
+use objc2_core_graphics::{CGDisplayIsAsleep, CGMainDisplayID};
 use objc2_foundation::{NSNotification, NSString};
 use openlogi_core::brand::{self, DeeplinkCommand};
 use openlogi_core::config::AppIcon;
@@ -117,6 +118,7 @@ struct ActivityTargetIvars {
 const SYSTEM_SLEEP: u8 = 1 << 0;
 const SCREEN_SLEEP: u8 = 1 << 1;
 const SESSION_INACTIVE: u8 = 1 << 2;
+const STARTUP: u8 = 1 << 3;
 
 define_class!(
     // SAFETY: NSObject has no subclassing requirements, and `ActivityTarget`
@@ -156,12 +158,23 @@ define_class!(
 
 impl ActivityTarget {
     fn new(signal: DeviceIoSignal) -> Retained<Self> {
+        // `main` closes the gate before spawning the core thread; repeat the
+        // idempotent close here so the target's STARTUP source is self-contained
+        // in tests and any future caller cannot accidentally start open.
+        let _ = signal.suspend();
         let this = Self::alloc().set_ivars(ActivityTargetIvars {
             signal,
-            suspended_by: Mutex::new(0),
+            suspended_by: Mutex::new(STARTUP),
         });
         // SAFETY: `init` initializes our freshly allocated NSObject subclass.
         unsafe { msg_send![super(this), init] }
+    }
+
+    fn finish_startup(&self, display_asleep: bool) {
+        if display_asleep {
+            self.suspend_from(SCREEN_SLEEP);
+        }
+        self.resume_from(STARTUP);
     }
 
     fn suspend_from(&self, source: u8) {
@@ -321,10 +334,18 @@ pub fn run_app_loop(
     let app = NSApplication::sharedApplication(mtm);
     app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
 
+    let activity_target = install_activity_observer(device_io_signal);
     // Bind the status item (+ its target/menu) so they outlive `run()` — the
     // menu items only weakly reference the target. `None` when hidden.
     let _tray = show_in_menu_bar.then(|| install_status_item(mtm, app_icon));
-    let _activity_target = install_activity_observer(device_io_signal);
+
+    // AppKit documents that an app launched into an inactive session receives
+    // `NSWorkspaceSessionDidResignActiveNotification` between its will- and
+    // did-finish-launching notifications. Finish that lifecycle while STARTUP
+    // still holds the hardware gate closed, then snapshot display sleep before
+    // permitting the core's initial inventory scan.
+    app.finishLaunching();
+    activity_target.finish_startup(CGDisplayIsAsleep(CGMainDisplayID()));
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
@@ -485,6 +506,7 @@ mod tests {
     fn overlapping_suspend_sources_all_clear_before_device_io_resumes() {
         let (signal, gate) = device_io_channel();
         let target = install_activity_observer(signal);
+        target.finish_startup(false);
         let workspace = NSWorkspace::sharedWorkspace();
         let center = workspace.notificationCenter();
 
@@ -528,6 +550,31 @@ mod tests {
         // SAFETY: `workspace` is live, matches the registration filter, and
         // notification delivery completes synchronously.
         unsafe { center.postNotificationName_object(session_active, Some(&workspace)) };
+        assert!(gate.allows_io());
+
+        // SAFETY: This is the same live target registered with `center` above.
+        unsafe { center.removeObserver(&target) };
+    }
+
+    #[test]
+    fn startup_stays_suspended_when_the_display_is_already_asleep() {
+        let (signal, gate) = device_io_channel();
+        let target = install_activity_observer(signal);
+        assert!(!gate.allows_io(), "startup must fail closed");
+
+        target.finish_startup(true);
+        assert!(
+            !gate.allows_io(),
+            "an initially sleeping display must retain the suspension",
+        );
+
+        let workspace = NSWorkspace::sharedWorkspace();
+        let center = workspace.notificationCenter();
+        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
+        let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
+        // SAFETY: `workspace` is live, matches the registration filter, and
+        // notification delivery completes synchronously.
+        unsafe { center.postNotificationName_object(screen_wake, Some(&workspace)) };
         assert!(gate.allows_io());
 
         // SAFETY: This is the same live target registered with `center` above.

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -19,6 +19,7 @@
 )]
 
 use std::cell::RefCell;
+use std::sync::{Mutex, PoisonError};
 
 use dispatch2::DispatchQueue;
 use objc2::rc::Retained;
@@ -35,7 +36,7 @@ use objc2_app_kit::{
     NSWorkspaceSessionDidBecomeActiveNotification, NSWorkspaceSessionDidResignActiveNotification,
     NSWorkspaceWillSleepNotification,
 };
-use objc2_foundation::{NSNotification, NSNotificationName, NSString};
+use objc2_foundation::{NSNotification, NSString};
 use openlogi_core::brand::{self, DeeplinkCommand};
 use openlogi_core::config::AppIcon;
 use openlogi_hid::DeviceIoSignal;
@@ -110,7 +111,12 @@ pub fn relocalize() {
 
 struct ActivityTargetIvars {
     signal: DeviceIoSignal,
+    suspended_by: Mutex<u8>,
 }
+
+const SYSTEM_SLEEP: u8 = 1 << 0;
+const SCREEN_SLEEP: u8 = 1 << 1;
+const SESSION_INACTIVE: u8 = 1 << 2;
 
 define_class!(
     // SAFETY: NSObject has no subclassing requirements, and `ActivityTarget`
@@ -121,27 +127,73 @@ define_class!(
     struct ActivityTarget;
 
     impl ActivityTarget {
-        #[unsafe(method(workspaceDidSuspend:))]
-        fn workspace_did_suspend(&self, _notification: &NSNotification) {
-            if self.ivars().signal.suspend() {
-                info!("display/session suspended — pausing device I/O");
-            }
+        #[unsafe(method(workspaceWillSleep:))]
+        fn workspace_will_sleep(&self, _notification: &NSNotification) {
+            self.suspend_from(SYSTEM_SLEEP);
         }
 
-        #[unsafe(method(workspaceDidResume:))]
-        fn workspace_did_resume(&self, _notification: &NSNotification) {
-            if self.ivars().signal.resume() {
-                info!("display/session resumed — enabling device I/O");
-            }
+        #[unsafe(method(workspaceScreensDidSleep:))]
+        fn workspace_screens_did_sleep(&self, _notification: &NSNotification) {
+            self.suspend_from(SCREEN_SLEEP);
+        }
+
+        #[unsafe(method(workspaceSessionDidResignActive:))]
+        fn workspace_session_did_resign_active(&self, _notification: &NSNotification) {
+            self.suspend_from(SESSION_INACTIVE);
+        }
+
+        #[unsafe(method(workspaceScreensDidWake:))]
+        fn workspace_screens_did_wake(&self, _notification: &NSNotification) {
+            self.resume_from(SYSTEM_SLEEP | SCREEN_SLEEP);
+        }
+
+        #[unsafe(method(workspaceSessionDidBecomeActive:))]
+        fn workspace_session_did_become_active(&self, _notification: &NSNotification) {
+            self.resume_from(SYSTEM_SLEEP | SESSION_INACTIVE);
         }
     }
 );
 
 impl ActivityTarget {
     fn new(signal: DeviceIoSignal) -> Retained<Self> {
-        let this = Self::alloc().set_ivars(ActivityTargetIvars { signal });
+        let this = Self::alloc().set_ivars(ActivityTargetIvars {
+            signal,
+            suspended_by: Mutex::new(0),
+        });
         // SAFETY: `init` initializes our freshly allocated NSObject subclass.
         unsafe { msg_send![super(this), init] }
+    }
+
+    fn suspend_from(&self, source: u8) {
+        let changed = {
+            let mut suspended_by = self
+                .ivars()
+                .suspended_by
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            let was_allowed = *suspended_by == 0;
+            *suspended_by |= source;
+            was_allowed && self.ivars().signal.suspend()
+        };
+        if changed {
+            info!("display/session suspended — pausing device I/O");
+        }
+    }
+
+    fn resume_from(&self, sources: u8) {
+        let changed = {
+            let mut suspended_by = self
+                .ivars()
+                .suspended_by
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            let was_suspended = *suspended_by != 0;
+            *suspended_by &= !sources;
+            was_suspended && *suspended_by == 0 && self.ivars().signal.resume()
+        };
+        if changed {
+            info!("display/session resumed — enabling device I/O");
+        }
     }
 }
 
@@ -291,51 +343,51 @@ fn install_activity_observer(signal: DeviceIoSignal) -> Retained<ActivityTarget>
     let target = ActivityTarget::new(signal);
     let workspace = NSWorkspace::sharedWorkspace();
     let center = workspace.notificationCenter();
-    for name in suspend_notification_names() {
-        // SAFETY: `ActivityTarget` implements `workspaceDidSuspend:` with the
-        // exact one-NSNotification argument signature, and the caller retains
-        // the target for the AppKit loop's lifetime.
-        unsafe {
-            center.addObserver_selector_name_object(
-                &target,
-                sel!(workspaceDidSuspend:),
-                Some(name),
-                Some(&workspace),
-            );
-        }
-    }
-    for name in resume_notification_names() {
-        // SAFETY: `ActivityTarget` implements `workspaceDidResume:` with the
-        // exact one-NSNotification argument signature, and the caller retains
-        // the target for the AppKit loop's lifetime.
-        unsafe {
-            center.addObserver_selector_name_object(
-                &target,
-                sel!(workspaceDidResume:),
-                Some(name),
-                Some(&workspace),
-            );
-        }
-    }
-    target
-}
-
-fn suspend_notification_names() -> [&'static NSNotificationName; 3] {
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let system_sleep = unsafe { NSWorkspaceWillSleepNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let screen_sleep = unsafe { NSWorkspaceScreensDidSleepNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let session_inactive = unsafe { NSWorkspaceSessionDidResignActiveNotification };
-    [system_sleep, screen_sleep, session_inactive]
-}
-
-fn resume_notification_names() -> [&'static NSNotificationName; 2] {
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let session_active = unsafe { NSWorkspaceSessionDidBecomeActiveNotification };
-    [screen_wake, session_active]
+    // SAFETY: Every selector below has exactly one `NSNotification` argument,
+    // and the caller retains the target for the AppKit loop's lifetime.
+    unsafe {
+        center.addObserver_selector_name_object(
+            &target,
+            sel!(workspaceWillSleep:),
+            Some(system_sleep),
+            Some(&workspace),
+        );
+        center.addObserver_selector_name_object(
+            &target,
+            sel!(workspaceScreensDidSleep:),
+            Some(screen_sleep),
+            Some(&workspace),
+        );
+        center.addObserver_selector_name_object(
+            &target,
+            sel!(workspaceSessionDidResignActive:),
+            Some(session_inactive),
+            Some(&workspace),
+        );
+        center.addObserver_selector_name_object(
+            &target,
+            sel!(workspaceScreensDidWake:),
+            Some(screen_wake),
+            Some(&workspace),
+        );
+        center.addObserver_selector_name_object(
+            &target,
+            sel!(workspaceSessionDidBecomeActive:),
+            Some(session_active),
+            Some(&workspace),
+        );
+    }
+    target
 }
 
 /// Build and install the menu-bar status item, returning the objects that must
@@ -430,16 +482,27 @@ mod tests {
     use openlogi_hid::device_io_channel;
 
     #[test]
-    fn darkwake_does_not_reopen_device_io() {
+    fn overlapping_suspend_sources_all_clear_before_device_io_resumes() {
         let (signal, gate) = device_io_channel();
         let target = install_activity_observer(signal);
         let workspace = NSWorkspace::sharedWorkspace();
         let center = workspace.notificationCenter();
 
-        let screen_sleep = suspend_notification_names()[1];
+        // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+        let system_sleep = unsafe { NSWorkspaceWillSleepNotification };
+        // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+        let screen_sleep = unsafe { NSWorkspaceScreensDidSleepNotification };
+        // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+        let session_inactive = unsafe { NSWorkspaceSessionDidResignActiveNotification };
+        // SAFETY: `workspace` is live, matches the registration filter, and
+        // notification delivery completes synchronously.
+        unsafe { center.postNotificationName_object(system_sleep, Some(&workspace)) };
         // SAFETY: `workspace` is live, matches the registration filter, and
         // notification delivery completes synchronously.
         unsafe { center.postNotificationName_object(screen_sleep, Some(&workspace)) };
+        // SAFETY: `workspace` is live, matches the registration filter, and
+        // notification delivery completes synchronously.
+        unsafe { center.postNotificationName_object(session_inactive, Some(&workspace)) };
         assert!(!gate.allows_io());
 
         // `DidWake` is a maintenance/system wake and intentionally has no
@@ -450,10 +513,21 @@ mod tests {
         unsafe { center.postNotificationName_object(darkwake, Some(&workspace)) };
         assert!(!gate.allows_io());
 
-        let screen_wake = resume_notification_names()[0];
+        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
+        let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
         // SAFETY: `workspace` is live, matches the registration filter, and
         // notification delivery completes synchronously.
         unsafe { center.postNotificationName_object(screen_wake, Some(&workspace)) };
+        assert!(
+            !gate.allows_io(),
+            "screen wake must not override an inactive session",
+        );
+
+        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
+        let session_active = unsafe { NSWorkspaceSessionDidBecomeActiveNotification };
+        // SAFETY: `workspace` is live, matches the registration filter, and
+        // notification delivery completes synchronously.
+        unsafe { center.postNotificationName_object(session_active, Some(&workspace)) };
         assert!(gate.allows_io());
 
         // SAFETY: This is the same live target registered with `center` above.

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -27,15 +27,18 @@ use objc2::{
     AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel,
 };
 use objc2_app_kit::NSStatusItem;
+#[cfg(test)]
+use objc2_app_kit::NSWorkspaceDidWakeNotification;
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSImage, NSRunningApplication, NSWorkspace,
-    NSWorkspaceDidWakeNotification, NSWorkspaceScreensDidWakeNotification,
-    NSWorkspaceSessionDidBecomeActiveNotification,
+    NSWorkspaceScreensDidSleepNotification, NSWorkspaceScreensDidWakeNotification,
+    NSWorkspaceSessionDidBecomeActiveNotification, NSWorkspaceSessionDidResignActiveNotification,
+    NSWorkspaceWillSleepNotification,
 };
 use objc2_foundation::{NSNotification, NSNotificationName, NSString};
-use openlogi_agent_core::watchers::inventory::ResumeSignal;
 use openlogi_core::brand::{self, DeeplinkCommand};
 use openlogi_core::config::AppIcon;
+use openlogi_hid::DeviceIoSignal;
 use tracing::{info, warn};
 
 use crate::status_item;
@@ -105,29 +108,38 @@ pub fn relocalize() {
     });
 }
 
-struct ResumeTargetIvars {
-    signal: ResumeSignal,
+struct ActivityTargetIvars {
+    signal: DeviceIoSignal,
 }
 
 define_class!(
-    // SAFETY: NSObject has no subclassing requirements, and `ResumeTarget`
+    // SAFETY: NSObject has no subclassing requirements, and `ActivityTarget`
     // does not implement `Drop`.
     #[unsafe(super(NSObject))]
-    #[ivars = ResumeTargetIvars]
-    #[name = "OpenLogiAgentWorkspaceResumeTarget"]
-    struct ResumeTarget;
+    #[ivars = ActivityTargetIvars]
+    #[name = "OpenLogiAgentWorkspaceActivityTarget"]
+    struct ActivityTarget;
 
-    impl ResumeTarget {
+    impl ActivityTarget {
+        #[unsafe(method(workspaceDidSuspend:))]
+        fn workspace_did_suspend(&self, _notification: &NSNotification) {
+            if self.ivars().signal.suspend() {
+                info!("display/session suspended — pausing device I/O");
+            }
+        }
+
         #[unsafe(method(workspaceDidResume:))]
         fn workspace_did_resume(&self, _notification: &NSNotification) {
-            self.ivars().signal.notify();
+            if self.ivars().signal.resume() {
+                info!("display/session resumed — enabling device I/O");
+            }
         }
     }
 );
 
-impl ResumeTarget {
-    fn new(signal: ResumeSignal) -> Retained<Self> {
-        let this = Self::alloc().set_ivars(ResumeTargetIvars { signal });
+impl ActivityTarget {
+    fn new(signal: DeviceIoSignal) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(ActivityTargetIvars { signal });
         // SAFETY: `init` initializes our freshly allocated NSObject subclass.
         unsafe { msg_send![super(this), init] }
     }
@@ -239,8 +251,13 @@ fn gui_is_running() -> bool {
 /// tokio core still does all the work). The toggle takes effect on the agent's
 /// next launch — a no-restart live toggle would need a main-thread hop from the
 /// IPC reload path (deferred; it can't be verified headlessly).
-/// `resume_signal` forwards coalesced workspace resume notifications to that core.
-pub fn run_app_loop(show_in_menu_bar: bool, app_icon: AppIcon, resume_signal: ResumeSignal) -> ! {
+/// `device_io_signal` closes the hardware gate while the display/session is
+/// asleep and reopens it only for a user-visible resume.
+pub fn run_app_loop(
+    show_in_menu_bar: bool,
+    app_icon: AppIcon,
+    device_io_signal: DeviceIoSignal,
+) -> ! {
     let Some(mtm) = MainThreadMarker::new() else {
         warn!("agent AppKit loop not started off the main thread — exiting");
         #[expect(
@@ -255,7 +272,7 @@ pub fn run_app_loop(show_in_menu_bar: bool, app_icon: AppIcon, resume_signal: Re
     // Bind the status item (+ its target/menu) so they outlive `run()` — the
     // menu items only weakly reference the target. `None` when hidden.
     let _tray = show_in_menu_bar.then(|| install_status_item(mtm, app_icon));
-    let _resume_target = install_resume_observer(resume_signal);
+    let _activity_target = install_activity_observer(device_io_signal);
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
@@ -266,14 +283,29 @@ pub fn run_app_loop(show_in_menu_bar: bool, app_icon: AppIcon, resume_signal: Re
     std::process::exit(0);
 }
 
-/// Observe native resume transitions that the inventory clock-gap heuristic
-/// cannot see. The returned target must live for the AppKit loop's lifetime.
-fn install_resume_observer(signal: ResumeSignal) -> Retained<ResumeTarget> {
-    let target = ResumeTarget::new(signal);
+/// Observe display/session sleep and user-visible resume transitions. Generic
+/// `NSWorkspaceDidWakeNotification` is deliberately not registered: macOS
+/// emits it for maintenance DarkWake, where opening BLE HID is exactly what can
+/// promote an otherwise invisible wake into a full display wake (#656).
+fn install_activity_observer(signal: DeviceIoSignal) -> Retained<ActivityTarget> {
+    let target = ActivityTarget::new(signal);
     let workspace = NSWorkspace::sharedWorkspace();
     let center = workspace.notificationCenter();
+    for name in suspend_notification_names() {
+        // SAFETY: `ActivityTarget` implements `workspaceDidSuspend:` with the
+        // exact one-NSNotification argument signature, and the caller retains
+        // the target for the AppKit loop's lifetime.
+        unsafe {
+            center.addObserver_selector_name_object(
+                &target,
+                sel!(workspaceDidSuspend:),
+                Some(name),
+                Some(&workspace),
+            );
+        }
+    }
     for name in resume_notification_names() {
-        // SAFETY: `ResumeTarget` implements `workspaceDidResume:` with the
+        // SAFETY: `ActivityTarget` implements `workspaceDidResume:` with the
         // exact one-NSNotification argument signature, and the caller retains
         // the target for the AppKit loop's lifetime.
         unsafe {
@@ -288,14 +320,22 @@ fn install_resume_observer(signal: ResumeSignal) -> Retained<ResumeTarget> {
     target
 }
 
-fn resume_notification_names() -> [&'static NSNotificationName; 3] {
+fn suspend_notification_names() -> [&'static NSNotificationName; 3] {
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
-    let system_wake = unsafe { NSWorkspaceDidWakeNotification };
+    let system_sleep = unsafe { NSWorkspaceWillSleepNotification };
+    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+    let screen_sleep = unsafe { NSWorkspaceScreensDidSleepNotification };
+    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+    let session_inactive = unsafe { NSWorkspaceSessionDidResignActiveNotification };
+    [system_sleep, screen_sleep, session_inactive]
+}
+
+fn resume_notification_names() -> [&'static NSNotificationName; 2] {
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let session_active = unsafe { NSWorkspaceSessionDidBecomeActiveNotification };
-    [system_wake, screen_wake, session_active]
+    [screen_wake, session_active]
 }
 
 /// Build and install the menu-bar status item, returning the objects that must
@@ -387,24 +427,34 @@ fn build_menu(mtm: MainThreadMarker, target: &MenuTarget) -> Retained<objc2_app_
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlogi_agent_core::watchers::inventory::resume_channel;
+    use openlogi_hid::device_io_channel;
 
-    #[tokio::test]
-    async fn resume_notifications_are_forwarded() {
-        let (signal, mut events) = resume_channel();
-        let target = install_resume_observer(signal.clone());
+    #[test]
+    fn darkwake_does_not_reopen_device_io() {
+        let (signal, gate) = device_io_channel();
+        let target = install_activity_observer(signal);
         let workspace = NSWorkspace::sharedWorkspace();
         let center = workspace.notificationCenter();
 
-        for name in resume_notification_names() {
-            // SAFETY: `workspace` is live, matches the registration filter,
-            // and notification delivery completes synchronously.
-            unsafe { center.postNotificationName_object(name, Some(&workspace)) };
-        }
-        tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
-            .await
-            .expect("workspace notification reaches the inventory signal")
-            .expect("the signal producer remains alive");
+        let screen_sleep = suspend_notification_names()[1];
+        // SAFETY: `workspace` is live, matches the registration filter, and
+        // notification delivery completes synchronously.
+        unsafe { center.postNotificationName_object(screen_sleep, Some(&workspace)) };
+        assert!(!gate.allows_io());
+
+        // `DidWake` is a maintenance/system wake and intentionally has no
+        // observer, so posting it must leave the gate closed.
+        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
+        let darkwake = unsafe { NSWorkspaceDidWakeNotification };
+        // SAFETY: `workspace` is live and notification delivery is synchronous.
+        unsafe { center.postNotificationName_object(darkwake, Some(&workspace)) };
+        assert!(!gate.allows_io());
+
+        let screen_wake = resume_notification_names()[0];
+        // SAFETY: `workspace` is live, matches the registration filter, and
+        // notification delivery completes synchronously.
+        unsafe { center.postNotificationName_object(screen_wake, Some(&workspace)) };
+        assert!(gate.allows_io());
 
         // SAFETY: This is the same live target registered with `center` above.
         unsafe { center.removeObserver(&target) };

--- a/crates/openlogi-device/src/device_io.rs
+++ b/crates/openlogi-device/src/device_io.rs
@@ -1,0 +1,117 @@
+//! Process activity gate for host HID access.
+//!
+//! The gate carries policy from a host lifecycle observer down to code that
+//! may open a HID node or send a request. It contains no host integration of
+//! its own, so the device layer remains portable and testable.
+
+use tokio::sync::watch;
+
+/// Non-blocking producer owned by the host lifecycle observer.
+#[derive(Clone)]
+pub struct DeviceIoSignal {
+    sender: watch::Sender<DeviceIoState>,
+}
+
+/// Cheaply cloneable read capability for device-I/O producers.
+#[derive(Clone)]
+pub struct DeviceIoGate {
+    receiver: watch::Receiver<DeviceIoState>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeviceIoState {
+    Allowed,
+    Suspended,
+}
+
+/// Create an initially-open device-I/O gate.
+#[must_use]
+pub fn device_io_channel() -> (DeviceIoSignal, DeviceIoGate) {
+    let (sender, receiver) = watch::channel(DeviceIoState::Allowed);
+    (DeviceIoSignal { sender }, DeviceIoGate { receiver })
+}
+
+impl DeviceIoSignal {
+    /// Close the gate without blocking the native lifecycle callback.
+    ///
+    /// Returns whether this call changed the published state.
+    #[must_use]
+    pub fn suspend(&self) -> bool {
+        self.sender.send_if_modified(|state| {
+            if *state == DeviceIoState::Suspended {
+                return false;
+            }
+            *state = DeviceIoState::Suspended;
+            true
+        })
+    }
+
+    /// Reopen the gate after a user-visible resume.
+    ///
+    /// Returns whether this call changed the published state.
+    #[must_use]
+    pub fn resume(&self) -> bool {
+        self.sender.send_if_modified(|state| {
+            if *state == DeviceIoState::Allowed {
+                return false;
+            }
+            *state = DeviceIoState::Allowed;
+            true
+        })
+    }
+}
+
+impl DeviceIoGate {
+    /// Whether opening a node or sending a request is currently allowed.
+    #[must_use]
+    pub fn allows_io(&self) -> bool {
+        *self.receiver.borrow() == DeviceIoState::Allowed
+    }
+
+    /// Wait for the next distinct gate transition.
+    ///
+    /// Returns the new allow-state, or `None` if the lifecycle producer was
+    /// dropped.
+    pub async fn changed(&mut self) -> Option<bool> {
+        self.receiver.changed().await.ok()?;
+        Some(self.allows_io())
+    }
+
+    /// Wait until the gate is open. Returns `false` if its producer disappears
+    /// while it is closed.
+    pub async fn wait_until_allowed(&mut self) -> bool {
+        while !self.allows_io() {
+            if self.changed().await.is_none() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::device_io_channel;
+
+    #[tokio::test]
+    async fn latest_transition_is_retained_and_duplicates_coalesce() {
+        let (signal, mut gate) = device_io_channel();
+        assert!(gate.allows_io());
+
+        assert!(signal.suspend());
+        assert!(!signal.suspend());
+        gate.changed()
+            .await
+            .expect("the suspend transition should remain available");
+        assert!(!gate.allows_io());
+        tokio::time::timeout(Duration::from_millis(10), gate.changed())
+            .await
+            .expect_err("duplicate suspend publications must coalesce");
+
+        assert!(signal.resume());
+        assert!(gate.wait_until_allowed().await);
+        assert!(gate.allows_io());
+    }
+}

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -17,6 +17,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 mod channel;
+mod device_io;
 
 pub mod backend;
 pub mod backlight;
@@ -37,6 +38,7 @@ pub use channel::route::{
     speaks_unifying_protocol,
 };
 pub use channel::{ChannelPool, ChannelRegistry, SharedChannel};
+pub use device_io::{DeviceIoGate, DeviceIoSignal, device_io_channel};
 pub use inventory::hotplug::watch_hotplug;
 pub use inventory::standalone::enumerate_standalone;
 pub use inventory::{Enumerator, InventoryError, enumerate};

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -35,9 +35,9 @@ use openlogi_core::binding::{ButtonId, GestureDirection, SwipeAccumulator};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
-use crate::backend::HidBackend;
+use crate::backend::{BackendError, HidBackend};
 use crate::channel::route::{DeviceRoute, open_route_channel};
-use crate::{ChannelRegistry, SharedChannel};
+use crate::{ChannelRegistry, DeviceIoGate, SharedChannel};
 
 use liveness::{CaptureLiveness, ChannelActivity, LivenessDecision, PingOutcome};
 
@@ -227,13 +227,20 @@ pub async fn run_capture_session(
     sink: mpsc::UnboundedSender<CapturedInput>,
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
+    device_io: DeviceIoGate,
 ) -> Result<CaptureSessionOutcome, CaptureSessionFailure> {
+    if !device_io.allows_io() {
+        return Err(GestureError::Hid(BackendError::Backend(
+            "host device I/O is suspended".into(),
+        ))
+        .into());
+    }
     let chan = open_route_channel(backend, &route)
         .await
         .map_err(GestureError::from)?
         .ok_or(GestureError::DeviceNotFound)?;
     let shared = SharedChannel::new(chan, route.clone());
-    run_capture_session_on(shared, spec, sink, shutdown, channel_slot, None).await
+    run_capture_session_on(shared, spec, sink, shutdown, channel_slot, None, device_io).await
 }
 
 /// Capture through the inventory-owned channel currently published for
@@ -247,11 +254,21 @@ pub async fn run_capture_session_with_registry_spec(
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
     registry: &ChannelRegistry,
+    device_io: DeviceIoGate,
 ) -> Result<CaptureSessionOutcome, CaptureSessionFailure> {
     let shared = registry
         .lookup(&route)
         .ok_or(GestureError::DeviceNotFound)?;
-    run_capture_session_on(shared, spec, sink, shutdown, channel_slot, Some(registry)).await
+    run_capture_session_on(
+        shared,
+        spec,
+        sink,
+        shutdown,
+        channel_slot,
+        Some(registry),
+        device_io,
+    )
+    .await
 }
 
 async fn run_capture_session_on(
@@ -261,7 +278,14 @@ async fn run_capture_session_on(
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
     registry: Option<&ChannelRegistry>,
+    device_io: DeviceIoGate,
 ) -> Result<CaptureSessionOutcome, CaptureSessionFailure> {
+    if !device_io.allows_io() {
+        return Err(GestureError::Hid(BackendError::Backend(
+            "host device I/O is suspended".into(),
+        ))
+        .into());
+    }
     let chan = Arc::clone(shared.channel());
     let device_index = shared.device_index();
     let armed = arm_controls(&chan, device_index, &spec, &shared, registry).await?;
@@ -355,6 +379,7 @@ async fn run_capture_session_on(
         },
         wireless,
         shutdown,
+        device_io,
     )
     .await;
 
@@ -471,8 +496,11 @@ impl ArmedControls {
     /// Reapply volatile diversion after a wireless reconnect broadcast. The
     /// broadcast can precede the device accepting feature writes, so allow a
     /// short settling window like the keyboard capture path does.
-    async fn rearm(&self) {
+    async fn rearm(&self, device_io: &DeviceIoGate) {
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        if !device_io.allows_io() {
+            return;
+        }
         if let Some(rc) = self.reprog.as_ref() {
             for &reporting in &self.reporting {
                 let raw_xy = self.gesture_cids.contains(&reporting.cid)
@@ -529,17 +557,37 @@ async fn monitor_capture(
     context: CaptureMonitor<'_>,
     wireless: Option<WirelessDeviceStatusFeature>,
     shutdown: oneshot::Receiver<()>,
+    mut device_io: DeviceIoGate,
 ) -> CaptureStop {
     let mut wake_events = wireless.as_ref().map(EmittingFeature::listen);
     let mut shutdown = std::pin::pin!(shutdown);
     let mut liveness =
         CaptureLiveness::new(tokio::time::Instant::now(), context.activity.generation());
     loop {
+        if !device_io.allows_io() {
+            if !device_io.wait_until_allowed().await {
+                return stop_for_current_publication(context.registry, context.shared);
+            }
+            // Time asleep is not channel idleness. Give the transport a full
+            // quiet interval after visible resume and clear any pre-sleep
+            // strike before considering a liveness ping.
+            liveness.record_activity(tokio::time::Instant::now(), context.activity.generation());
+        }
         let activity_generation = liveness.activity_generation();
         let idle_deadline = liveness.idle_deadline();
         tokio::select! {
             biased;
 
+            allowed = device_io.changed() => {
+                match allowed {
+                    Some(true) => liveness.record_activity(
+                        tokio::time::Instant::now(),
+                        context.activity.generation(),
+                    ),
+                    Some(false) => {}
+                    None => return stop_for_current_publication(context.registry, context.shared),
+                }
+            }
             transition = wait_for_channel_change(
                 context.registry,
                 context.shared,
@@ -567,7 +615,7 @@ async fn monitor_capture(
                 info!(?broadcast, "device reconnected — re-arming control capture");
                 *context.accum.lock().unwrap_or_else(PoisonError::into_inner) =
                     CaptureAccum::default();
-                context.armed.rearm().await;
+                context.armed.rearm(&device_io).await;
             }
             generation = context.activity.changed_after(activity_generation) => {
                 liveness.record_activity(tokio::time::Instant::now(), generation);

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -26,7 +26,7 @@ use tokio::{
 use tracing::{debug, info};
 
 use crate::{
-    ChannelPool, DeviceRoute,
+    ChannelPool, DeviceIoGate, DeviceRoute,
     backend::BackendError,
     reprog_controls::{self, ReprogControlsV4},
 };
@@ -105,7 +105,13 @@ pub async fn run_host_switch_session(
     keyboard: DeviceRoute,
     shutdown: oneshot::Receiver<HostSwitchStopReason>,
     channel_pool: ChannelPool,
+    mut device_io: DeviceIoGate,
 ) -> Result<Option<u8>, HostSwitchError> {
+    if !device_io.allows_io() {
+        return Err(HostSwitchError::Hid(BackendError::Backend(
+            "host device I/O is suspended".into(),
+        )));
+    }
     let channel = open_channel(&channel_pool, &keyboard, "opening keyboard channel")
         .await?
         .ok_or(HostSwitchError::KeyboardNotFound)?;
@@ -160,7 +166,7 @@ pub async fn run_host_switch_session(
     };
 
     drop(listener);
-    if outcome.1 {
+    if outcome.1 && device_io.wait_until_allowed().await {
         restore_host_controls(&controls, armed).await;
     }
     Ok(outcome.0)

--- a/crates/openlogi-device/src/session/keyboard.rs
+++ b/crates/openlogi-device/src/session/keyboard.rs
@@ -37,10 +37,9 @@ use super::gesture::{
     CaptureChannel, CaptureSessionFailure, CaptureSessionOutcome, CapturedInput, GestureError,
     PendingCaptureRestore, enumerate_controls,
 };
-use crate::ChannelRegistry;
-use crate::SharedChannel;
-use crate::backend::HidBackend;
+use crate::backend::{BackendError, HidBackend};
 use crate::channel::route::{DeviceRoute, open_route_channel};
+use crate::{ChannelRegistry, DeviceIoGate, SharedChannel};
 
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 
@@ -75,13 +74,26 @@ pub async fn run_keyboard_capture_session(
     sink: mpsc::UnboundedSender<CapturedInput>,
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
+    device_io: DeviceIoGate,
 ) -> Result<CaptureSessionOutcome, CaptureSessionFailure> {
+    if !device_io.allows_io() {
+        return Err(device_io_suspended().into());
+    }
     let chan = open_route_channel(backend, &route)
         .await
         .map_err(GestureError::from)?
         .ok_or(GestureError::DeviceNotFound)?;
     let shared = SharedChannel::new(chan, route.clone());
-    run_keyboard_capture_session_on(shared, wanted, sink, shutdown, channel_slot, None).await
+    run_keyboard_capture_session_on(
+        shared,
+        wanted,
+        sink,
+        shutdown,
+        channel_slot,
+        None,
+        device_io,
+    )
+    .await
 }
 
 /// Run keyboard capture on the exact channel currently published by `registry`.
@@ -96,12 +108,21 @@ pub async fn run_keyboard_capture_session_with_registry(
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
     registry: &ChannelRegistry,
+    device_io: DeviceIoGate,
 ) -> Result<CaptureSessionOutcome, CaptureSessionFailure> {
     let shared = registry
         .lookup(&route)
         .ok_or(GestureError::DeviceNotFound)?;
-    run_keyboard_capture_session_on(shared, wanted, sink, shutdown, channel_slot, Some(registry))
-        .await
+    run_keyboard_capture_session_on(
+        shared,
+        wanted,
+        sink,
+        shutdown,
+        channel_slot,
+        Some(registry),
+        device_io,
+    )
+    .await
 }
 
 async fn run_keyboard_capture_session_on(
@@ -111,7 +132,11 @@ async fn run_keyboard_capture_session_on(
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
     registry: Option<&ChannelRegistry>,
+    device_io: DeviceIoGate,
 ) -> Result<CaptureSessionOutcome, CaptureSessionFailure> {
+    if !device_io.allows_io() {
+        return Err(device_io_suspended().into());
+    }
     let chan = Arc::clone(shared.channel());
     let device_index = shared.device_index();
     let device = Device::new(Arc::clone(&chan), device_index)
@@ -196,6 +221,7 @@ async fn run_keyboard_capture_session_on(
         },
         wireless,
         shutdown,
+        device_io,
     )
     .await;
 
@@ -236,11 +262,22 @@ async fn monitor_keyboard_capture(
     context: KeyboardMonitor<'_>,
     wireless: Option<WirelessDeviceStatusFeature>,
     shutdown: oneshot::Receiver<()>,
+    mut device_io: DeviceIoGate,
 ) -> CaptureStop {
     let mut wake_events = wireless.as_ref().map(EmittingFeature::listen);
     let mut shutdown = std::pin::pin!(shutdown);
     loop {
+        if !device_io.allows_io() && !device_io.wait_until_allowed().await {
+            return stop_for_current_publication(context.registry, context.shared);
+        }
         tokio::select! {
+            biased;
+
+            allowed = device_io.changed() => {
+                if allowed.is_none() {
+                    return stop_for_current_publication(context.registry, context.shared);
+                }
+            }
             _ = &mut shutdown => {
                 return stop_for_current_publication(context.registry, context.shared);
             }
@@ -259,7 +296,7 @@ async fn monitor_keyboard_capture(
                     continue;
                 };
                 info!(?broadcast, "keyboard reconnected — re-arming key diversion");
-                rearm_keys(context.armed).await;
+                rearm_keys(context.armed, &device_io).await;
             }
         }
     }
@@ -343,10 +380,13 @@ async fn arm_keys(
 /// Re-issue diversion for every armed control after a device power-cycle.
 /// Failures are logged, not propagated — the next reconnection broadcast
 /// retries.
-async fn rearm_keys(armed: &ArmedKeys) {
+async fn rearm_keys(armed: &ArmedKeys, device_io: &DeviceIoGate) {
     // A settling pause: the broadcast arrives the instant the link is back,
     // occasionally before the device accepts feature writes again.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    if !device_io.allows_io() {
+        return;
+    }
     for &reporting in &armed.reporting {
         if let Err(e) = armed
             .controls
@@ -360,6 +400,10 @@ async fn rearm_keys(armed: &ArmedKeys) {
             );
         }
     }
+}
+
+fn device_io_suspended() -> GestureError {
+    GestureError::Hid(BackendError::Backend("host device I/O is suspended".into()))
 }
 
 #[cfg(test)]

--- a/crates/openlogi-hid/src/host.rs
+++ b/crates/openlogi-hid/src/host.rs
@@ -18,7 +18,6 @@ use crate::probe_cache::FileProbeCacheStore;
 use crate::transport::native_backend;
 use openlogi_core::hid::smartshift::{SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus};
 use openlogi_device::ChannelPool;
-use openlogi_device::DeviceRoute;
 use openlogi_device::backend::{HidBackend, HotplugStream};
 use openlogi_device::backlight::BacklightState;
 use openlogi_device::inventory::{Enumerator, InventoryError};
@@ -27,6 +26,7 @@ use openlogi_device::write::{
     self as device, Dpi, DpiInfo, FeatureEntry, FirmwareEntity, HapticWaveform, LightingMethod,
     LitraModel, ReprogControlEntry, ScrollResolution, ScrollWheelMode,
 };
+use openlogi_device::{DeviceIoGate, DeviceIoSignal, DeviceRoute};
 
 /// This host's HID stack.
 ///
@@ -36,6 +36,19 @@ use openlogi_device::write::{
 #[must_use]
 pub fn backend() -> Arc<dyn HidBackend> {
     native_backend()
+}
+
+/// Control the process-wide native HID activity gate from the host lifecycle
+/// observer.
+#[must_use]
+pub fn device_io_signal() -> DeviceIoSignal {
+    crate::transport::device_io_signal()
+}
+
+/// Subscribe to the process-wide native HID activity gate.
+#[must_use]
+pub fn device_io_gate() -> DeviceIoGate {
+    crate::transport::device_io_gate()
 }
 
 /// Read the sensor DPI of the device `route` reaches.

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -8,7 +8,6 @@
 //! collections carry both reports; BLE-direct collections are long-only, and the
 //! `hidpp` channel up-converts outgoing short messages to long for them.
 
-#[cfg(not(target_os = "windows"))]
 use std::error::Error;
 #[cfg(not(target_os = "windows"))]
 use std::sync::atomic::AtomicBool;
@@ -30,6 +29,7 @@ use tracing::debug;
 use crate::LOGITECH_VENDOR_ID;
 use openlogi_device::backend::{BackendError, HotplugEvent, NodeId, NodeInfo};
 use openlogi_device::write::matches_litra;
+use openlogi_device::{DeviceIoGate, DeviceIoSignal, device_io_channel};
 
 /// Collapses `async-hid`'s error taxonomy into the backend-agnostic
 /// [`BackendError`] every caller above this module sees.
@@ -46,6 +46,18 @@ fn backend_error(error: async_hid::HidError) -> BackendError {
         }
         other => BackendError::Backend(other.to_string()),
     }
+}
+
+fn device_io_suspended() -> BackendError {
+    BackendError::Backend("host device I/O is suspended".into())
+}
+
+fn device_io_error() -> Box<dyn Error + Send + Sync> {
+    std::io::Error::new(
+        std::io::ErrorKind::WouldBlock,
+        "host device I/O is suspended",
+    )
+    .into()
 }
 
 /// Classify a failed device open. On macOS `IOHIDDeviceOpen` denies silently —
@@ -197,6 +209,18 @@ fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
 /// (`IOHIDManagerCopyDevices`), and sharing a single long-lived `IOHIDManager`
 /// across threads is the model hidapi uses too.
 static HID_BACKEND: LazyLock<HidBackend> = LazyLock::new(HidBackend::default);
+
+/// One process-wide lifecycle authority for this host HID stack. Every native
+/// backend handle and open channel receives the corresponding read gate.
+static DEVICE_IO: LazyLock<(DeviceIoSignal, DeviceIoGate)> = LazyLock::new(device_io_channel);
+
+pub(crate) fn device_io_signal() -> DeviceIoSignal {
+    DEVICE_IO.0.clone()
+}
+
+pub(crate) fn device_io_gate() -> DeviceIoGate {
+    DEVICE_IO.1.clone()
+}
 
 /// Subscribe to the backend's node connect/disconnect events, restated as the
 /// backend-agnostic [`HotplugEvent`].
@@ -369,7 +393,11 @@ fn configure_channel_sw_ids(channel: &mut HidppChannel) -> Result<(), BackendErr
 
 pub(crate) async fn open_hidpp_channel(
     dev: &async_hid::Device,
+    device_io: DeviceIoGate,
 ) -> Result<Option<Arc<HidppChannel>>, BackendError> {
+    if !device_io.allows_io() {
+        return Err(device_io_suspended());
+    }
     // `Device: Deref<Target = DeviceInfo>` — clone the deref'd value because
     // the channel keeps it for the lifetime of the open.
     let info: DeviceInfo = (**dev).clone();
@@ -379,7 +407,7 @@ pub(crate) async fn open_hidpp_channel(
     // both reports (or is long-only), handled by AsyncHidChannel.
     #[cfg(target_os = "windows")]
     {
-        let raw = WindowsHidppChannel::open(dev, info.clone())
+        let raw = WindowsHidppChannel::open(dev, info.clone(), device_io)
             .await
             .map_err(backend_error)?;
         let channel = match HidppChannel::from_raw_channel(raw).await {
@@ -398,10 +426,13 @@ pub(crate) async fn open_hidpp_channel(
     #[cfg(not(target_os = "windows"))]
     {
         let (reader, writer) = dev.open().await.map_err(open_error)?;
+        if !device_io.allows_io() {
+            return Err(device_io_suspended());
+        }
         // BLE-direct devices expose only the long HID++ report; flag the channel so
         // it advertises short-unsupported and the `hidpp` channel up-converts shorts.
         let long_only = is_long_only_collection(info.usage_page, info.usage_id);
-        let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
+        let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only, device_io);
         let channel = match HidppChannel::from_raw_channel(raw).await {
             Ok(mut c) => {
                 configure_channel_sw_ids(&mut c)?;
@@ -454,6 +485,7 @@ pub(crate) struct AsyncHidChannel {
     writer: Mutex<DeviceWriter>,
     info: DeviceInfo,
     connected: AtomicBool,
+    device_io: DeviceIoGate,
     /// Whether the device exposes only the long HID++ report (a BLE-direct
     /// peripheral on macOS). Reported via `supports_short_long_hidpp` so the
     /// `hidpp` channel up-converts outgoing short messages to long.
@@ -467,12 +499,14 @@ impl AsyncHidChannel {
         writer: DeviceWriter,
         info: DeviceInfo,
         long_only: bool,
+        device_io: DeviceIoGate,
     ) -> Self {
         Self {
             reader: Mutex::new(reader),
             writer: Mutex::new(writer),
             info,
             connected: AtomicBool::new(true),
+            device_io,
             long_only,
         }
     }
@@ -496,7 +530,13 @@ impl RawHidChannel for AsyncHidChannel {
     }
 
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        if !self.device_io.allows_io() {
+            return Err(device_io_error());
+        }
         let mut w = self.writer.lock().await;
+        if !self.device_io.allows_io() {
+            return Err(device_io_error());
+        }
         match w.write_output_report(src).await {
             Ok(()) => Ok(src.len()),
             Err(e) => {

--- a/crates/openlogi-hid/src/transport/native.rs
+++ b/crates/openlogi-hid/src/transport/native.rs
@@ -11,11 +11,15 @@ use async_hid::{AsyncHidWrite as _, Device, DeviceWriter};
 use hidpp::async_trait;
 use hidpp::channel::HidppChannel;
 
+use openlogi_device::DeviceIoGate;
 use openlogi_device::backend::{
     BackendError, HidBackend, HotplugStream, NodeId, NodeInfo, RawWriter,
 };
 
-use super::{enumerate_devices, is_hidpp_node, open_hidpp_channel, watch_nodes};
+use super::{
+    device_io_gate, device_io_suspended, enumerate_devices, is_hidpp_node, open_hidpp_channel,
+    watch_nodes,
+};
 
 /// One logical top-level collection exposed by an OS HID node.
 ///
@@ -65,7 +69,6 @@ pub(crate) fn native_backend() -> Arc<dyn HidBackend> {
 }
 
 /// [`HidBackend`] over `async-hid`.
-#[derive(Default)]
 pub(crate) struct NativeBackend {
     /// OS handles from the most recent enumeration, keyed by the node id and
     /// top-level usage pair that enumeration reported them under.
@@ -77,16 +80,32 @@ pub(crate) struct NativeBackend {
     /// than looking them up again. Held behind an `Arc` so an open can borrow
     /// one without keeping the map locked across its await.
     nodes: Mutex<HashMap<HandleKey, Arc<Device>>>,
+    device_io: DeviceIoGate,
+}
+
+impl Default for NativeBackend {
+    fn default() -> Self {
+        Self {
+            nodes: Mutex::new(HashMap::new()),
+            device_io: device_io_gate(),
+        }
+    }
 }
 
 impl NativeBackend {
     /// Enumerate the host's HID nodes and refresh the handle cache.
     async fn refresh(&self) -> Result<Vec<Arc<Device>>, BackendError> {
+        if !self.device_io.allows_io() {
+            return Err(device_io_suspended());
+        }
         let devices: Vec<Arc<Device>> = enumerate_devices()
             .await?
             .into_iter()
             .map(Arc::new)
             .collect();
+        if !self.device_io.allows_io() {
+            return Err(device_io_suspended());
+        }
         let handles = devices
             .iter()
             .map(|device| (HandleKey::for_device(device), Arc::clone(device)))
@@ -128,17 +147,29 @@ impl HidBackend for NativeBackend {
     }
 
     async fn open_hidpp(&self, node: &NodeInfo) -> Result<Option<Arc<HidppChannel>>, BackendError> {
+        if !self.device_io.allows_io() {
+            return Err(device_io_suspended());
+        }
         let device = self.handle(node)?;
-        open_hidpp_channel(&device).await
+        open_hidpp_channel(&device, self.device_io.clone()).await
     }
 
     async fn open_raw_writer(&self, node: &NodeInfo) -> Result<Box<dyn RawWriter>, BackendError> {
+        if !self.device_io.allows_io() {
+            return Err(device_io_suspended());
+        }
         let (_reader, writer) = self
             .handle(node)?
             .open()
             .await
             .map_err(super::backend_error)?;
-        Ok(Box::new(NativeRawWriter(writer)))
+        if !self.device_io.allows_io() {
+            return Err(device_io_suspended());
+        }
+        Ok(Box::new(NativeRawWriter {
+            writer,
+            device_io: self.device_io.clone(),
+        }))
     }
 
     fn watch(&self) -> Result<HotplugStream, BackendError> {
@@ -147,12 +178,18 @@ impl HidBackend for NativeBackend {
 }
 
 /// [`RawWriter`] over an `async-hid` output-report writer.
-struct NativeRawWriter(DeviceWriter);
+struct NativeRawWriter {
+    writer: DeviceWriter,
+    device_io: DeviceIoGate,
+}
 
 #[async_trait]
 impl RawWriter for NativeRawWriter {
     async fn write_output_report(&mut self, report: &[u8]) -> Result<(), BackendError> {
-        self.0
+        if !self.device_io.allows_io() {
+            return Err(device_io_suspended());
+        }
+        self.writer
             .write_output_report(report)
             .await
             .map_err(super::backend_error)

--- a/crates/openlogi-hid/src/transport/windows.rs
+++ b/crates/openlogi-hid/src/transport/windows.rs
@@ -19,6 +19,9 @@ use tokio::sync::Mutex;
 use tracing::debug;
 
 #[cfg(target_os = "windows")]
+use openlogi_device::DeviceIoGate;
+
+#[cfg(target_os = "windows")]
 use super::windows_hid::NativeHidWriter;
 
 #[cfg(target_os = "windows")]
@@ -95,6 +98,7 @@ pub(super) struct WindowsHidppChannel {
     /// `inventory::ledger` evict this channel — the node-vanish path never
     /// fires for a cabled device whose receiver keeps the HID node enumerated.
     connected: AtomicBool,
+    device_io: DeviceIoGate,
 }
 
 #[cfg(target_os = "windows")]
@@ -102,6 +106,7 @@ impl WindowsHidppChannel {
     pub(super) async fn open(
         long_dev: &async_hid::Device,
         long_info: DeviceInfo,
+        device_io: DeviceIoGate,
     ) -> Result<Self, async_hid::HidError> {
         let short_dev = find_windows_short_collection(&long_info).await?;
         let (long_reader, long_writer) = long_dev.open().await?;
@@ -146,6 +151,7 @@ impl WindowsHidppChannel {
             short,
             long,
             connected: AtomicBool::new(true),
+            device_io,
         })
     }
 
@@ -247,6 +253,9 @@ impl RawHidChannel for WindowsHidppChannel {
     }
 
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        if !self.device_io.allows_io() {
+            return Err(super::device_io_error());
+        }
         let endpoint = match src.first().copied().and_then(endpoint_for_report_id) {
             Some(ReportEndpoint::Short) => self.short.as_ref(),
             Some(ReportEndpoint::Long) => Some(&self.long),
@@ -262,6 +271,9 @@ impl RawHidChannel for WindowsHidppChannel {
             )
         })?;
 
+        if !self.device_io.allows_io() {
+            return Err(super::device_io_error());
+        }
         let result = endpoint.write_report(src).await;
         if let Err(e) = &result
             && is_permanent_disconnect(e.as_ref())


### PR DESCRIPTION
## Summary

Prevent proactive Logitech HID access from promoting an unrelated macOS maintenance DarkWake into a full wake that turns external displays back on.

This builds on the native lifecycle and inventory architecture introduced by #1137. Unified logs in #656 show the triggering sequence as RTC maintenance DarkWake → OpenLogi `IOHIDDeviceOpen` → Bluetooth LE HID activity → DarkWake-to-FullWake promotion.

## Changes

- **openlogi-device / openlogi-hid**
  - Add a latest-state process device-I/O gate shared by host lifecycle observers and HID producers.
  - Reject enumeration, HID++ opens, raw-writer opens, and writes while the gate is suspended.
  - Keep passive capture listeners alive while deferring liveness probes, reconnect rearming, and restoration writes until resume.
- **openlogi-agent-core**
  - Pause inventory, gesture, keyboard, host-switch, action, lighting, and volatile-setting I/O while suspended.
  - Discard inventory scans interrupted by suspension and reconcile once after a visible resume.
  - Disable clock-gap wake promotion on macOS, where native screen/session lifecycle is authoritative.
- **openlogi-agent**
  - Suspend on system sleep, screen sleep, or session deactivation.
  - Resume only on screen wake or session activation; deliberately ignore generic `NSWorkspaceDidWakeNotification`, which also fires for maintenance DarkWake.
  - Map Linux logind and Windows power callbacks onto the same gate.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci wasm`
- `RUSTFLAGS='-D warnings' cargo clippy --target x86_64-pc-windows-gnu -p openlogi-hid -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo clippy --target aarch64-apple-darwin -p openlogi-hid -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`

Not runtime-tested on macOS or Logitech hardware in the Linux orb. Hardware verification should use a direct-Bluetooth mouse, put the Mac/display to sleep, and confirm maintenance DarkWake logs contain no OpenLogi-triggered `IOHIDDeviceOpen`, `Bluetooth LE HID Activity`, or DarkWake-to-FullWake promotion.

Fixes #656

