### PR TITLE
fix(hid): normalize thumbwheel direction per device

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -292,7 +292,29 @@ impl Orchestrator {
                 gestures.remove(button);
             }
         }
-        HookMaps { bindings, gestures }
+        HookMaps {
+            bindings,
+            gestures,
+            selected_device: key.map(str::to_owned),
+            ..HookMaps::default()
+        }
+    }
+
+    /// Publish hook maps while preserving thumb-wheel polarities learned from
+    /// hardware capture sessions. Selection, polarity, and bindings share the
+    /// one lock the callback reads, so a device switch cannot combine facts
+    /// from two devices.
+    fn publish_hook_maps(&self, mut maps: HookMaps) {
+        match self.shared.hook_maps.write() {
+            Ok(mut current) => {
+                maps.thumbwheel_positive_is_forward =
+                    std::mem::take(&mut current.thumbwheel_positive_is_forward);
+                *current = maps;
+            }
+            Err(error) => {
+                warn!(%error, lock = "hook_maps", "lock poisoned — keeping stale value");
+            }
+        }
     }
 
     /// The keyboard key-capture spec for the first known keyboard, or `None`
@@ -340,13 +362,7 @@ impl Orchestrator {
     /// Rewrite every shared map from the current config + selected device.
     fn rebuild(&self) {
         let key = self.current_key();
-        // One write publishes both hook maps atomically, so a button press during
-        // an owner switch can't observe a half-updated state.
-        write_value(
-            &self.shared.hook_maps,
-            self.hook_maps_for(key, self.current_app.as_deref()),
-            "hook_maps",
-        );
+        self.publish_hook_maps(self.hook_maps_for(key, self.current_app.as_deref()));
         self.publish_device_runtime();
     }
 
@@ -810,11 +826,7 @@ impl Orchestrator {
             return false;
         }
         self.current_app = id;
-        write_value(
-            &self.shared.hook_maps,
-            self.hook_maps_for(self.current_key(), self.current_app.as_deref()),
-            "hook_maps",
-        );
+        self.publish_hook_maps(self.hook_maps_for(self.current_key(), self.current_app.as_deref()));
         // Capture plans are app-scoped (per-app binding overlays); republish
         // them with the keyboard's effective bindings.
         self.publish_device_runtime();

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -921,6 +921,27 @@ fn app_switch_republishes_capture_plans() {
 }
 
 #[test]
+fn hook_maps_publish_selection_and_preserve_learned_thumbwheel_polarity() {
+    let mut orch = orchestrator(Config::default());
+    orch.devices = vec![dev("a", 1, true)];
+    orch.rebuild();
+
+    {
+        let mut maps = orch.shared.hook_maps.write().expect("hook maps");
+        assert_eq!(maps.selected_device.as_deref(), Some("a"));
+        maps.thumbwheel_positive_is_forward
+            .insert("a".to_owned(), true);
+    }
+
+    // Config/app rebuilds replace binding maps but hardware observations must
+    // remain in the same atomically published snapshot.
+    orch.reload_config(Config::default());
+    let maps = orch.shared.hook_maps.read().expect("hook maps");
+    assert_eq!(maps.selected_device.as_deref(), Some("a"));
+    assert_eq!(maps.thumbwheel_positive_is_forward.get("a"), Some(&true));
+}
+
+#[test]
 fn macos_side_gesture_capture_follows_mouse_hook_availability() {
     let mut config = Config::default();
     config.set_gesture_mode("a", ButtonId::Forward, true);

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -49,15 +49,6 @@ pub struct HookMaps {
     pub(crate) thumbwheel_positive_is_forward: BTreeMap<String, bool>,
 }
 
-impl HookMaps {
-    #[cfg(any(target_os = "windows", test))]
-    fn selected_thumbwheel_positive_is_forward(&self) -> Option<bool> {
-        self.thumbwheel_positive_is_forward
-            .get(self.selected_device.as_deref()?)
-            .copied()
-    }
-}
-
 /// Shared, atomically-published [`HookMaps`], threaded between the config owner
 /// (orchestrator), the OS-hook callback, and the gesture watcher.
 pub type SharedHookMaps = Arc<RwLock<HookMaps>>;
@@ -525,13 +516,16 @@ pub fn start(
 /// The built-in horizontal-scroll defaults intentionally return `None` so the
 /// physical wheel stays native unless the user changed that direction. On
 /// devices exposing `0x2150`, the learned `default_dir` determines which
-/// physical direction the native delta represents. Unknown devices retain the
-/// MX Master 2S fallback: positive is physical backward/down.
+/// physical direction the native delta represents. A selected device whose
+/// polarity has not arrived yet fails open instead of guessing the opposite
+/// action; only the legacy no-device-context path retains the MX Master 2S
+/// fallback (positive is physical backward/down).
 #[cfg(any(target_os = "windows", test))]
 fn rebound_thumbwheel_action(maps: &HookMaps, delta_x: f64) -> Option<(ButtonId, Action)> {
-    let positive_is_forward = maps
-        .selected_thumbwheel_positive_is_forward()
-        .unwrap_or(false);
+    let positive_is_forward = match maps.selected_device.as_deref() {
+        Some(key) => maps.thumbwheel_positive_is_forward.get(key).copied()?,
+        None => false,
+    };
     let forward = if delta_x > 0.0 {
         positive_is_forward
     } else if delta_x < 0.0 {

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -23,10 +23,10 @@ use super::scroll::ScrollInputHandle;
 use super::{ActionDispatcher, PressToken};
 use crate::event_monitor::SharedEventMonitor;
 
-/// The two button maps the OS-hook callback reads, kept behind ONE lock so a
-/// config rebuild publishes both atomically — a press during an owner switch can
-/// never see the new single-action bindings against the old gesture map (or vice
-/// versa), and the common case reads one lock instead of two.
+/// The button maps and selected-device thumb-wheel polarity the OS-hook callback
+/// reads, kept behind ONE lock so a config rebuild publishes one coherent
+/// snapshot. A callback during a device/app switch can never combine one
+/// device's bindings with another device's direction convention.
 #[derive(Default)]
 pub struct HookMaps {
     /// Per-button immediate or threshold binding — the non-gesture dispatch path.
@@ -36,6 +36,26 @@ pub struct HookMaps {
     /// HID++ gesture button (0x00c3) uses the gesture watcher's separate map
     /// instead — it never reaches the OS hook.
     pub gestures: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
+    /// Device whose binding maps this snapshot contains.
+    #[cfg_attr(
+        not(any(target_os = "windows", test)),
+        expect(dead_code, reason = "read only by the Windows native-wheel fallback")
+    )]
+    pub(crate) selected_device: Option<String>,
+    /// Per-device `0x2150 default_dir`, learned by HID++ capture sessions:
+    /// `true` means a positive native horizontal delta is physical forward/up.
+    /// Entries survive map rebuilds because they are hardware observations,
+    /// not configuration.
+    pub(crate) thumbwheel_positive_is_forward: BTreeMap<String, bool>,
+}
+
+impl HookMaps {
+    #[cfg(any(target_os = "windows", test))]
+    fn selected_thumbwheel_positive_is_forward(&self) -> Option<bool> {
+        self.thumbwheel_positive_is_forward
+            .get(self.selected_device.as_deref()?)
+            .copied()
+    }
 }
 
 /// Shared, atomically-published [`HookMaps`], threaded between the config owner
@@ -504,16 +524,25 @@ pub fn start(
 /// Resolve a native horizontal-wheel tick to a rebound thumb-wheel action.
 /// The built-in horizontal-scroll defaults intentionally return `None` so the
 /// physical wheel stays native unless the user changed that direction. On
-/// Windows/MX Master 2S, positive `WM_MOUSEHWHEEL` delta is the physical
-/// backward/down direction, so it maps to `ThumbwheelScrollDown`.
+/// devices exposing `0x2150`, the learned `default_dir` determines which
+/// physical direction the native delta represents. Unknown devices retain the
+/// MX Master 2S fallback: positive is physical backward/down.
 #[cfg(any(target_os = "windows", test))]
 fn rebound_thumbwheel_action(maps: &HookMaps, delta_x: f64) -> Option<(ButtonId, Action)> {
-    let button = if delta_x > 0.0 {
-        ButtonId::ThumbwheelScrollDown
+    let positive_is_forward = maps
+        .selected_thumbwheel_positive_is_forward()
+        .unwrap_or(false);
+    let forward = if delta_x > 0.0 {
+        positive_is_forward
     } else if delta_x < 0.0 {
-        ButtonId::ThumbwheelScrollUp
+        !positive_is_forward
     } else {
         return None;
+    };
+    let button = if forward {
+        ButtonId::ThumbwheelScrollUp
+    } else {
+        ButtonId::ThumbwheelScrollDown
     };
     let action = maps.bindings.get(&button)?.click_action();
     (action != default_binding(button)).then_some((button, action))

--- a/crates/openlogi-agent-core/src/runtime/hook/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook/tests.rs
@@ -201,7 +201,7 @@ fn rebound_horizontal_wheel_maps_to_thumbwheel_directions() {
             (ButtonId::ThumbwheelScrollUp, Action::NextTab.into()),
             (ButtonId::ThumbwheelScrollDown, Action::PrevTab.into()),
         ]),
-        gestures: BTreeMap::new(),
+        ..HookMaps::default()
     };
     assert_eq!(
         rebound_thumbwheel_action(&maps, 1.0),
@@ -212,6 +212,27 @@ fn rebound_horizontal_wheel_maps_to_thumbwheel_directions() {
         Some((ButtonId::ThumbwheelScrollUp, Action::NextTab))
     );
     assert_eq!(rebound_thumbwheel_action(&maps, 0.0), None);
+}
+
+#[test]
+fn rebound_horizontal_wheel_uses_the_selected_devices_polarity() {
+    let maps = HookMaps {
+        bindings: BTreeMap::from([
+            (ButtonId::ThumbwheelScrollUp, Action::NextTab.into()),
+            (ButtonId::ThumbwheelScrollDown, Action::PrevTab.into()),
+        ]),
+        selected_device: Some("mx3".to_owned()),
+        thumbwheel_positive_is_forward: BTreeMap::from([("mx3".to_owned(), true)]),
+        ..HookMaps::default()
+    };
+    assert_eq!(
+        rebound_thumbwheel_action(&maps, 1.0),
+        Some((ButtonId::ThumbwheelScrollUp, Action::NextTab))
+    );
+    assert_eq!(
+        rebound_thumbwheel_action(&maps, -1.0),
+        Some((ButtonId::ThumbwheelScrollDown, Action::PrevTab))
+    );
 }
 
 #[test]
@@ -227,7 +248,7 @@ fn native_thumbwheel_scroll_stays_os_native() {
                 default_binding(ButtonId::ThumbwheelScrollDown).into(),
             ),
         ]),
-        gestures: BTreeMap::new(),
+        ..HookMaps::default()
     };
     assert_eq!(rebound_thumbwheel_action(&maps, 1.0), None);
     assert_eq!(rebound_thumbwheel_action(&maps, -1.0), None);

--- a/crates/openlogi-agent-core/src/runtime/hook/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook/tests.rs
@@ -236,6 +236,20 @@ fn rebound_horizontal_wheel_uses_the_selected_devices_polarity() {
 }
 
 #[test]
+fn rebound_horizontal_wheel_does_not_guess_a_selected_devices_polarity() {
+    let maps = HookMaps {
+        bindings: BTreeMap::from([
+            (ButtonId::ThumbwheelScrollUp, Action::NextTab.into()),
+            (ButtonId::ThumbwheelScrollDown, Action::PrevTab.into()),
+        ]),
+        selected_device: Some("not-learned-yet".to_owned()),
+        ..HookMaps::default()
+    };
+    assert_eq!(rebound_thumbwheel_action(&maps, 1.0), None);
+    assert_eq!(rebound_thumbwheel_action(&maps, -1.0), None);
+}
+
+#[test]
 fn native_thumbwheel_scroll_stays_os_native() {
     let maps = HookMaps {
         bindings: BTreeMap::from([

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -41,6 +41,7 @@ use self::dispatch::InputDispatcher;
 use super::capture_session::{CaptureSession, CompletionAction, ReconcileAction};
 use crate::capture_plan::{CaptureTarget, DeviceCapturePlan, DispatchPlan, SharedCapturePlans};
 use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
+use crate::runtime::hook::SharedHookMaps;
 use crate::runtime::scroll::ScrollInputHandle;
 use crate::runtime::{ActionDispatcher, HidppSessionId};
 
@@ -84,6 +85,7 @@ pub fn spawn(
     channel_registry: openlogi_hid::ChannelRegistry,
     device_io: DeviceIoGate,
     outputs: GestureOutputs,
+    hook_maps: SharedHookMaps,
 ) {
     let plans = capture_plans.clone();
     let receiver_requests = receiver_access.subscribe_requests();
@@ -105,6 +107,7 @@ pub fn spawn(
             receiver_requests,
             channel_registry,
             device_io,
+            hook_maps,
             outputs,
         ));
     });
@@ -319,12 +322,12 @@ fn restart_deadline(unexpected: bool, now: Instant) -> Option<Instant> {
 }
 
 impl GestureManagerState {
-    fn new(outputs: GestureOutputs) -> Self {
+    fn new(hook_maps: SharedHookMaps, outputs: GestureOutputs) -> Self {
         Self {
             sessions: HashMap::new(),
             pending_restores: HashMap::new(),
             restart_after: HashMap::new(),
-            input_dispatcher: InputDispatcher::new(outputs),
+            input_dispatcher: InputDispatcher::new(hook_maps, outputs),
             lease: std::sync::Weak::new(),
         }
     }
@@ -499,6 +502,7 @@ async fn manage(
     mut receiver_requests: watch::Receiver<ReceiverRequestState>,
     channel_registry: openlogi_hid::ChannelRegistry,
     mut device_io: DeviceIoGate,
+    hook_maps: SharedHookMaps,
     outputs: GestureOutputs,
 ) {
     let (events, mut event_rx) = mpsc::unbounded_channel::<SessionEvent>();
@@ -516,7 +520,7 @@ async fn manage(
         registry: channel_registry,
         device_io: device_io.clone(),
     };
-    let mut state = GestureManagerState::new(outputs);
+    let mut state = GestureManagerState::new(hook_maps, outputs);
     let mut reconcile = true;
 
     loop {

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -52,13 +52,22 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 pub struct GestureOutputs {
     actions: ActionDispatcher,
     scroll: ScrollInputHandle,
+    hook_maps: SharedHookMaps,
 }
 
 impl GestureOutputs {
     /// Build gesture outputs backed by the shared action and scroll runtimes.
     #[must_use]
-    pub fn new(actions: ActionDispatcher, scroll: ScrollInputHandle) -> Self {
-        Self { actions, scroll }
+    pub fn new(
+        actions: ActionDispatcher,
+        scroll: ScrollInputHandle,
+        hook_maps: SharedHookMaps,
+    ) -> Self {
+        Self {
+            actions,
+            scroll,
+            hook_maps,
+        }
     }
 
     fn cancel_session(&self, session: &HidppSessionId) {
@@ -85,7 +94,6 @@ pub fn spawn(
     channel_registry: openlogi_hid::ChannelRegistry,
     device_io: DeviceIoGate,
     outputs: GestureOutputs,
-    hook_maps: SharedHookMaps,
 ) {
     let plans = capture_plans.clone();
     let receiver_requests = receiver_access.subscribe_requests();
@@ -107,7 +115,6 @@ pub fn spawn(
             receiver_requests,
             channel_registry,
             device_io,
-            hook_maps,
             outputs,
         ));
     });
@@ -322,12 +329,12 @@ fn restart_deadline(unexpected: bool, now: Instant) -> Option<Instant> {
 }
 
 impl GestureManagerState {
-    fn new(hook_maps: SharedHookMaps, outputs: GestureOutputs) -> Self {
+    fn new(outputs: GestureOutputs) -> Self {
         Self {
             sessions: HashMap::new(),
             pending_restores: HashMap::new(),
             restart_after: HashMap::new(),
-            input_dispatcher: InputDispatcher::new(hook_maps, outputs),
+            input_dispatcher: InputDispatcher::new(outputs),
             lease: std::sync::Weak::new(),
         }
     }
@@ -502,7 +509,6 @@ async fn manage(
     mut receiver_requests: watch::Receiver<ReceiverRequestState>,
     channel_registry: openlogi_hid::ChannelRegistry,
     mut device_io: DeviceIoGate,
-    hook_maps: SharedHookMaps,
     outputs: GestureOutputs,
 ) {
     let (events, mut event_rx) = mpsc::unbounded_channel::<SessionEvent>();
@@ -520,7 +526,7 @@ async fn manage(
         registry: channel_registry,
         device_io: device_io.clone(),
     };
-    let mut state = GestureManagerState::new(hook_maps, outputs);
+    let mut state = GestureManagerState::new(outputs);
     let mut reconcile = true;
 
     loop {

--- a/crates/openlogi-agent-core/src/watchers/gesture/dispatch.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/dispatch.rs
@@ -13,6 +13,7 @@ use tracing::debug;
 use self::wheel::{ScrollScale, WheelAccumulators, WheelOutput, WheelRotation};
 use super::GestureOutputs;
 use crate::capture_plan::DispatchPlan;
+use crate::runtime::hook::SharedHookMaps;
 use crate::runtime::{HidppSessionId, PressToken};
 
 /// Effective thumb-wheel configuration whose continuity is tied to one
@@ -94,6 +95,7 @@ impl SessionWheels {
 /// Input routing plus the per-session state retained between
 /// captured events. Capture-session lifecycle remains owned by the parent.
 pub(super) struct InputDispatcher {
+    hook_maps: SharedHookMaps,
     outputs: GestureOutputs,
     wheels: SessionWheels,
     gesture_presses: GesturePresses,
@@ -101,12 +103,28 @@ pub(super) struct InputDispatcher {
 
 impl InputDispatcher {
     /// Build a dispatcher for session-owned capture-plan snapshots.
-    pub(super) fn new(outputs: GestureOutputs) -> Self {
+    pub(super) fn new(hook_maps: SharedHookMaps, outputs: GestureOutputs) -> Self {
         Self {
+            hook_maps,
             outputs,
             wheels: SessionWheels::default(),
             gesture_presses: GesturePresses::default(),
         }
+    }
+
+    /// Publish a hardware polarity observation into the OS-hook snapshot.
+    fn record_thumbwheel_direction(&self, key: &str, input: CapturedInput) -> bool {
+        let CapturedInput::ThumbwheelDirection {
+            positive_is_forward,
+        } = input
+        else {
+            return false;
+        };
+        if let Ok(mut maps) = self.hook_maps.write() {
+            maps.thumbwheel_positive_is_forward
+                .insert(key.to_owned(), positive_is_forward);
+        }
+        true
     }
 
     /// Cancel every input lifecycle retained for one capture session.
@@ -125,6 +143,9 @@ impl InputDispatcher {
         input: CapturedInput,
     ) {
         let key = session.device_key();
+        if self.record_thumbwheel_direction(key, input) {
+            return;
+        }
         match input {
             CapturedInput::Gesture(button, direction) => {
                 let Some(press) = self.gesture_presses.get(session, button) else {
@@ -212,6 +233,9 @@ impl InputDispatcher {
                         self.outputs.actions.dispatch(action, Some(key));
                     }
                 }
+            }
+            CapturedInput::ThumbwheelDirection { .. } => {
+                unreachable!("thumb-wheel direction reports return before dispatch")
             }
         }
     }

--- a/crates/openlogi-agent-core/src/watchers/gesture/dispatch.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/dispatch.rs
@@ -103,9 +103,9 @@ pub(super) struct InputDispatcher {
 
 impl InputDispatcher {
     /// Build a dispatcher for session-owned capture-plan snapshots.
-    pub(super) fn new(hook_maps: SharedHookMaps, outputs: GestureOutputs) -> Self {
+    pub(super) fn new(outputs: GestureOutputs) -> Self {
         Self {
-            hook_maps,
+            hook_maps: outputs.hook_maps.clone(),
             outputs,
             wheels: SessionWheels::default(),
             gesture_presses: GesturePresses::default(),

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -167,7 +167,9 @@ fn dispatch_input(
         CapturedInput::ButtonPulse(button) => {
             dispatcher.dispatch_hidpp_button_pulse(session, button, bindings.bindings.get(&button));
         }
-        CapturedInput::Gesture(..) | CapturedInput::Scroll { .. } => {}
+        CapturedInput::Gesture(..)
+        | CapturedInput::Scroll { .. }
+        | CapturedInput::ThumbwheelDirection { .. } => {}
     }
 }
 

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -176,8 +176,11 @@ pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputService
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
         shared.device_io.clone(),
-        GestureOutputs::new(inputs.dispatcher.clone(), inputs.scroll_input.clone()),
-        shared.hook_maps.clone(),
+        GestureOutputs::new(
+            inputs.dispatcher.clone(),
+            inputs.scroll_input.clone(),
+            shared.hook_maps.clone(),
+        ),
     );
     watchers::host_switch::spawn(
         &shared.host_switch_links,

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -177,6 +177,7 @@ pub(crate) fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputService
         shared.channel_registry.clone(),
         shared.device_io.clone(),
         GestureOutputs::new(inputs.dispatcher.clone(), inputs.scroll_input.clone()),
+        shared.hook_maps.clone(),
     );
     watchers::host_switch::spawn(
         &shared.host_switch_links,

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -57,13 +57,15 @@ pub fn default_binding(button: ButtonId) -> Action {
                       not because the control stays native like the keyboard arm below"
         )]
         ButtonId::Thumbwheel => Action::None,
-        // The thumb wheel scrolls horizontally by default: rotating it produces
-        // continuous horizontal scroll, with "up" → right and "down" → left.
-        // The wheel watcher renders these two actions as smooth, sensitivity-
-        // scaled scrolling rather than the discrete per-press burst a button
-        // would get (see `watchers::gesture`).
-        ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollRight,
-        ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollLeft,
+        // The thumb wheel scrolls horizontally in firmware: "up" (forward)
+        // scrolls left and "down" scrolls right. The device capture boundary
+        // normalises model-specific `0x2150 default_dir` polarity before these
+        // bindings are resolved, so the same physical direction reaches the
+        // same default on every model. The wheel watcher renders these actions
+        // as smooth, sensitivity-scaled scrolling rather than the discrete
+        // per-press burst a button would get (see `watchers::gesture`).
+        ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollLeft,
+        ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollRight,
         ButtonId::GestureButton => Action::MissionControl,
         ButtonId::HapticPanel => Action::ShowActionsRing,
         // Keyboard keys stay on their native firmware function until the user

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -533,6 +533,21 @@ fn wheel_tilt_defaults_to_the_scroll_its_firmware_already_does() {
     }
 }
 
+#[test]
+fn thumbwheel_defaults_match_normalised_native_direction() {
+    // HID++ capture normalises the per-model firmware polarity to physical
+    // forward/up. The defaults must then reproduce native horizontal scroll,
+    // including when sensitivity alone causes the wheel to be diverted.
+    assert_eq!(
+        default_binding(ButtonId::ThumbwheelScrollUp),
+        Action::HorizontalScrollLeft
+    );
+    assert_eq!(
+        default_binding(ButtonId::ThumbwheelScrollDown),
+        Action::HorizontalScrollRight
+    );
+}
+
 // ── Effect classification ─────────────────────────────────────────────────
 //
 // `Action::effect()` is the platform-neutral IR `openlogi-inject`'s three

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -49,6 +49,11 @@ use settings::GestureOwner;
 /// persisted shape or enum vocabulary changes; readers inspect this value
 /// before consuming the rest of the file.
 ///
+/// v7 aligns the thumb-wheel scroll defaults with its normalised physical
+/// direction. Pre-v7 explicit default pairs are migrated in device and
+/// per-application profiles so they remain native rather than becoming a
+/// reversal (see `Config::migrate_thumbwheel_native_direction`).
+///
 /// v6 adds threshold-based `{ short = ..., long = ... }` button bindings.
 ///
 /// v5 also drops the transport prefix from `direct:` keys: `direct:046d:c08d:unit:6be9d300`
@@ -86,7 +91,7 @@ use settings::GestureOwner;
 /// next save; [`Config::load_from_path`] accepts supported versions `1` through
 /// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
 /// silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 6;
+pub const SCHEMA_VERSION: u32 = 7;
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -511,6 +516,68 @@ impl Config {
             for target in &mut device.host_switch_targets {
                 if let Some((new, _)) = renames.get(target) {
                     *target = new.clone();
+                }
+            }
+        }
+    }
+
+    /// Preserve the native behavior of explicit pre-v7 thumb-wheel defaults.
+    ///
+    /// Before v7 the built-in pair was forward/up → right and backward/down →
+    /// left. Because that pair equaled the defaults, an explicit copy in either
+    /// a device or per-app profile kept the wheel native. v7 swaps the defaults
+    /// after normalising device polarity; leaving an old pair in place would
+    /// now request a real reversal. Rewrite only profiles whose effective pair
+    /// was exactly the old default. Mixed/custom pairs already had literal
+    /// diverted semantics and must remain untouched.
+    #[cfg(feature = "fs")]
+    fn migrate_thumbwheel_native_direction(&mut self) {
+        let old_up = Action::HorizontalScrollRight;
+        let old_down = Action::HorizontalScrollLeft;
+        let new_up = Action::HorizontalScrollLeft;
+        let new_down = Action::HorizontalScrollRight;
+        let is_old_default = |binding: Option<&Binding>, old: &Action| match binding {
+            None => true,
+            Some(Binding::Single(action)) => action == old,
+            Some(Binding::Gesture(_) | Binding::LongPress(_)) => false,
+        };
+
+        for device in self.devices.values_mut() {
+            let global_up_is_old =
+                is_old_default(device.bindings.get(&ButtonId::ThumbwheelScrollUp), &old_up);
+            let global_down_is_old = is_old_default(
+                device.bindings.get(&ButtonId::ThumbwheelScrollDown),
+                &old_down,
+            );
+
+            for overlay in device.per_app_bindings.values_mut() {
+                let overrides_direction = overlay.contains_key(&ButtonId::ThumbwheelScrollUp)
+                    || overlay.contains_key(&ButtonId::ThumbwheelScrollDown);
+                let effective_up_is_old = overlay
+                    .get(&ButtonId::ThumbwheelScrollUp)
+                    .map_or(global_up_is_old, |action| action == &old_up);
+                let effective_down_is_old = overlay
+                    .get(&ButtonId::ThumbwheelScrollDown)
+                    .map_or(global_down_is_old, |action| action == &old_down);
+                if overrides_direction && effective_up_is_old && effective_down_is_old {
+                    // Write the complete pair. This also handles a profile that
+                    // reached the old defaults by overriding one half of a
+                    // custom global pair and inheriting the other half.
+                    overlay.insert(ButtonId::ThumbwheelScrollUp, new_up.clone());
+                    overlay.insert(ButtonId::ThumbwheelScrollDown, new_down.clone());
+                }
+            }
+
+            if global_up_is_old && global_down_is_old {
+                if let Some(Binding::Single(action)) =
+                    device.bindings.get_mut(&ButtonId::ThumbwheelScrollUp)
+                {
+                    *action = new_up.clone();
+                }
+                if let Some(Binding::Single(action)) =
+                    device.bindings.get_mut(&ButtonId::ThumbwheelScrollDown)
+                {
+                    *action = new_down.clone();
                 }
             }
         }

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -273,6 +273,11 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
     if header.schema_version <= 4 {
         config.migrate_transport_scoped_keys();
     }
+    // Every released schema may contain an explicit copy of the pre-v7
+    // thumb-wheel defaults, either globally or in a per-app profile.
+    if header.schema_version <= 6 {
+        config.migrate_thumbwheel_native_direction();
+    }
     config.repair_duplicate_routes();
     config.schema_version = SCHEMA_VERSION;
     Ok((config, header.schema_version))

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1047,6 +1047,144 @@ Click = \"Paste\"
 }
 
 #[test]
+fn migrates_pre_v7_thumbwheel_defaults_to_normalised_native_direction() {
+    let v6 = "\
+schema_version = 6
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = \"HorizontalScrollRight\"
+ThumbwheelScrollDown = \"HorizontalScrollLeft\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v6).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v6");
+    let bindings = cfg.bindings_for("unit:6be9d300");
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::HorizontalScrollLeft))
+    );
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::HorizontalScrollRight))
+    );
+}
+
+#[test]
+fn migrates_a_pre_v7_per_app_pair_that_was_effectively_default() {
+    // The app overrides only one half; the other old default comes from a
+    // custom global pair. The migration must materialise both new defaults in
+    // the app so it remains native without changing the custom global profile.
+    let v6 = "\
+schema_version = 6
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = \"NextTab\"
+ThumbwheelScrollDown = \"HorizontalScrollLeft\"
+
+[devices.\"unit:6be9d300\".per_app_bindings.\"com.example.Editor\"]
+ThumbwheelScrollUp = \"HorizontalScrollRight\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v6).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v6");
+    let app = cfg.effective_bindings("unit:6be9d300", Some("com.example.Editor"));
+    assert_eq!(
+        app.get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::HorizontalScrollLeft))
+    );
+    assert_eq!(
+        app.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::HorizontalScrollRight))
+    );
+    assert_eq!(
+        cfg.bindings_for("unit:6be9d300")
+            .get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::NextTab)),
+        "the custom global pair must stay literal"
+    );
+}
+
+#[test]
+fn pre_v7_thumbwheel_migration_leaves_a_custom_pair_unchanged() {
+    let v6 = "\
+schema_version = 6
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = \"HorizontalScrollRight\"
+ThumbwheelScrollDown = \"NextTab\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v6).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v6");
+    let bindings = cfg.bindings_for("unit:6be9d300");
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::HorizontalScrollRight))
+    );
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::NextTab))
+    );
+}
+
+#[test]
+fn pre_v7_thumbwheel_migration_preserves_non_single_binding_shapes() {
+    let v6 = "\
+schema_version = 6
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = { short = \"HorizontalScrollRight\", long = \"NextTab\" }
+ThumbwheelScrollDown = \"HorizontalScrollLeft\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v6).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v6");
+    let bindings = cfg.bindings_for("unit:6be9d300");
+    let Some(Binding::LongPress(up)) = bindings.get(&ButtonId::ThumbwheelScrollUp) else {
+        panic!("custom long-press binding must keep its shape");
+    };
+    assert_eq!(up.short(), &Action::HorizontalScrollRight);
+    assert_eq!(up.long(), &Action::NextTab);
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::HorizontalScrollLeft))
+    );
+}
+
+#[test]
+fn v7_reversed_thumbwheel_pair_survives_reload() {
+    let v7 = "\
+schema_version = 7
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = \"HorizontalScrollRight\"
+ThumbwheelScrollDown = \"HorizontalScrollLeft\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v7).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v7");
+    let bindings = cfg.bindings_for("unit:6be9d300");
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::HorizontalScrollRight))
+    );
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::HorizontalScrollLeft))
+    );
+}
+
+#[test]
 fn migration_gesture_map_wins_over_legacy_single_gesture_button_entry() {
     // The data-loss guard: when a legacy single button_bindings[GestureButton]
     // entry coexists with a gesture_bindings map (reachable via hand-edited

--- a/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
+++ b/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
@@ -28,10 +28,11 @@ pub(crate) enum ThumbwheelPreset {
     VerticalScroll,
     VerticalScrollReversed,
     HorizontalScroll,
+    HorizontalScrollReversed,
 }
 
 impl ThumbwheelPreset {
-    pub(crate) const ALL: [Self; 12] = [
+    pub(crate) const ALL: [Self; 13] = [
         Self::BackForward,
         Self::UndoRedo,
         Self::BrowserHistory,
@@ -44,6 +45,7 @@ impl ThumbwheelPreset {
         Self::VerticalScroll,
         Self::VerticalScrollReversed,
         Self::HorizontalScroll,
+        Self::HorizontalScrollReversed,
     ];
 
     #[must_use]
@@ -60,7 +62,13 @@ impl ThumbwheelPreset {
             Self::CycleDpi => (Action::CycleDpiPresets, Action::CycleDpiPresets),
             Self::VerticalScroll => (Action::ScrollDown, Action::ScrollUp),
             Self::VerticalScrollReversed => (Action::ScrollUp, Action::ScrollDown),
-            Self::HorizontalScroll => (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),
+            // The plain pair must equal the native-direction defaults so
+            // picking it never diverts the wheel; the reversed pair is the
+            // swap, which diverts and injects the opposite direction.
+            Self::HorizontalScroll => (Action::HorizontalScrollRight, Action::HorizontalScrollLeft),
+            Self::HorizontalScrollReversed => {
+                (Action::HorizontalScrollLeft, Action::HorizontalScrollRight)
+            }
         };
         ThumbwheelPair { backward, forward }
     }
@@ -90,6 +98,7 @@ impl ThumbwheelPreset {
             Self::VerticalScroll => "Vertical Scroll",
             Self::VerticalScrollReversed => "Vertical Scroll (Reversed)",
             Self::HorizontalScroll => "Horizontal Scroll",
+            Self::HorizontalScrollReversed => "Horizontal Scroll (Reversed)",
         }
     }
 
@@ -105,7 +114,9 @@ impl ThumbwheelPreset {
             Self::Volume | Self::VolumeReversed => "action-icons/volume-2.svg",
             Self::CycleDpi => "action-icons/gauge.svg",
             Self::VerticalScroll | Self::VerticalScrollReversed => "action-icons/chevrons-up.svg",
-            Self::HorizontalScroll => "action-icons/chevrons-right.svg",
+            Self::HorizontalScroll | Self::HorizontalScrollReversed => {
+                "action-icons/chevrons-right.svg"
+            }
         }
     }
 }
