### PR TITLE
fix(scroll): post phaseless continuous scroll events on macOS

### DIFF
--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -395,10 +395,13 @@ pub fn post_scroll(delta: ScrollDelta) {
 
 /// Lifecycle phase of one synthetic smooth-scroll frame.
 ///
-/// macOS forwards this state to the scroll-wheel event so applications see a
-/// balanced continuous gesture. Linux and Windows have no equivalent field;
-/// there the phase is retained by the runtime contract but only the frame's
-/// distance is injected.
+/// Part of the runtime contract — the motion engine emits a balanced
+/// lifecycle — but no backend forwards it today: injected frames carry only
+/// distance. macOS deliberately posts *phaseless* continuous events (matching
+/// wheel semantics); stamping `kCGScrollWheelEventScrollPhase` instead
+/// declares a trackpad gesture, which enables rubber-band overscroll and
+/// WebKit gesture latching that breaks JS-scrolled sites. Linux and Windows
+/// have no equivalent field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SmoothScrollPhase {
     /// First output frame of a new animation.
@@ -413,11 +416,11 @@ pub enum SmoothScrollPhase {
 
 /// Synthesise one frame of a finite smooth-scroll animation.
 ///
-/// On macOS wheel ticks become continuous pixel events at ten points per tick,
-/// matching the line/point relationship carried in native continuous events.
-/// Other platforms preserve fractional wheel ticks through their native
-/// high-resolution output. Non-finite distance is rejected at this I/O
-/// boundary; zero-distance terminal frames remain meaningful on macOS.
+/// On macOS wheel ticks become phaseless continuous pixel events at ten
+/// points per tick, matching the line/point relationship carried in native
+/// continuous events. Other platforms preserve fractional wheel ticks through
+/// their native high-resolution output. Non-finite distance is rejected at
+/// this I/O boundary, and zero-distance frames are dropped everywhere.
 pub fn post_smooth_scroll(delta: ScrollDelta, phase: SmoothScrollPhase) {
     if !delta.is_finite() {
         return;

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -26,10 +26,6 @@ static PIXEL_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
 static SMOOTH_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
     LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
 
-// `core-graphics` 0.25 does not expose these `CGEventTypes.h` fields.
-const SCROLL_PHASE: u32 = 99; // kCGScrollWheelEventScrollPhase
-const MOMENTUM_PHASE: u32 = 123; // kCGScrollWheelEventMomentumPhase
-
 // NX_KEYTYPE_* constants from <IOKit/hidsystem/ev_keymap.h>.
 const NX_KEYTYPE_SOUND_UP: i32 = 0;
 const NX_KEYTYPE_SOUND_DOWN: i32 = 1;
@@ -648,7 +644,7 @@ pub(super) fn post_scroll(delta: ScrollDelta) {
     ev.post(CGEventTapLocation::HID);
 }
 
-pub(super) fn post_smooth_scroll(delta: ScrollDelta, phase: SmoothScrollPhase) {
+pub(super) fn post_smooth_scroll(delta: ScrollDelta, _phase: SmoothScrollPhase) {
     const POINTS_PER_WHEEL_TICK: f64 = 10.0;
 
     let units_per_input = match delta {
@@ -662,6 +658,13 @@ pub(super) fn post_smooth_scroll(delta: ScrollDelta, phase: SmoothScrollPhase) {
     let delta = quantizer.quantize(delta, units_per_input);
     drop(quantizer);
 
+    // Sub-pixel frames quantize to zero; posting them would only flood the
+    // event stream. With no phase fields on the output there is nothing else
+    // a zero-distance frame could carry, terminal or not.
+    if delta == QuantizedScroll::default() {
+        return;
+    }
+
     let Ok(src) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
         tracing::warn!("CGEventSource::new failed for smooth scroll");
         return;
@@ -671,20 +674,15 @@ pub(super) fn post_smooth_scroll(delta: ScrollDelta, phase: SmoothScrollPhase) {
         tracing::warn!("CGEvent::new_scroll_event failed for smooth scroll");
         return;
     };
+    // Deliberately phaseless: continuous events with zeroed gesture/momentum
+    // phases scroll everywhere a wheel does, while a Began/Changed/Ended
+    // stream declares a trackpad gesture — which switches AppKit/WebKit into
+    // gesture handling (rubber-band overscroll appears on wheel scrolls, and
+    // WebKit's gesture latching can starve sites that scroll from JS wheel
+    // handlers).
     set_continuous_scroll_fields(&ev, delta);
-    ev.set_integer_value_field(SCROLL_PHASE, scroll_phase_value(phase));
-    ev.set_integer_value_field(MOMENTUM_PHASE, 0);
     tag_synthetic(&ev);
     ev.post(CGEventTapLocation::HID);
-}
-
-const fn scroll_phase_value(phase: SmoothScrollPhase) -> i64 {
-    match phase {
-        SmoothScrollPhase::Began => 1,
-        SmoothScrollPhase::Changed => 2,
-        SmoothScrollPhase::Ended => 4,
-        SmoothScrollPhase::Cancelled => 8,
-    }
 }
 
 fn set_continuous_scroll_fields(event: &CGEvent, delta: QuantizedScroll) {


### PR DESCRIPTION
## Summary

Hardware-verification follow-up to #1141 (second of the fix series proposed there; independent of #1156 — they touch different functions and merge in any order).

Stamping `kCGScrollWheelEventScrollPhase` (Began/Changed/Ended) onto the synthetic smooth-scroll frames declares a trackpad **gesture** to the system, and applications act on that:

- **Rubber-band elastic overscroll** appears on plain wheel scrolling (AppKit/WebKit enable it for gesture streams) — reproduced in Brave and Apple Mail's sidebar.
- **WebKit gesture latching starves sites that scroll from JS wheel handlers** — reproduced on Fastmail's virtualized mailbox list in Safari, which stopped scrolling entirely. The `Began` frames even go out with zero delta, exactly what a latch keys off.

Native continuous wheels and established smooth-scroll utilities emit **phaseless** continuous events (captured SmoothScroll.app 1.7.6 output: phase 0 on all events). Switching our macOS injection to phaseless fixed both problems on hardware immediately, with no change in delivered distance.

The engine's balanced phase lifecycle stays the cross-platform runtime contract (Linux/Windows already inject distance only); the phase is simply no longer forwarded into the CGEvent. Zero-distance frames now have nothing left to carry, so they're dropped at the boundary instead of flooding the stream.

Known trade-off, accepted deliberately: phaseless output also means no elastic bounce in apps where trackpad users get it — identical to how the commercial reference utilities behave.

## Test plan

- `cargo fmt --all --check`, `cargo clippy -p openlogi-inject --all-targets -- -D warnings` (aarch64-darwin + x86_64-pc-windows-gnu), `cargo test -p openlogi-inject`, `cargo check --workspace` — all green.
- On hardware (macOS 15.7, MX Master 4): rubber-band gone in Brave/Mail, Fastmail scrolls normally, no regressions across several days of daily use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)