### PR TITLE
feat(core): add an action that holds modifiers and taps the key once

### DIFF
--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -37,15 +37,15 @@ struct HeldShortcuts {
 
 impl HeldShortcuts {
     fn start(&mut self, press: &PressToken, action: &Action) -> bool {
-        let Some(combo) = action.held_combo() else {
+        let Some((combo, keys)) = action.held_chord() else {
             return false;
         };
         match self.by_press.entry(press.clone()) {
             std::collections::hash_map::Entry::Occupied(mut held) => {
-                held.get_mut().replace(combo);
+                held.get_mut().replace(combo, keys);
             }
             std::collections::hash_map::Entry::Vacant(slot) => {
-                slot.insert(openlogi_inject::press_hold(combo));
+                slot.insert(openlogi_inject::press_hold(combo, keys));
             }
         }
         true

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -405,7 +405,7 @@ fn handle_key(
     };
 
     info!(keycode, action = %action.label(), "key → executing bound action");
-    let queued = if action.held_combo().is_some() {
+    let queued = if action.held_chord().is_some() {
         let queued = dispatcher.try_hook_key_down(keycode, &action);
         if queued {
             HELD_KEYS.with_borrow_mut(|keys| {

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -24,7 +24,7 @@ mod value;
 #[cfg(test)]
 mod tests;
 
-pub use action::{Action, WorkflowStep};
+pub use action::{Action, HeldKeys, WorkflowStep};
 pub use action_ring::{
     ActionRingConfig, ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot,
     RingAction, RingActionError,

--- a/crates/openlogi-core/src/binding/action.rs
+++ b/crates/openlogi-core/src/binding/action.rs
@@ -187,6 +187,37 @@ pub enum Action {
     /// cancellation and shutdown. Dispatchers without a release context must
     /// degrade this action to a balanced tap rather than leave keys held.
     HoldShortcut(KeyCombo),
+    /// Hold the chord's modifiers for the lifetime of the physical press while
+    /// tapping its ordinary key exactly once, the way a hand does on a
+    /// keyboard.
+    ///
+    /// This is the shape an application switcher needs. Cmd+Tab steps one
+    /// window forward and leaves the switcher on screen for as long as Cmd is
+    /// down. Neither existing variant can express it:
+    /// [`Action::CustomShortcut`] releases Cmd immediately, so the switcher
+    /// closes again at once, and [`Action::HoldShortcut`] holds Tab down too,
+    /// so key repeat walks the switcher to its last window and parks there.
+    ///
+    /// Lifecycle-aware runtimes emit the modifier down edges plus one tap of
+    /// the ordinary key when the press starts, and the modifier up edges for
+    /// every terminal outcome. Dispatchers without a release context degrade
+    /// this to a balanced tap of the whole chord, exactly as they do for
+    /// [`Action::HoldShortcut`].
+    TapKeyHoldingModifiers(KeyCombo),
+}
+
+/// Which of a held chord's keys stay down for the lifetime of the press.
+///
+/// Both shapes hold the chord's modifiers; they differ in the ordinary key.
+/// See [`Action::held_chord`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HeldKeys {
+    /// Modifiers and ordinary key alike stay down
+    /// ([`Action::HoldShortcut`]).
+    WholeChord,
+    /// The modifiers stay down and the ordinary key is tapped once as the
+    /// hold starts ([`Action::TapKeyHoldingModifiers`]).
+    ModifiersOnly,
 }
 
 /// One step in a [`Action::Workflow`]. A workflow is a `Vec<WorkflowStep>`
@@ -313,6 +344,12 @@ macro_rules! derive_action_core {
                     Action::Workflow(steps) => format!("Workflow ({} steps)", steps.len()),
                     Action::OpenApplication(target) => format!("Open {}", target.display_name()),
                     Action::HoldShortcut(combo) => format!("Hold {}", combo.rendered_label()),
+                    Action::TapKeyHoldingModifiers(combo) => match combo.rendered_modifiers() {
+                        Some(modifiers) => {
+                            format!("Hold {modifiers}, tap {}", combo.rendered_key())
+                        }
+                        None => format!("Tap {}", combo.rendered_key()),
+                    },
                 }
             }
 
@@ -328,7 +365,8 @@ macro_rules! derive_action_core {
                     | Action::RunAppleScript(_)
                     | Action::RunShellCommand(_)
                     | Action::Workflow(_)
-                    | Action::HoldShortcut(_) => Category::Editing,
+                    | Action::HoldShortcut(_)
+                    | Action::TapKeyHoldingModifiers(_) => Category::Editing,
                     Action::SetDpiPreset(_) => Category::Dpi,
                     Action::OpenApplication(_) => Category::System,
                 }
@@ -362,11 +400,13 @@ for_each_unit_action!(derive_action_core);
 
 impl Action {
     /// The chord whose output must remain down until the originating press
-    /// ends, or `None` for an instantaneous action.
+    /// ends, together with which of its keys stay down. `None` for an
+    /// instantaneous action.
     #[must_use]
-    pub fn held_combo(&self) -> Option<&KeyCombo> {
+    pub fn held_chord(&self) -> Option<(&KeyCombo, HeldKeys)> {
         match self {
-            Self::HoldShortcut(combo) => Some(combo),
+            Self::HoldShortcut(combo) => Some((combo, HeldKeys::WholeChord)),
+            Self::TapKeyHoldingModifiers(combo) => Some((combo, HeldKeys::ModifiersOnly)),
             _ => None,
         }
     }

--- a/crates/openlogi-core/src/binding/action_ring/icon.rs
+++ b/crates/openlogi-core/src/binding/action_ring/icon.rs
@@ -317,7 +317,8 @@ macro_rules! derive_action_icon {
                     Action::CustomShortcut(_)
                     | Action::TypeText(_)
                     | Action::Workflow(_)
-                    | Action::HoldShortcut(_) => Self::Keyboard,
+                    | Action::HoldShortcut(_)
+                    | Action::TapKeyHoldingModifiers(_) => Self::Keyboard,
                     Action::RunAppleScript(_) | Action::RunShellCommand(_) => Self::Terminal,
                     Action::OpenApplication(_) => Self::Applications,
                 }

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -41,6 +41,12 @@ pub enum Effect<'a> {
     /// A user-recorded chord whose output is held by a lifecycle-aware
     /// runtime. A one-shot executor treats this as [`Effect::Key`] so direct
     /// dispatch remains balanced when no matching release can arrive.
+    ///
+    /// Which keys the runtime actually holds is the action's business, not
+    /// the backend's: [`Action::HoldShortcut`] holds the whole chord while
+    /// [`Action::TapKeyHoldingModifiers`] holds only the modifiers. Both
+    /// degrade to the same balanced chord tap here, so the split lives in
+    /// [`Action::held_chord`] rather than in this IR.
     HeldKey(&'a KeyCombo),
     /// Synthesise one scroll tick. `dx`/`dy` are unit direction (-1/0/1);
     /// each backend applies its own tick magnitude.
@@ -274,7 +280,9 @@ impl Action {
             Action::HorizontalScrollRight => Effect::Scroll { dx: 1, dy: 0 },
 
             Action::CustomShortcut(combo) => Effect::Key(combo),
-            Action::HoldShortcut(combo) => Effect::HeldKey(combo),
+            Action::HoldShortcut(combo) | Action::TapKeyHoldingModifiers(combo) => {
+                Effect::HeldKey(combo)
+            }
 
             Action::TypeText(text) => Effect::Text(text),
             Action::RunAppleScript(src) => Effect::Script(Script::AppleScript(src)),

--- a/crates/openlogi-core/src/binding/key_combo.rs
+++ b/crates/openlogi-core/src/binding/key_combo.rs
@@ -194,21 +194,37 @@ impl KeyCombo {
     /// Canonical user-facing chord label.
     #[must_use]
     pub fn rendered_label(&self) -> String {
+        match self.rendered_modifiers() {
+            Some(modifiers) => format!("{modifiers}+{}", self.rendered_key()),
+            None => self.rendered_key(),
+        }
+    }
+
+    /// Canonical label for the chord's modifiers alone, or `None` when it
+    /// carries none. An action that holds the modifiers while tapping the
+    /// ordinary key separately labels the two halves separately too.
+    #[must_use]
+    pub fn rendered_modifiers(&self) -> Option<String> {
         let mut parts = Vec::new();
         if self.has_command() {
-            parts.push("Cmd".to_string());
+            parts.push("Cmd");
         }
         if self.has_control() {
-            parts.push("Ctrl".to_string());
+            parts.push("Ctrl");
         }
         if self.has_option() {
-            parts.push("Alt".to_string());
+            parts.push("Alt");
         }
         if self.has_shift() {
-            parts.push("Shift".to_string());
+            parts.push("Shift");
         }
-        parts.push(self.key.label());
-        parts.join("+")
+        (!parts.is_empty()).then(|| parts.join("+"))
+    }
+
+    /// Canonical label for the chord's ordinary key alone.
+    #[must_use]
+    pub fn rendered_key(&self) -> String {
+        self.key.label()
     }
 }
 

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -33,7 +33,12 @@ fn catalog_excludes_custom_shortcut() {
     let catalog = Action::catalog();
     for action in &catalog {
         assert!(
-            !matches!(action, Action::CustomShortcut(_) | Action::HoldShortcut(_)),
+            !matches!(
+                action,
+                Action::CustomShortcut(_)
+                    | Action::HoldShortcut(_)
+                    | Action::TapKeyHoldingModifiers(_)
+            ),
             "catalog must not contain recorded shortcut actions"
         );
     }
@@ -46,9 +51,45 @@ fn hold_shortcut_has_distinct_lifecycle_semantics() {
 
     assert_eq!(held.label(), "Hold Alt+Space");
     assert_eq!(held.category(), Category::Editing);
-    assert_eq!(held.held_combo(), Some(&combo));
+    assert_eq!(held.held_chord(), Some((&combo, HeldKeys::WholeChord)));
     assert_matches!(held.effect(), Effect::HeldKey(actual) if actual == &combo);
-    assert_eq!(Action::CustomShortcut(combo).held_combo(), None);
+    assert_eq!(Action::CustomShortcut(combo).held_chord(), None);
+}
+
+/// The switcher case the other two shortcut actions cannot express: the
+/// modifiers are held for the press while the ordinary key is tapped once.
+#[test]
+fn tap_key_holding_modifiers_holds_only_the_modifiers() {
+    let combo: KeyCombo = "Cmd+Tab".parse().expect("valid shortcut failed");
+    let action = Action::TapKeyHoldingModifiers(combo.clone());
+
+    assert_eq!(action.label(), "Hold Cmd, tap Tab");
+    assert_eq!(action.category(), Category::Editing);
+    assert_eq!(action.held_chord(), Some((&combo, HeldKeys::ModifiersOnly)));
+
+    // Same chord, same one-shot fallback, different held set. The two actions
+    // are distinguishable only through `held_chord`.
+    assert_matches!(action.effect(), Effect::HeldKey(actual) if actual == &combo);
+    assert_eq!(
+        Action::HoldShortcut(combo)
+            .held_chord()
+            .map(|(_, keys)| keys),
+        Some(HeldKeys::WholeChord)
+    );
+}
+
+/// A chord with no modifier has nothing to hold, so its label drops the
+/// "Hold" half rather than rendering an empty one.
+#[test]
+fn tap_key_holding_modifiers_labels_a_bare_key_without_a_hold() {
+    let action = Action::TapKeyHoldingModifiers("F5".parse().expect("valid shortcut failed"));
+    assert_eq!(action.label(), "Tap F5");
+}
+
+#[test]
+fn tap_key_holding_modifiers_roundtrips_toml() {
+    let action = Action::TapKeyHoldingModifiers("Cmd+Tab".parse().expect("valid shortcut failed"));
+    assert_eq!(roundtrip(&action), action);
 }
 
 #[test]
@@ -307,6 +348,11 @@ fn persisted_action_variant_names_are_stable() {
             "F2".parse()
                 .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
         ),
+        Action::TapKeyHoldingModifiers(
+            "Cmd+Tab"
+                .parse()
+                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
+        ),
     ]);
     let mut actual: Vec<String> = actions
         .into_iter()
@@ -371,6 +417,7 @@ fn persisted_action_variant_names_are_stable() {
         "ShowActionsRing",
         "ShowDesktop",
         "Sleep",
+        "TapKeyHoldingModifiers",
         "ToggleSmartShift",
         "TypeText",
         "Undo",
@@ -567,6 +614,13 @@ fn power_user_and_device_side_actions_lower_to_the_expected_bucket() {
             .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
     );
     assert_matches!(hold_shortcut.effect(), Effect::HeldKey(_));
+
+    let tap_key_holding_modifiers = Action::TapKeyHoldingModifiers(
+        "Cmd+Tab"
+            .parse()
+            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
+    );
+    assert_matches!(tap_key_holding_modifiers.effect(), Effect::HeldKey(_));
 
     let type_text = Action::TypeText("hi".into());
     assert_matches!(type_text.effect(), Effect::Text("hi"));

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -100,9 +100,10 @@ pub(crate) fn action_icon_path(action: &Action) -> &'static str {
         Action::ScrollDown => "action-icons/chevrons-down.svg",
         Action::HorizontalScrollLeft => "action-icons/chevrons-left.svg",
         Action::HorizontalScrollRight => "action-icons/chevrons-right.svg",
-        Action::CustomShortcut(_) | Action::HoldShortcut(_) | Action::TypeText(_) => {
-            "action-icons/keyboard.svg"
-        }
+        Action::CustomShortcut(_)
+        | Action::HoldShortcut(_)
+        | Action::TapKeyHoldingModifiers(_)
+        | Action::TypeText(_) => "action-icons/keyboard.svg",
         Action::RunAppleScript(_) | Action::RunShellCommand(_) => "action-icons/terminal.svg",
     }
 }

--- a/crates/openlogi-desktop/src/services/i18n.rs
+++ b/crates/openlogi-desktop/src/services/i18n.rs
@@ -41,6 +41,19 @@ mod tests {
 
     use crate::features::mouse::thumbwheel::ThumbwheelPreset;
 
+    /// The chord actions label the two halves of a combo differently, so each
+    /// shape carries its own key. Grouped here rather than inlined so the one
+    /// locale test below stays inside the line budget, and not a `#[test]` of
+    /// its own because the locale it reads is a process-global.
+    fn assert_chord_labels() {
+        assert_eq!(rust_i18n::t!("Hold %{chord}", chord => "X"), "按住 X");
+        assert_eq!(
+            rust_i18n::t!("Hold %{modifiers}, tap %{key}", modifiers => "Cmd", key => "Tab"),
+            "按住 Cmd，点按 Tab"
+        );
+        assert_eq!(rust_i18n::t!("Tap %{key}", key => "F5"), "点按 F5");
+    }
+
     /// End-to-end check that `locales/*.yml` loaded and the gettext-style
     /// English keys match — a typo'd key silently falls back to English, which
     /// this catches. All locale-dependent assertions live in this one test on
@@ -68,7 +81,7 @@ mod tests {
             rust_i18n::t!("DPI Preset %{index}", index => "2"),
             "灵敏度预设 2"
         ); // parameterized action label
-        assert_eq!(rust_i18n::t!("Hold %{chord}", chord => "X"), "按住 X"); // held action label
+        assert_chord_labels();
         assert_eq!(rust_i18n::t!("Quit OpenLogi"), "退出 OpenLogi"); // menu-bar status item
         assert_eq!(rust_i18n::t!("No devices connected"), "未连接设备"); // menu-bar device line
         assert_eq!(rust_i18n::t!("Lighting"), "灯光"); // keyboard lighting tab
@@ -97,8 +110,8 @@ mod tests {
 
         // Exhaustive: every non-parameterized device/action label has a `zh-CN`
         // entry. Parameterized `Action`s (`SetDpiPreset`, `CustomShortcut`,
-        // `HoldShortcut`) are skipped here and checked explicitly above where
-        // needed.
+        // `HoldShortcut`, `TapKeyHoldingModifiers`) are skipped here and
+        // checked explicitly above where needed.
         let covered = |label: &str| rust_i18n::t!(label) != label;
         for b in ButtonId::ALL {
             assert!(covered(b.label()), "no zh-CN for ButtonId::{b:?}");

--- a/crates/openlogi-desktop/src/ui/action.rs
+++ b/crates/openlogi-desktop/src/ui/action.rs
@@ -13,6 +13,14 @@ pub(crate) fn localized_action_label(action: &Action) -> SharedString {
         Action::HoldShortcut(combo) => {
             tr!("Hold %{chord}", chord => combo.rendered_label())
         }
+        Action::TapKeyHoldingModifiers(combo) => match combo.rendered_modifiers() {
+            Some(modifiers) => tr!(
+                "Hold %{modifiers}, tap %{key}",
+                modifiers => modifiers,
+                key => combo.rendered_key()
+            ),
+            None => tr!("Tap %{key}", key => combo.rendered_key()),
+        },
         _ => tr!(action.label()),
     }
 }

--- a/crates/openlogi-inject/examples/hold_chord.rs
+++ b/crates/openlogi-inject/examples/hold_chord.rs
@@ -1,0 +1,125 @@
+//! Manual smoke-test for `openlogi_inject::press_hold`.
+//!
+//! Holds one chord for a fixed time, then releases it, so the two hold shapes
+//! can be watched side by side against a real keyboard.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --example hold_chord -p openlogi-inject -- \
+//!     [--delay <secs>] [--hold <ms>] [--whole-chord] <chord>
+//! ```
+//!
+//! `--whole-chord` selects `HeldKeys::WholeChord`, what `Action::HoldShortcut`
+//! does. The default is `HeldKeys::ModifiersOnly`, what
+//! `Action::TapKeyHoldingModifiers` does.
+//!
+//! ```text
+//! # Cmd stays down for 3 s and Tab is tapped once: the application switcher
+//! # steps one window forward and stays open until the release.
+//! cargo run --example hold_chord -p openlogi-inject -- --hold 3000 Cmd+Tab
+//!
+//! # The same chord held whole: key repeat walks the switcher to its last
+//! # window and parks there.
+//! cargo run --example hold_chord -p openlogi-inject -- --hold 3000 --whole-chord Cmd+Tab
+//! ```
+//!
+//! To watch the edges rather than the effect, point an event monitor at the
+//! session tap and compare the two shapes: the ordinary key up edge follows its
+//! down edge by milliseconds under `ModifiersOnly` and by the whole hold under
+//! `WholeChord`. A chord no system hotkey claims, such as `Shift+F13`, keeps
+//! the reading about the injection alone.
+
+use std::process::ExitCode;
+use std::thread::sleep;
+use std::time::Duration;
+
+use openlogi_core::binding::{HeldKeys, KeyCombo};
+
+const USAGE: &str = "usage: hold_chord [--delay <secs>] [--hold <ms>] [--whole-chord] <chord>";
+
+struct Options {
+    delay: Duration,
+    hold: Duration,
+    keys: HeldKeys,
+    chord: KeyCombo,
+}
+
+fn main() -> ExitCode {
+    let options = match parse(std::env::args().skip(1)) {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("hold_chord: {message}\n{USAGE}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!(
+        "holding {} as {:?} in {:.1} s for {} ms",
+        options.chord.rendered_label(),
+        options.keys,
+        options.delay.as_secs_f64(),
+        options.hold.as_millis()
+    );
+    sleep(options.delay);
+
+    let chord = openlogi_inject::press_hold(&options.chord, options.keys);
+    sleep(options.hold);
+    drop(chord);
+
+    println!("released");
+    ExitCode::SUCCESS
+}
+
+fn parse(mut args: impl Iterator<Item = String>) -> Result<Options, String> {
+    let mut delay = Duration::from_secs(2);
+    let mut hold = Duration::from_millis(3000);
+    let mut keys = HeldKeys::ModifiersOnly;
+    let mut chord = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--delay" => delay = seconds(&value(&mut args, "--delay")?)?,
+            "--hold" => hold = milliseconds(&value(&mut args, "--hold")?)?,
+            "--whole-chord" => keys = HeldKeys::WholeChord,
+            other => {
+                chord = Some(
+                    other
+                        .parse::<KeyCombo>()
+                        .map_err(|error| format!("{other}: {error}"))?,
+                );
+            }
+        }
+    }
+
+    Ok(Options {
+        delay,
+        hold,
+        keys,
+        chord: chord.ok_or("a chord is required")?,
+    })
+}
+
+fn value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("{flag} requires a value"))
+}
+
+fn seconds(raw: &str) -> Result<Duration, String> {
+    // `Duration::from_secs_f64` panics on a negative, NaN, or infinite input.
+    let secs: f64 = raw
+        .parse()
+        .map_err(|_| format!("--delay: expected a number, got {raw}"))?;
+    if !secs.is_finite() || secs < 0.0 {
+        return Err(format!(
+            "--delay: expected a non-negative number, got {raw}"
+        ));
+    }
+    Ok(Duration::from_secs_f64(secs))
+}
+
+fn milliseconds(raw: &str) -> Result<Duration, String> {
+    raw.parse()
+        .map(Duration::from_millis)
+        .map_err(|_| format!("--hold: expected a number of milliseconds, got {raw}"))
+}

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -13,7 +13,7 @@ use std::sync::{LazyLock, Mutex, PoisonError};
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use openlogi_core::binding::KeyboardUsage;
-use openlogi_core::binding::{Action, KeyCombo};
+use openlogi_core::binding::{Action, HeldKeys, KeyCombo};
 use openlogi_core::scroll::ScrollDelta;
 
 #[cfg(target_os = "macos")]
@@ -97,11 +97,11 @@ struct HeldOutput {
 impl HeldOutput {
     fn transition(
         &mut self,
-        released: Option<&KeyCombo>,
-        pressed: Option<&KeyCombo>,
+        released: Option<(&KeyCombo, HeldKeys)>,
+        pressed: Option<(&KeyCombo, HeldKeys)>,
     ) -> HoldTransition {
-        let released = released.map_or_else(Vec::new, held_keys);
-        let pressed = pressed.map_or_else(Vec::new, held_keys);
+        let released = released.map_or_else(Vec::new, |(combo, keys)| held_keys(combo, keys));
+        let pressed = pressed.map_or_else(Vec::new, |(combo, keys)| held_keys(combo, keys));
         let before = self.owners.clone();
 
         for key in &released {
@@ -149,7 +149,7 @@ static HELD_OUTPUT: LazyLock<Mutex<HeldOutput>> =
     LazyLock::new(|| Mutex::new(HeldOutput::default()));
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-fn held_keys(combo: &KeyCombo) -> Vec<HeldKey> {
+fn held_keys(combo: &KeyCombo, held: HeldKeys) -> Vec<HeldKey> {
     let mut keys = Vec::with_capacity(4);
     #[cfg(target_os = "macos")]
     if combo.has_command() {
@@ -169,8 +169,22 @@ fn held_keys(combo: &KeyCombo) -> Vec<HeldKey> {
     if combo.has_option() {
         keys.push(HeldKey::Alt);
     }
-    keys.push(HeldKey::Key(combo.key()));
+    if held == HeldKeys::WholeChord {
+        keys.push(HeldKey::Key(combo.key()));
+    }
     keys
+}
+
+/// The ordinary key a starting hold taps exactly once, if any.
+///
+/// [`HeldKeys::ModifiersOnly`] leaves the key out of the held set precisely so
+/// it can be tapped here instead, once per hold rather than held down and
+/// repeated.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+fn tapped_key(pressed: Option<(&KeyCombo, HeldKeys)>) -> Option<HeldKey> {
+    pressed.and_then(|(combo, held)| {
+        (held == HeldKeys::ModifiersOnly).then(|| HeldKey::Key(combo.key()))
+    })
 }
 
 /// Synthesise the OS-level event for `action`.
@@ -246,37 +260,51 @@ pub fn execute(action: &Action) {
 #[must_use = "dropping the held chord immediately releases its synthetic output"]
 pub struct HeldChord {
     combo: KeyCombo,
+    keys: HeldKeys,
 }
 
 impl HeldChord {
     /// Replace this held chord without releasing physical keys shared by both.
-    pub fn replace(&mut self, combo: &KeyCombo) {
+    ///
+    /// A replacement is a fresh hold of `combo`, so a
+    /// [`HeldKeys::ModifiersOnly`] replacement taps its ordinary key the same
+    /// way the original press did.
+    pub fn replace(&mut self, combo: &KeyCombo, keys: HeldKeys) {
         let old = std::mem::replace(&mut self.combo, combo.clone());
-        hold_transition(Some(&old), Some(&self.combo));
+        let old_keys = std::mem::replace(&mut self.keys, keys);
+        hold_transition(Some((&old, old_keys)), Some((&self.combo, self.keys)));
     }
 }
 
 impl Drop for HeldChord {
     fn drop(&mut self) {
-        hold_transition(Some(&self.combo), None);
+        hold_transition(Some((&self.combo, self.keys)), None);
     }
 }
 
 /// Synthesise the down edge of `combo` and return its release owner.
 ///
+/// `keys` selects which of the chord's keys stay down: [`HeldKeys::WholeChord`]
+/// holds the ordinary key with the modifiers, while
+/// [`HeldKeys::ModifiersOnly`] taps it once here and holds only the modifiers.
+///
 /// Keep the returned [`HeldChord`] until the physical press ends. Prefer
 /// [`execute`] when the caller does not own a matching terminal event.
-pub fn press_hold(combo: &KeyCombo) -> HeldChord {
+pub fn press_hold(combo: &KeyCombo, keys: HeldKeys) -> HeldChord {
     // Construct the owner before posting the edge so unwinding from the
     // platform backend still balances any ownership transition it completed.
     let held = HeldChord {
         combo: combo.clone(),
+        keys,
     };
-    hold_transition(None, Some(&held.combo));
+    hold_transition(None, Some((&held.combo, held.keys)));
     held
 }
 
-fn hold_transition(released: Option<&KeyCombo>, pressed: Option<&KeyCombo>) {
+fn hold_transition(
+    released: Option<(&KeyCombo, HeldKeys)>,
+    pressed: Option<(&KeyCombo, HeldKeys)>,
+) {
     cfg_select! {
         target_os = "macos" => {
             let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
@@ -289,18 +317,34 @@ fn hold_transition(released: Option<&KeyCombo>, pressed: Option<&KeyCombo>) {
             let modifiers = macos::hold_keys(&transition.up, KeyPhase::Up, modifiers);
             let modifiers = macos::hold_keys(&transition.down, KeyPhase::Down, modifiers);
             debug_assert_eq!(modifiers, output.modifiers());
+            // The tap rides on the modifiers just posted, and owns nothing:
+            // its own down/up pair cancel out, leaving the cursor where the
+            // held state already is.
+            if let Some(key) = tapped_key(pressed) {
+                let tapped = macos::hold_keys(&[key], KeyPhase::Down, modifiers);
+                let tapped = macos::hold_keys(&[key], KeyPhase::Up, tapped);
+                debug_assert_eq!(tapped, output.modifiers());
+            }
         }
         target_os = "linux" => {
             let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
             let transition = output.transition(released, pressed);
             linux::hold_keys(&transition.up, KeyPhase::Up);
             linux::hold_keys(&transition.down, KeyPhase::Down);
+            if let Some(key) = tapped_key(pressed) {
+                linux::hold_keys(&[key], KeyPhase::Down);
+                linux::hold_keys(&[key], KeyPhase::Up);
+            }
         }
         target_os = "windows" => {
             let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
             let transition = output.transition(released, pressed);
             windows::hold_keys(&transition.up, KeyPhase::Up);
             windows::hold_keys(&transition.down, KeyPhase::Down);
+            if let Some(key) = tapped_key(pressed) {
+                windows::hold_keys(&[key], KeyPhase::Down);
+                windows::hold_keys(&[key], KeyPhase::Up);
+            }
         }
         _ => {
             tracing::warn!(
@@ -502,10 +546,10 @@ mod tests {
     use openlogi_core::scroll::ScrollDelta;
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    use openlogi_core::binding::KeyCombo;
+    use openlogi_core::binding::{HeldKeys, KeyCombo};
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    use super::{HeldKey, HeldOutput, HoldTransition};
+    use super::{HeldKey, HeldOutput, HoldTransition, tapped_key};
     use super::{QuantizedScroll, ScrollQuantizer};
 
     /// Synthetic high-resolution input: eight eighth-ticks must total exactly
@@ -546,28 +590,28 @@ mod tests {
         let mut output = HeldOutput::default();
 
         assert_eq!(
-            output.transition(None, Some(&control_a)),
+            output.transition(None, Some((&control_a, HeldKeys::WholeChord))),
             HoldTransition {
                 up: vec![],
                 down: vec![HeldKey::Control, HeldKey::Key(control_a.key())],
             }
         );
         assert_eq!(
-            output.transition(None, Some(&control_b)),
+            output.transition(None, Some((&control_b, HeldKeys::WholeChord))),
             HoldTransition {
                 up: vec![],
                 down: vec![HeldKey::Key(control_b.key())],
             }
         );
         assert_eq!(
-            output.transition(Some(&control_a), None),
+            output.transition(Some((&control_a, HeldKeys::WholeChord)), None),
             HoldTransition {
                 up: vec![HeldKey::Key(control_a.key())],
                 down: vec![],
             }
         );
         assert_eq!(
-            output.transition(Some(&control_b), None),
+            output.transition(Some((&control_b, HeldKeys::WholeChord)), None),
             HoldTransition {
                 up: vec![HeldKey::Control, HeldKey::Key(control_b.key())],
                 down: vec![],
@@ -582,16 +626,16 @@ mod tests {
         let control_b = combo("Ctrl+B");
         let mut output = HeldOutput::default();
 
-        output.transition(None, Some(&command_a));
+        output.transition(None, Some((&command_a, HeldKeys::WholeChord)));
         assert_eq!(
-            output.transition(None, Some(&control_b)),
+            output.transition(None, Some((&control_b, HeldKeys::WholeChord))),
             HoldTransition {
                 up: vec![],
                 down: vec![HeldKey::Key(control_b.key())],
             }
         );
         assert_eq!(
-            output.transition(Some(&command_a), None),
+            output.transition(Some((&command_a, HeldKeys::WholeChord)), None),
             HoldTransition {
                 up: vec![HeldKey::Key(command_a.key())],
                 down: vec![],
@@ -606,16 +650,16 @@ mod tests {
         let control_b = combo("Ctrl+B");
         let mut output = HeldOutput::default();
 
-        output.transition(None, Some(&command_a));
+        output.transition(None, Some((&command_a, HeldKeys::WholeChord)));
         assert_eq!(
-            output.transition(None, Some(&control_b)),
+            output.transition(None, Some((&control_b, HeldKeys::WholeChord))),
             HoldTransition {
                 up: vec![],
                 down: vec![HeldKey::Control, HeldKey::Key(control_b.key())],
             }
         );
         assert_eq!(
-            output.transition(Some(&command_a), None),
+            output.transition(Some((&command_a, HeldKeys::WholeChord)), None),
             HoldTransition {
                 up: vec![HeldKey::Command, HeldKey::Key(command_a.key())],
                 down: vec![],
@@ -630,26 +674,72 @@ mod tests {
         let command_b = combo("Cmd+B");
         let mut output = HeldOutput::default();
 
-        output.transition(None, Some(&command_a));
+        output.transition(None, Some((&command_a, HeldKeys::WholeChord)));
         assert_eq!(
-            output.transition(None, Some(&command_b)),
+            output.transition(None, Some((&command_b, HeldKeys::WholeChord))),
             HoldTransition {
                 up: vec![],
                 down: vec![HeldKey::Key(command_b.key())],
             }
         );
         assert_eq!(
-            output.transition(Some(&command_a), None),
+            output.transition(Some((&command_a, HeldKeys::WholeChord)), None),
             HoldTransition {
                 up: vec![HeldKey::Key(command_a.key())],
                 down: vec![],
             }
         );
         assert_eq!(
-            output.transition(Some(&command_b), None),
+            output.transition(Some((&command_b, HeldKeys::WholeChord)), None),
             HoldTransition {
                 up: vec![HeldKey::Command, HeldKey::Key(command_b.key())],
                 down: vec![],
+            }
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn a_modifiers_only_hold_never_owns_its_ordinary_key() {
+        let control_tab = combo("Ctrl+Tab");
+        let mut output = HeldOutput::default();
+
+        // The ordinary key is absent from both edges: it is tapped by
+        // `hold_transition`, not held, so it never enters the ownership map.
+        assert_eq!(
+            output.transition(None, Some((&control_tab, HeldKeys::ModifiersOnly))),
+            HoldTransition {
+                up: vec![],
+                down: vec![HeldKey::Control],
+            }
+        );
+        assert_eq!(
+            tapped_key(Some((&control_tab, HeldKeys::ModifiersOnly))),
+            Some(HeldKey::Key(control_tab.key()))
+        );
+        assert_eq!(tapped_key(Some((&control_tab, HeldKeys::WholeChord))), None);
+        assert_eq!(
+            output.transition(Some((&control_tab, HeldKeys::ModifiersOnly)), None),
+            HoldTransition {
+                up: vec![HeldKey::Control],
+                down: vec![],
+            }
+        );
+    }
+
+    /// A whole-chord hold of the same chord must keep holding the ordinary
+    /// key: this is the difference the two actions exist to express.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn a_whole_chord_hold_of_the_same_chord_still_owns_its_ordinary_key() {
+        let control_tab = combo("Ctrl+Tab");
+        let mut output = HeldOutput::default();
+
+        assert_eq!(
+            output.transition(None, Some((&control_tab, HeldKeys::WholeChord))),
+            HoldTransition {
+                up: vec![],
+                down: vec![HeldKey::Control, HeldKey::Key(control_tab.key())],
             }
         );
     }
@@ -661,9 +751,12 @@ mod tests {
         let new = combo("Ctrl+B");
         let mut output = HeldOutput::default();
 
-        output.transition(None, Some(&old));
+        output.transition(None, Some((&old, HeldKeys::WholeChord)));
         assert_eq!(
-            output.transition(Some(&old), Some(&new)),
+            output.transition(
+                Some((&old, HeldKeys::WholeChord)),
+                Some((&new, HeldKeys::WholeChord))
+            ),
             HoldTransition {
                 up: vec![HeldKey::Key(old.key())],
                 down: vec![HeldKey::Key(new.key())],

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -61,7 +61,9 @@ pub use succession::Identity;
 /// v28: `Action::HoldShortcut` appended for lifecycle-held keyboard output.
 /// v29: `Agent::declare_client` + [`ClientKind`] appended — typed demand for
 ///      the macOS dormancy gate.
-pub const PROTOCOL_VERSION: u32 = 29;
+/// v30: `Action::TapKeyHoldingModifiers` appended for switcher-style output
+///      that holds the modifiers and taps the ordinary key once.
+pub const PROTOCOL_VERSION: u32 = 30;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -101,7 +101,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 29);
+    assert_eq!(PROTOCOL_VERSION, 30);
 }
 
 #[test]

--- a/crates/openlogi-ui/locales/be.yml
+++ b/crates/openlogi-ui/locales/be.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Сярэдняя"
 "DPI Preset %{index}": "Прэсет DPI %{index}"
 "Hold %{chord}": "Утрымліваць %{chord}"
+"Hold %{modifiers}, tap %{key}": "Hold %{modifiers}, tap %{key}"
+"Tap %{key}": "Tap %{key}"
 "Gesture %{name}": "Жэст %{name}"
 "Left Click": "Левы націск"
 "Right Click": "Правы націск"

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Midterknap"
 "DPI Preset %{index}": "DPI-forindstilling %{index}"
 "Hold %{chord}": "Hold %{chord}"
+"Hold %{modifiers}, tap %{key}": "Hold %{modifiers}, tryk %{key}"
+"Tap %{key}": "Tryk %{key}"
 "Gesture %{name}": "Bevægelse %{name}"
 "Left Click": "Venstreklik"
 "Right Click": "Højreklik"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Mitteltaste"
 "DPI Preset %{index}": "DPI-Voreinstellung %{index}"
 "Hold %{chord}": "%{chord} halten"
+"Hold %{modifiers}, tap %{key}": "%{modifiers} halten, %{key} tippen"
+"Tap %{key}": "%{key} tippen"
 "Gesture %{name}": "Geste %{name}"
 "Left Click": "Linksklick"
 "Right Click": "Rechtsklick"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Μεσαίο"
 "DPI Preset %{index}": "Προεπιλογή DPI %{index}"
 "Hold %{chord}": "Κράτημα %{chord}"
+"Hold %{modifiers}, tap %{key}": "Κράτημα %{modifiers}, πάτημα %{key}"
+"Tap %{key}": "Πάτημα %{key}"
 "Gesture %{name}": "Χειρονομία %{name}"
 "Left Click": "Αριστερό κλικ"
 "Right Click": "Δεξί κλικ"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Middle"
 "DPI Preset %{index}": "DPI Preset %{index}"
 "Hold %{chord}": "Hold %{chord}"
+"Hold %{modifiers}, tap %{key}": "Hold %{modifiers}, tap %{key}"
+"Tap %{key}": "Tap %{key}"
 "Gesture %{name}": "Gesture %{name}"
 "Left Click": "Left Click"
 "Right Click": "Right Click"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Central"
 "DPI Preset %{index}": "Preajuste de DPI %{index}"
 "Hold %{chord}": "Mantener %{chord}"
+"Hold %{modifiers}, tap %{key}": "Mantener %{modifiers}, pulsar %{key}"
+"Tap %{key}": "Pulsar %{key}"
 "Gesture %{name}": "Gesto %{name}"
 "Left Click": "Clic izquierdo"
 "Right Click": "Clic derecho"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Keskipainike"
 "DPI Preset %{index}": "DPI-esiasetus %{index}"
 "Hold %{chord}": "Pidä %{chord}"
+"Hold %{modifiers}, tap %{key}": "Pidä %{modifiers}, napauta %{key}"
+"Tap %{key}": "Napauta %{key}"
 "Gesture %{name}": "Ele %{name}"
 "Left Click": "Vasen napsautus"
 "Right Click": "Oikea napsautus"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Milieu"
 "DPI Preset %{index}": "Préréglage DPI %{index}"
 "Hold %{chord}": "Maintenir %{chord}"
+"Hold %{modifiers}, tap %{key}": "Maintenir %{modifiers}, appuyer sur %{key}"
+"Tap %{key}": "Appuyer sur %{key}"
 "Gesture %{name}": "Geste %{name}"
 "Left Click": "Clic gauche"
 "Right Click": "Clic droit"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Centrale"
 "DPI Preset %{index}": "Preset DPI %{index}"
 "Hold %{chord}": "Tieni premuto %{chord}"
+"Hold %{modifiers}, tap %{key}": "Tieni premuto %{modifiers}, tocca %{key}"
+"Tap %{key}": "Tocca %{key}"
 "Gesture %{name}": "Gesture %{name}"
 "Left Click": "Click sinistro"
 "Right Click": "Click destro"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "中ボタン"
 "DPI Preset %{index}": "DPI プリセット %{index}"
 "Hold %{chord}": "%{chord} を長押し"
+"Hold %{modifiers}, tap %{key}": "%{modifiers} を長押しして %{key} を1回押す"
+"Tap %{key}": "%{key} を1回押す"
 "Gesture %{name}": "ジェスチャー %{name}"
 "Left Click": "左クリック"
 "Right Click": "右クリック"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "가운데 버튼"
 "DPI Preset %{index}": "DPI 프리셋 %{index}"
 "Hold %{chord}": "%{chord} 길게 누르기"
+"Hold %{modifiers}, tap %{key}": "%{modifiers} 길게 누르고 %{key} 한 번 누르기"
+"Tap %{key}": "%{key} 한 번 누르기"
 "Gesture %{name}": "제스처 %{name}"
 "Left Click": "왼쪽 클릭"
 "Right Click": "오른쪽 클릭"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Midtknapp"
 "DPI Preset %{index}": "DPI-forhåndsinnstilling %{index}"
 "Hold %{chord}": "Hold %{chord}"
+"Hold %{modifiers}, tap %{key}": "Hold %{modifiers}, trykk %{key}"
+"Tap %{key}": "Trykk %{key}"
 "Gesture %{name}": "Bevegelse %{name}"
 "Left Click": "Venstreklikk"
 "Right Click": "Høyreklikk"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Middenknop"
 "DPI Preset %{index}": "DPI-voorinstelling %{index}"
 "Hold %{chord}": "%{chord} ingedrukt houden"
+"Hold %{modifiers}, tap %{key}": "%{modifiers} ingedrukt houden, %{key} tikken"
+"Tap %{key}": "%{key} tikken"
 "Gesture %{name}": "Gebaar %{name}"
 "Left Click": "Linkerklik"
 "Right Click": "Rechterklik"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Środkowy"
 "DPI Preset %{index}": "Ustawienie wstępne DPI %{index}"
 "Hold %{chord}": "Przytrzymaj %{chord}"
+"Hold %{modifiers}, tap %{key}": "Przytrzymaj %{modifiers}, naciśnij %{key}"
+"Tap %{key}": "Naciśnij %{key}"
 "Gesture %{name}": "Gest %{name}"
 "Left Click": "Lewy przycisk"
 "Right Click": "Prawy przycisk"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Meio"
 "DPI Preset %{index}": "Predefinição de DPI %{index}"
 "Hold %{chord}": "Manter %{chord}"
+"Hold %{modifiers}, tap %{key}": "Manter %{modifiers}, tocar %{key}"
+"Tap %{key}": "Tocar %{key}"
 "Gesture %{name}": "Gesto %{name}"
 "Left Click": "Clique Esquerdo"
 "Right Click": "Clique Direito"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Central"
 "DPI Preset %{index}": "Predefinição de DPI %{index}"
 "Hold %{chord}": "Manter %{chord}"
+"Hold %{modifiers}, tap %{key}": "Manter %{modifiers}, tocar %{key}"
+"Tap %{key}": "Tocar %{key}"
 "Gesture %{name}": "Gesto %{name}"
 "Left Click": "Clique esquerdo"
 "Right Click": "Clique direito"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Средняя"
 "DPI Preset %{index}": "Пресет DPI %{index}"
 "Hold %{chord}": "Удерживать %{chord}"
+"Hold %{modifiers}, tap %{key}": "Удерживать %{modifiers}, нажать %{key}"
+"Tap %{key}": "Нажать %{key}"
 "Gesture %{name}": "Жест %{name}"
 "Left Click": "Левый щелчок"
 "Right Click": "Правый щелчок"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Mittenknapp"
 "DPI Preset %{index}": "DPI-förinställning %{index}"
 "Hold %{chord}": "Håll %{chord}"
+"Hold %{modifiers}, tap %{key}": "Håll %{modifiers}, tryck %{key}"
+"Tap %{key}": "Tryck %{key}"
 "Gesture %{name}": "Gest %{name}"
 "Left Click": "Vänsterklick"
 "Right Click": "Högerklick"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Orta"
 "DPI Preset %{index}": "DPI Ön Ayarı %{index}"
 "Hold %{chord}": "%{chord} basılı tut"
+"Hold %{modifiers}, tap %{key}": "%{modifiers} basılı tut, %{key} tuşuna bas"
+"Tap %{key}": "%{key} tuşuna bas"
 "Gesture %{name}": "%{name} hareketi"
 "Left Click": "Sol Tık"
 "Right Click": "Sağ Tık"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "Середня"
 "DPI Preset %{index}": "Пресет DPI %{index}"
 "Hold %{chord}": "Утримувати %{chord}"
+"Hold %{modifiers}, tap %{key}": "Утримувати %{modifiers}, натиснути %{key}"
+"Tap %{key}": "Натиснути %{key}"
 "Gesture %{name}": "Жест %{name}"
 "Left Click": "Клацання лівою"
 "Right Click": "Клацання правою"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "中键"
 "DPI Preset %{index}": "灵敏度预设 %{index}"
 "Hold %{chord}": "按住 %{chord}"
+"Hold %{modifiers}, tap %{key}": "按住 %{modifiers}，点按 %{key}"
+"Tap %{key}": "点按 %{key}"
 "Gesture %{name}": "手势 %{name}"
 "Left Click": "左键单击"
 "Right Click": "右键单击"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "中鍵"
 "DPI Preset %{index}": "靈敏度預設 %{index}"
 "Hold %{chord}": "按住 %{chord}"
+"Hold %{modifiers}, tap %{key}": "按住 %{modifiers}，輕按 %{key}"
+"Tap %{key}": "輕按 %{key}"
 "Gesture %{name}": "手勢 %{name}"
 "Left Click": "左鍵單擊"
 "Right Click": "右鍵單擊"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -175,6 +175,8 @@ _version: 1
 "Middle": "中鍵"
 "DPI Preset %{index}": "靈敏度預設 %{index}"
 "Hold %{chord}": "按住 %{chord}"
+"Hold %{modifiers}, tap %{key}": "按住 %{modifiers}，輕點 %{key}"
+"Tap %{key}": "輕點 %{key}"
 "Gesture %{name}": "手勢 %{name}"
 "Left Click": "左鍵按一下"
 "Right Click": "右鍵按一下"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,6 +92,7 @@ Payload actions use a one-key inline table:
 ```toml
 Back = { CustomShortcut = "Cmd+Shift+P" }
 Forward = { HoldShortcut = "Ctrl+Space" }
+GestureButton = { TapKeyHoldingModifiers = "Cmd+Tab" }
 MiddleClick = { OpenApplication = { path = "~/Downloads", display_name = "Downloads" } }
 DpiToggle = { short = "ShowDesktop", long = "MissionControl" }
 ```
@@ -100,6 +101,15 @@ DpiToggle = { short = "ShowDesktop", long = "MissionControl" }
 the chord down until the originating physical button is released, and also
 releases it if capture is interrupted, the binding becomes invalid, or the
 agent shuts down. Use it for push-to-talk and other hold-to-activate controls.
+
+`TapKeyHoldingModifiers` splits the chord: the modifiers are held for the same
+lifetime as `HoldShortcut`, while the ordinary key is tapped exactly once when
+the press starts. That is what an application switcher needs. `Cmd+Tab` steps
+one window forward and leaves the switcher on screen until the button is
+released, where `HoldShortcut` would hold Tab down too and let key repeat walk
+the switcher to its last window, and `CustomShortcut` would release Cmd at once
+and dismiss it. The same shape covers ``Cmd+` ``, `Alt+Tab`, and an IDE's
+`Ctrl+Tab`. A chord with no modifier degrades to a plain tap of its key.
 
 A `{ short = ..., long = ... }` binding waits for the button's outcome instead
 of firing on press. Releasing before 500 ms fires `short`; keeping the button

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -30,8 +30,10 @@ scroll_resolution = "high"
 
 [devices."receiver:aabbccdd:slot:1".bindings]
 Back = "BrowserBack"
-Forward = "BrowserForward"
-# Hold the chord for exactly as long as the physical button is held.
+# Hold only the modifiers and tap the key once: the application switcher steps
+# one window forward and stays open until the button is released.
+Forward = { TapKeyHoldingModifiers = "Cmd+Tab" }
+# Hold the whole chord for exactly as long as the physical button is held.
 MiddleClick = { HoldShortcut = "Ctrl+Space" }
 # Release before 500 ms runs `short`; reaching 500 ms runs `long` once.
 DpiToggle = { short = "ShowDesktop", long = "MissionControl" }


### PR DESCRIPTION
## Summary

Binding a mouse button to the application switcher cannot be expressed today. The switcher needs the modifiers held for the lifetime of the press while the ordinary key is tapped exactly once, and neither existing shortcut action has that shape: `CustomShortcut` releases the modifiers immediately, so the switcher opens and closes again at once, and `HoldShortcut` holds the ordinary key down too, so key repeat walks the switcher to its last window and parks there.

`Action::TapKeyHoldingModifiers(KeyCombo)` is the third leg of that family. It holds the chord's modifiers for as long as the physical button is down and taps the chord's ordinary key once on the press edge, which is what a hand does on a keyboard.

Measured over `kCGSessionEventTap` with the new `hold_chord` example, holding `Shift+F13` (a chord no system hotkey claims, so the reading is about the injection alone) for about three seconds under each shape, with a real keyboard press of `Cmd+Tab` for scale:

| | modifier held | ordinary key |
|---|---|---|
| `WholeChord`, the shape of `HoldShortcut` | 3023.1 ms | 3005.8 ms, held the whole time |
| `ModifiersOnly`, the shape of `TapKeyHoldingModifiers` | 3024.0 ms | 1.0 ms, tapped once |
| `Cmd+Tab` typed on a keyboard, held about as long | 3143 ms | 5 ms |

The behavioural consequence, the same example driving `Cmd+Tab` end to end, with the recently used order pinned so one step always lands on the same app:

```
holding 1000 / 3000 / 8000 ms, starting from the same app
  ModifiersOnly: one step every time
  WholeChord:    overshoots, and lands further the longer it is held
```

`HoldShortcut` is not wrong here. It was built for push to talk (#399), where holding the whole chord is the correct behaviour. This is a shape it does not cover, not a bug in it.

Fixes #1098.

## Changes

**`openlogi-core`**

- `Action::TapKeyHoldingModifiers(KeyCombo)`, appended at the end of the enum so the bincode variant indices of the existing variants do not move.
- `Action::held_combo` becomes `Action::held_chord`, returning `(&KeyCombo, HeldKeys)` instead of `&KeyCombo`. The new `HeldKeys { WholeChord, ModifiersOnly }` makes "which keys stay down" a fact the action owns rather than something the injection layer infers from the variant.
- `Action::effect` folds the new variant into `HoldShortcut`'s `Effect::HeldKey` arm, so the one-shot fallback is unchanged: a dispatcher with no release context still degrades the action to a balanced tap of the whole chord, exactly as it does for `HoldShortcut`.
- `KeyCombo::rendered_label` is split into `rendered_modifiers() -> Option<String>` and `rendered_key() -> String`, so an action that treats the two halves differently can label them separately. `rendered_label` keeps its output exactly as before, now composed from the two.
- Catalog derives: the new variant joins `HoldShortcut` in `Category::Editing` and in the keyboard icon arm. It is parameterized, so like `CustomShortcut` and `HoldShortcut` it is not a picker row.

**`openlogi-inject`**

- `press_hold(combo, keys)` takes the new `HeldKeys`. `ModifiersOnly` presses the modifiers, emits a balanced down/up for the ordinary key on the press edge, and releases the modifiers on every terminal outcome the way `HoldShortcut` already does (release, cancellation, invalidated binding, shutdown).
- The tap takes no ownership in the reference counted held-output map, so a modifier shared with another live hold is unaffected.
- New `examples/hold_chord.rs`: a manual smoke test that holds one chord for a fixed time under either shape, so the two can be measured side by side against a live event stream. `press_hold` had no equivalent of `execute`'s `inject_action` example.

**`openlogi-agent-core`**

- The two `held_combo()` call sites follow the rename. No behaviour change for `HoldShortcut`.

**`openlogi-ipc`**

- `PROTOCOL_VERSION` 29 to 30, with the version-history line, and the pinned assertion in `tests/wire_format.rs` updated.

**`openlogi-desktop` and `openlogi-ui`**

- Label: `Hold Cmd, tap Tab`, generated from the combo the way `HoldShortcut`'s `Hold {chord}` label already is. A chord with no modifier renders as `Tap {key}`.
- Icon: the keyboard glyph, alongside the other chord actions.
- Two new keys in all 23 locale files, at the same position as in `en.yml`, plus the matching assertions in the i18n suite. `be.yml` carries the English source text rather than a guessed translation, so its Belarusian arrives from Crowdin, which the header of that file names as the place to edit.

**`docs`**

- `CONFIGURATION.md` gains a paragraph next to the `HoldShortcut` one, and `config.example.toml` shows the switcher binding.

## Testing

`cargo xtask ci` on macOS 15.7.3, aarch64, rustc 1.98.0: 11 passed, 0 failed, 1 skipped.

- Pass: `rustfmt`, `typos`, `publish closure`, `shell`, `clippy`, `MSRV (cargo check)`, `rustdoc (non-GUI crates)`, `tests (macos, aarch64)`, `cargo-deny`, `clippy (windows) proxy`, `wasm (portable crates)`.
- Skipped, and therefore not claimed: `tests (linux)`, which needs a Linux host. CI's Intel macOS leg and its native Windows clippy job are likewise not covered here; the Windows job above is the cross lint the runner substitutes for it.
- `cargo test -p openlogi-ipc --test wire_format` and `cargo test -p openlogi-desktop i18n` both pass, since the wire format and the locale files both changed.
- Five new unit tests inside the `tests (macos, aarch64)` job above: `held_chord` returns the modifiers-only shape where `HoldShortcut` returns the whole chord and `CustomShortcut` returns nothing, a chord with no modifier labels as `Tap F5` rather than an empty hold, the variant round trips through TOML, and two in `openlogi-inject` pin the held-output ownership claim above from both sides, that a modifiers-only hold never owns its ordinary key while a whole-chord hold of the same chord still does. Four existing tests grew an arm for the new variant, including the persisted variant-name list and the effect lowering.

Verified on hardware, an MX Master 3 on macOS 15.7.3 with `Back = { TapKeyHoldingModifiers = "Cmd+Tab" }`, the button pressed by hand three times, watching `kCGSessionEventTap`. Both of the ways this mouse reaches the machine were measured on the same build, because they are different paths into the agent: over Bluetooth the HID++ notification arrives on the BLE link, over a Unifying receiver it arrives from a device slot on the dongle.

Over Bluetooth:

| press | Cmd held | Tab tapped | result |
|---|---|---|---|
| short | 105.0 ms | 0.1 ms | one step |
| about 1.2 s | 1224.6 ms | 0.1 ms | one step |
| about 2.6 s | 2580.2 ms | 0.1 ms | one step |

Over a Unifying receiver:

| press | Cmd held | Tab tapped | result |
|---|---|---|---|
| short | 152.1 ms | 0.1 ms | one step |
| about 1.7 s | 1747.4 ms | 0.1 ms | one step |
| about 3.6 s | 3646.9 ms | 0.2 ms | one step |

The tap stays between 0.1 and 0.2 ms on every press of both runs, while the modifier tracks the finger across a 25x range of hold durations over Bluetooth and a 24x range over the receiver. The frontmost application alternates between the two most recently used windows, which is one step every time rather than a walk down the list. The same measurement against `HoldShortcut` overshoots by more the longer the button is held. No native button event from the diverted button appears anywhere in either capture, so what is measured is the whole path from the HID++ notification to the injected chord.

The GUI label, with the three chord actions side by side on one device so the wording can be compared. Back is the new action, Forward is `HoldShortcut`, and Middle Click is `CustomShortcut`. The button inspector spells the new one out in full:

<img width="2560" height="1696" alt="screenshot-tap-key-while-holding-modifiers" src="https://github.com/user-attachments/assets/ead82d5b-9ed7-425f-bfe8-5bc85e2fc124" />

That screenshot is the dev GUI against `openlogi-agent-mock`, so the device in it is the mock MX Master 3S rather than hardware. The behaviour measurements above are from a real MX Master 3.

Not covered: Windows and Linux are lint-checked only, not run. The action is platform neutral by construction, since `KeyCombo` stores abstract modifier bits and the injection layer maps them per platform, so a Windows user binding `Alt+Tab` exercises the same code path.