@@ -128,6 +139,7 @@ mod tests {
             (Action::CycleDpiPresets, Action::CycleDpiPresets),
             (Action::ScrollDown, Action::ScrollUp),
             (Action::ScrollUp, Action::ScrollDown),
+            (Action::HorizontalScrollRight, Action::HorizontalScrollLeft),
             (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),
         ];
 

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -53,7 +53,7 @@ pub use super::capture_restore::{
     PendingCaptureRestore,
 };
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
-use crate::thumbwheel::{self, Thumbwheel, WheelDirection, WheelResolution};
+use crate::thumbwheel::{self, Thumbwheel, ThumbwheelInfo, WheelDirection, WheelResolution};
 
 /// One input captured from the active device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,13 +68,23 @@ pub enum CapturedInput {
     /// Emitted while the wheel is diverted (click bound, rotation rebound, or
     /// sensitivity changed).
     Scroll {
-        /// Rotation in the wheel's diverted increments.
+        /// Rotation in the wheel's diverted increments. Positive is always
+        /// physical forward/up: arming normalises the model-specific polarity
+        /// reported by `0x2150 default_dir`.
         increments: i16,
         /// What one revolution measures in each mode, so the dispatcher can
         /// scale those increments back to the wheel's native scroll amount
         /// instead of scrolling by however finely this wheel happens to
         /// report.
         resolution: WheelResolution,
+    },
+    /// The un-inverted polarity learned while arming a thumb wheel. This is a
+    /// one-time session fact rather than user input; the agent records it for
+    /// native horizontal-wheel events that the Windows hook cannot attribute
+    /// to a device.
+    ThumbwheelDirection {
+        /// Whether a positive native delta is physical forward/up.
+        positive_is_forward: bool,
     },
     /// A diverted button's physical up edge.
     ButtonUp(ButtonId),
