### PR TITLE
fix(macos): write the scroll point delta last so pixel precision survives

### DIFF
--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -715,9 +715,15 @@ fn set_continuous_axis(
     const POINTS_PER_LINE: i64 = 10;
     const FIXED_POINT_SCALE: i64 = 1 << 16;
     let points = i64::from(points);
-    event.set_integer_value_field(point_field, points);
+    // Write order is load-bearing: a scroll CGEvent keeps one canonical
+    // distance, and writing the coarse integer *line* field makes it the
+    // canonical value — the point delta is then re-derived from it at 8
+    // points per line, discarding pixel precision (measured on macOS 15.7:
+    // frames under 10 points arrived as zero and the rest quantized to
+    // 8-point steps). Writing the point delta last keeps it authoritative.
     event.set_integer_value_field(line_field, points / POINTS_PER_LINE);
     event.set_integer_value_field(fixed_field, points * FIXED_POINT_SCALE / POINTS_PER_LINE);
+    event.set_integer_value_field(point_field, points);
 }
 
 /// Raw FFI surface for the AXUIElement/CF calls used by [`ax_browser_navigate`]


### PR DESCRIPTION
## Summary

Hardware-verification follow-up to #1141 (first of the fix series proposed there).

A scroll `CGEvent` keeps one canonical distance. `set_continuous_axis` writes the pixel/point delta first and the coarse integer **line** field after it, which makes the line count canonical: at delivery the point delta is re-derived from it at 8 points per line. Every smooth-scroll frame under 10 posted points reaches applications as **zero**, and the rest quantize to 8-point steps.

Measured on macOS 15.7 (MX Master 4, free-spin wheel, listen-only session-tap logger): a slow animated stream lost **77%** of its distance, a medium one 45%. This is most of the reason `smooth_scroll = true` currently travels less than native (#1141's 0.58× number).

The fix is a reorder: write the line and fixed-point fields first, the point delta last, so it stays authoritative. Verified with isolated synthetic-event experiments that the mangle follows field write order, not posting location (HID vs session tap both show it when the line field is written last).

## Test plan

- `cargo fmt --all --check`, `cargo clippy -p openlogi-inject --all-targets -- -D warnings` (aarch64-darwin + x86_64-pc-windows-gnu), `cargo test -p openlogi-inject`, `cargo check --workspace` — all green.
- On hardware: with this reorder, sub-10-point frames arrive intact and slow smooth-scroll streams deliver their full distance (same logger, before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)