@@ -290,6 +300,10 @@ async fn run_capture_session_on(
     let device_index = shared.device_index();
     let armed = arm_controls(&chan, device_index, &spec, &shared, registry).await?;
 
+    if let Some(direction) = armed.thumbwheel_direction() {
+        let _ = sink.send(direction);
+    }
+
     // Publish this device's open channel so DPI/SmartShift writes reuse it
     // instead of opening their own. Cleared on the way out.
     if let Ok(mut slot) = channel_slot.write() {
@@ -303,11 +317,11 @@ async fn run_capture_session_on(
     let thumb_index = armed
         .thumb
         .as_ref()
-        .map(|(thumbwheel, _)| thumbwheel.feature_index());
+        .map(|thumb| thumb.wheel.feature_index());
     let thumb_resolution = armed
         .thumb
         .as_ref()
-        .map_or(WheelResolution::UNKNOWN, |(_, res)| *res);
+        .map_or(WheelResolution::UNKNOWN, ArmedThumbwheel::resolution);
     let dpi_set = armed.dpi_cids.clone();
     let button_set = armed.button_cids.clone();
     let activity = Arc::new(ChannelActivity::default());
@@ -466,12 +480,44 @@ struct ArmedControls {
     button_cids: Vec<(u16, ButtonId)>,
     /// Original reporting state for every diverted `0x1b04` control.
     reporting: Vec<ArmedReporting>,
-    /// `0x2150` accessor and the wheel's reported resolution, present when the
-    /// thumb wheel is diverted.
-    thumb: Option<(Thumbwheel, WheelResolution)>,
+    /// `0x2150` accessor and the information read while diverting it, present
+    /// when the thumb wheel is diverted.
+    thumb: Option<ArmedThumbwheel>,
+}
+
+struct ArmedThumbwheel {
+    wheel: Thumbwheel,
+    info: Option<ThumbwheelInfo>,
+}
+
+impl ArmedThumbwheel {
+    fn resolution(&self) -> WheelResolution {
+        self.info
+            .map_or(WheelResolution::UNKNOWN, |info| info.resolution)
+    }
+
+    fn direction(&self) -> WheelDirection {
+        if self.info.is_some_and(|info| !info.positive_is_forward()) {
+            WheelDirection::Inverted
+        } else {
+            WheelDirection::Default
+        }
+    }
 }
 
 impl ArmedControls {
+    /// Build the one-time polarity fact learned while arming the thumb wheel.
+    fn thumbwheel_direction(&self) -> Option<CapturedInput> {
+        let positive_is_forward = self
+            .thumb
+            .as_ref()?
+            .info
+            .map(ThumbwheelInfo::positive_is_forward)?;
+        Some(CapturedInput::ThumbwheelDirection {
+            positive_is_forward,
+        })
+    }
+
     /// Convert all armed firmware state into the one capability that can
     /// release it. Consuming `self` prevents a session and a restore retry from
     /// both claiming ownership at once.
@@ -487,9 +533,7 @@ impl ArmedControls {
         PendingCaptureRestore::new(
             retired,
             reprog,
-            thumb
-                .as_ref()
-                .map(|(thumbwheel, _)| thumbwheel.feature_index()),
+            thumb.as_ref().map(|thumb| thumb.wheel.feature_index()),
         )
     }
 
@@ -518,8 +562,8 @@ impl ArmedControls {
                 }
             }
         }
-        if let Some((thumbwheel, _)) = self.thumb.as_ref()
-            && let Err(error) = thumbwheel.divert(WheelDirection::Default).await
+        if let Some(thumb) = self.thumb.as_ref()
+            && let Err(error) = thumb.wheel.divert(thumb.direction()).await
         {
             warn!(?error, "thumb-wheel re-divert after wake failed");
         }
@@ -764,23 +808,28 @@ async fn arm_controls_into(
         // Consume the getInfo error here, before the next await: Hidpp20Error
         // isn't Send, so holding it across an await would make this future
         // (spawned on tokio) non-Send.
-        let (supports_single_tap, resolution) = match tw.get_info().await {
-            Ok(twinfo) => (twinfo.supports_single_tap, twinfo.resolution),
+        let wheel_info = match tw.get_info().await {
+            Ok(twinfo) => Some(twinfo),
             Err(e) => {
                 warn!(error = ?e, "thumb wheel getInfo failed");
-                (false, WheelResolution::UNKNOWN)
+                None
             }
         };
         // Divert whenever capture was requested: rotation rebinds and the
         // sensitivity multiplier need the diverted event stream even on wheels
         // that report no single-tap capability (e.g. MX Master 4) — lacking the
         // tap only means a bound click can never fire.
-        if !supports_single_tap {
+        if wheel_info.is_some_and(|info| !info.supports_single_tap) {
             debug!("thumb wheel reports no single tap — click not capturable");
         }
-        armed.thumb = Some((tw, resolution));
-        if let Some((tw, _)) = armed.thumb.as_ref()
-            && let Err(error) = tw.divert(WheelDirection::Default).await
+        // Store ownership before the write: a transport error cannot prove
+        // whether firmware applied diversion, so rollback must cover it too.
+        armed.thumb = Some(ArmedThumbwheel {
+            wheel: tw,
+            info: wheel_info,
+        });
+        if let Some(thumb) = armed.thumb.as_ref()
+            && let Err(error) = thumb.wheel.divert(thumb.direction()).await
         {
             return Err(GestureError::Hidpp(format!("{error:?}")));
         }

--- a/crates/openlogi-device/src/thumbwheel.rs
+++ b/crates/openlogi-device/src/thumbwheel.rs
@@ -153,6 +153,21 @@ pub struct ThumbwheelInfo {
     pub supports_single_tap: bool,
 }
 
+impl ThumbwheelInfo {
+    /// Whether an un-inverted positive rotation is toward the front of the
+    /// device — the physical direction represented by
+    /// [`ButtonId::ThumbwheelScrollUp`](openlogi_core::binding::ButtonId::ThumbwheelScrollUp).
+    ///
+    /// HID++ `0x2150` defines `default_dir = 0` as positive toward left/back
+    /// and `1` as positive toward right/front. The value varies by model, so
+    /// captured input must consult it instead of assigning meaning to the raw
+    /// sign globally.
+    #[must_use]
+    pub fn positive_is_forward(self) -> bool {
+        self.default_dir == 1
+    }
+}
+
 /// A decoded `thumbwheelEvent`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ThumbwheelEvent {
@@ -339,6 +354,17 @@ mod tests {
             RotationStatus::Inactive,
             "an unrecognised value must not make the tap permanently undeliverable"
         );
+    }
+
+    #[test]
+    fn positive_direction_follows_the_device_report() {
+        let info = |default_dir| ThumbwheelInfo {
+            resolution: WheelResolution::UNKNOWN,
+            default_dir,
+            supports_single_tap: false,
+        };
+        assert!(!info(0).positive_is_forward());
+        assert!(info(1).positive_is_forward());
     }
 
     /// The roll's own `Stop` reports no rotation — it is the release — so

--- a/crates/openlogi-ui/locales/be.yml
+++ b/crates/openlogi-ui/locales/be.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Вертыкальнае пракручванне"
 "Vertical Scroll (Reversed)": "Вертыкальнае пракручванне (Адваротнае)"
 "Horizontal Scroll": "Гарызантальнае пракручванне"
+"Horizontal Scroll (Reversed)": "Гарызантальнае пракручванне (Адваротнае)"
 "Custom": "Уласны"
 "Gesture Button": "Кнопка жэстаў"
 "Gestures": "Жэсты"

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Lodret rulning"
 "Vertical Scroll (Reversed)": "Lodret rulning (omvendt)"
 "Horizontal Scroll": "Vandret rulning"
+"Horizontal Scroll (Reversed)": "Vandret rulning (omvendt)"
 "Custom": "Brugerdefineret"
 "Gesture Button": "Bevægelsesknap"
 "Gestures": "Bevægelser"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Vertikales Scrollen"
 "Vertical Scroll (Reversed)": "Vertikales Scrollen (umgekehrt)"
 "Horizontal Scroll": "Horizontales Scrollen"
+"Horizontal Scroll (Reversed)": "Horizontales Scrollen (umgekehrt)"
 "Custom": "Benutzerdefiniert"
 "Gesture Button": "Gestentaste"
 "Gestures": "Gesten"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Κατακόρυφη κύλιση"
 "Vertical Scroll (Reversed)": "Κατακόρυφη κύλιση (αντίστροφη)"
 "Horizontal Scroll": "Οριζόντια κύλιση"
+"Horizontal Scroll (Reversed)": "Οριζόντια κύλιση (αντίστροφη)"
 "Custom": "Προσαρμοσμένο"
 "Gesture Button": "Κουμπί χειρονομιών"
 "Gestures": "Χειρονομίες"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Vertical Scroll"
 "Vertical Scroll (Reversed)": "Vertical Scroll (Reversed)"
 "Horizontal Scroll": "Horizontal Scroll"
+"Horizontal Scroll (Reversed)": "Horizontal Scroll (Reversed)"
 "Custom": "Custom"
 "Gesture Button": "Gesture Button"
 "Gestures": "Gestures"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Desplazamiento vertical"
 "Vertical Scroll (Reversed)": "Desplazamiento vertical (invertido)"
 "Horizontal Scroll": "Desplazamiento horizontal"
+"Horizontal Scroll (Reversed)": "Desplazamiento horizontal (invertido)"
 "Custom": "Personalizado"
 "Gesture Button": "Botón de gestos"
 "Gestures": "Gestos"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Pystyvieritys"
 "Vertical Scroll (Reversed)": "Pystyvieritys (käänteinen)"
 "Horizontal Scroll": "Vaakavieritys"
+"Horizontal Scroll (Reversed)": "Vaakavieritys (käänteinen)"
 "Custom": "Mukautettu"
 "Gesture Button": "Eletoiminto"
 "Gestures": "Eleet"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Défilement vertical"
 "Vertical Scroll (Reversed)": "Défilement vertical (inversé)"
 "Horizontal Scroll": "Défilement horizontal"
+"Horizontal Scroll (Reversed)": "Défilement horizontal (inversé)"
 "Custom": "Personnalisé"
 "Gesture Button": "Bouton de gestes"
 "Gestures": "Gestes"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Scorrimento verticale"
 "Vertical Scroll (Reversed)": "Scorrimento verticale (invertito)"
 "Horizontal Scroll": "Scorrimento orizzontale"
+"Horizontal Scroll (Reversed)": "Scorrimento orizzontale (invertito)"
 "Custom": "Personalizzato"
 "Gesture Button": "Pulsante gesture"
 "Gestures": "Gesture"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "縦スクロール"
 "Vertical Scroll (Reversed)": "縦スクロール（反転）"
 "Horizontal Scroll": "横スクロール"
+"Horizontal Scroll (Reversed)": "横スクロール（反転）"
 "Custom": "カスタム"
 "Gesture Button": "ジェスチャーボタン"
 "Gestures": "ジェスチャー"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "세로 스크롤"
 "Vertical Scroll (Reversed)": "세로 스크롤(반대 방향)"
 "Horizontal Scroll": "가로 스크롤"
+"Horizontal Scroll (Reversed)": "가로 스크롤(반대 방향)"
 "Custom": "사용자 지정"
 "Gesture Button": "제스처 버튼"
 "Gestures": "제스처"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Vertikal rulling"
 "Vertical Scroll (Reversed)": "Vertikal rulling (omvendt)"
 "Horizontal Scroll": "Horisontal rulling"
+"Horizontal Scroll (Reversed)": "Horisontal rulling (omvendt)"
 "Custom": "Egendefinert"
 "Gesture Button": "Bevegelsesknapp"
 "Gestures": "Bevegelser"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Verticaal scrollen"
 "Vertical Scroll (Reversed)": "Verticaal scrollen (omgekeerd)"
 "Horizontal Scroll": "Horizontaal scrollen"
+"Horizontal Scroll (Reversed)": "Horizontaal scrollen (omgekeerd)"
 "Custom": "Aangepast"
 "Gesture Button": "Gebarenknop"
 "Gestures": "Gebaren"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Przewijanie pionowe"
 "Vertical Scroll (Reversed)": "Przewijanie pionowe (odwrócone)"
 "Horizontal Scroll": "Przewijanie poziome"
+"Horizontal Scroll (Reversed)": "Przewijanie poziome (odwrócone)"
 "Custom": "Niestandardowe"
 "Gesture Button": "Przycisk gestów"
 "Gestures": "Gesty"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Rolagem vertical"
 "Vertical Scroll (Reversed)": "Rolagem vertical (invertida)"
 "Horizontal Scroll": "Rolagem horizontal"
+"Horizontal Scroll (Reversed)": "Rolagem horizontal (invertida)"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de Gesto"
 "Gestures": "Gestos"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Deslocamento vertical"
 "Vertical Scroll (Reversed)": "Deslocamento vertical (invertido)"
 "Horizontal Scroll": "Deslocamento horizontal"
+"Horizontal Scroll (Reversed)": "Deslocamento horizontal (invertido)"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de gesto"
 "Gestures": "Gestos"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Вертикальная прокрутка"
 "Vertical Scroll (Reversed)": "Вертикальная прокрутка (обратная)"
 "Horizontal Scroll": "Горизонтальная прокрутка"
+"Horizontal Scroll (Reversed)": "Горизонтальная прокрутка (обратная)"
 "Custom": "Свой"
 "Gesture Button": "Кнопка жестов"
 "Gestures": "Жесты"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Vertikal rullning"
 "Vertical Scroll (Reversed)": "Vertikal rullning (omvänd)"
 "Horizontal Scroll": "Horisontell rullning"
+"Horizontal Scroll (Reversed)": "Horisontell rullning (omvänd)"
 "Custom": "Anpassad"
 "Gesture Button": "Gestknapp"
 "Gestures": "Gester"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Dikey Kaydırma"
 "Vertical Scroll (Reversed)": "Dikey Kaydırma (Ters)"
 "Horizontal Scroll": "Yatay Kaydırma"
+"Horizontal Scroll (Reversed)": "Yatay Kaydırma (Ters)"
 "Custom": "Özel"
 "Gesture Button": "Hareket Düğmesi"
 "Gestures": "Hareketler"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "Вертикальне прокручування"
 "Vertical Scroll (Reversed)": "Вертикальне прокручування (зворотне)"
 "Horizontal Scroll": "Горизонтальне прокручування"
+"Horizontal Scroll (Reversed)": "Горизонтальне прокручування (зворотне)"
 "Custom": "Власна"
 "Gesture Button": "Кнопка жестів"
 "Gestures": "Жести"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "垂直滚动"
 "Vertical Scroll (Reversed)": "垂直滚动（反向）"
 "Horizontal Scroll": "水平滚动"
+"Horizontal Scroll (Reversed)": "水平滚动（反向）"
 "Custom": "自定义"
 "Gesture Button": "手势按钮"
 "Gestures": "手势"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "垂直捲動"
 "Vertical Scroll (Reversed)": "垂直捲動（反向）"
 "Horizontal Scroll": "水平捲動"
+"Horizontal Scroll (Reversed)": "水平捲動（反向）"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
 "Gestures": "手勢"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -198,6 +198,7 @@ _version: 1
 "Vertical Scroll": "垂直捲動"
 "Vertical Scroll (Reversed)": "垂直捲動（反向）"
 "Horizontal Scroll": "水平捲動"
+"Horizontal Scroll (Reversed)": "水平捲動（反向）"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
 "Gestures": "手勢"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,11 +30,13 @@ Schema versions newer than the running build are rejected before their fields
 are parsed. v1 binding maps and the v2–v3 gesture-owner layout migrate on load.
 The v3 physical-device-key transition cannot safely assign older model-scoped
 device settings when two identical devices exist, so v2 model-key entries must
-be copied manually to the generated physical keys.
+be copied manually to the generated physical keys. Pre-v7 thumb-wheel scroll
+pairs on the old defaults are migrated in both device and per-application
+profiles so they keep their native direction.
 
 ## Shape
 
-`schema_version` is required and currently `5`. `selected_device` is an
+`schema_version` is required and currently `7`. `selected_device` is an
 optional physical device key.
 
 `[app_settings]` contains application-wide preferences:

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,5 +1,5 @@
 # OpenLogi configuration example. Copy only the sections you need.
-schema_version = 6
+schema_version = 7
 selected_device = "receiver:aabbccdd:slot:1"
 
 [app_settings]


### PR DESCRIPTION
## Summary

Normalize thumb-wheel direction from each device's HID++ `0x2150 default_dir` instead of assuming one polarity for every model. This keeps sensitivity-only diversion aligned with native scrolling and makes horizontal reversal work consistently.

The UI/i18n preset work is cherry-picked from #1029 with the contributor's authorship preserved; the core, device, and agent path has been replaced with per-device direction handling.

## Changes

- `openlogi-device`: read the wheel's reported default direction, normalize diverted increments to physical forward/up, preserve that direction across wireless re-arm, and publish the learned native polarity to the agent.
- `openlogi-agent-core` / `openlogi-agent`: retain learned polarity per device in the atomically published hook snapshot and use the selected device's polarity for the Windows native-wheel fallback.
- `openlogi-core`: align defaults with normalized native direction, bump config schema to v7, and migrate explicit old-default pairs in global and per-app profiles without rewriting custom or non-single bindings.
- `openlogi-desktop` / `openlogi-ui`: add the **Horizontal Scroll (Reversed)** preset and locale entries; keep the plain preset on the native pair.
- `docs`: document the v7 migration and update the example schema version.

No IPC protocol bump is needed: `Config` is not carried over IPC, and `CapturedInput` is internal to the agent process.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS=\"-D warnings\" cargo test --workspace`
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci clippy-windows`
- `cargo clippy --target aarch64-unknown-linux-musl -p openlogi-hook -p openlogi-inject -p openlogi-hid -p openlogi-hidpp -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-ipc -p openlogi-permissions --all-targets -- -D warnings`
- `cargo xtask ci wasm`
- `cargo test -p openlogi-desktop i18n`
- `cargo test -p openlogi-ipc --test wire_format`

Not runtime-tested on hardware. To verify on a thumb-wheel device: confirm the default direction is unchanged, changing only sensitivity does not flip it, **Horizontal Scroll (Reversed)** flips it, and returning to **Horizontal Scroll** restores native direction. On Windows, also verify a rebound native horizontal-wheel event follows the selected device's direction.

Fixes #619