### PR TITLE
feat(linux): map native remaps on Hyprland

### DIFF
--- a/crates/openlogi-agent/src/autostart.rs
+++ b/crates/openlogi-agent/src/autostart.rs
@@ -13,8 +13,8 @@
 //! - **Linux** ([`linux`]): a systemd **user** unit, written/removed and
 //!   `systemctl --user` enabled/disabled. `Restart=on-failure` mirrors the
 //!   macOS service's `KeepAlive = {SuccessfulExit: false}` semantics. A
-//!   cargo `target/{debug,release}` binary skips reconcile so it cannot
-//!   overwrite or delete a packaged unit.
+//!   cargo-built binary (parent directory `debug` or `release`) skips
+//!   reconcile so it cannot overwrite or delete a packaged unit.
 //! - **Windows** ([`windows`]): an `HKCU\…\Run` registry value — login launch
 //!   only, no crash respawn.
 //!

--- a/crates/openlogi-agent/src/autostart.rs
+++ b/crates/openlogi-agent/src/autostart.rs
@@ -12,7 +12,9 @@
 //!   `config.toml` therefore takes effect the next time the GUI runs.
 //! - **Linux** ([`linux`]): a systemd **user** unit, written/removed and
 //!   `systemctl --user` enabled/disabled. `Restart=on-failure` mirrors the
-//!   macOS service's `KeepAlive = {SuccessfulExit: false}` semantics.
+//!   macOS service's `KeepAlive = {SuccessfulExit: false}` semantics. A
+//!   cargo `target/{debug,release}` binary skips reconcile so it cannot
+//!   overwrite or delete a packaged unit.
 //! - **Windows** ([`windows`]): an `HKCU\…\Run` registry value — login launch
 //!   only, no crash respawn.
 //!

--- a/crates/openlogi-agent/src/autostart/linux.rs
+++ b/crates/openlogi-agent/src/autostart/linux.rs
@@ -24,8 +24,8 @@ pub(super) fn reconcile(enabled: bool) {
 fn apply(enabled: bool) -> io::Result<()> {
     let exe = std::env::current_exe()?;
     // A `cargo build`/`cargo run` binary must not rewrite or delete the user's
-    // packaged unit. launch_at_login would otherwise point ExecStart at
-    // `target/release` (or wipe /usr/bin when the setting is off).
+    // packaged unit. launch_at_login would otherwise point ExecStart at the
+    // development binary (or wipe the user unit when the setting is off).
     if is_cargo_built_agent(&exe) {
         debug!(
             enabled,
@@ -65,17 +65,15 @@ fn apply(enabled: bool) -> io::Result<()> {
     Ok(())
 }
 
-/// True for binaries under a Cargo `target/{debug,release}/` directory.
+/// True for binaries Cargo wrote into a `debug` or `release` profile directory.
+///
+/// That directory is not always named `target/{debug,release}`: `CARGO_TARGET_DIR`,
+/// `--target-dir`, and a `--target` triple all move it. The profile directory
+/// name is the stable signal (same heuristic as xtask `Profile::of`).
 fn is_cargo_built_agent(exe: &Path) -> bool {
-    let mut saw_target = false;
-    for component in exe.components() {
-        let name = component.as_os_str();
-        if saw_target && (name == "release" || name == "debug") {
-            return true;
-        }
-        saw_target = name == "target";
-    }
-    false
+    exe.parent()
+        .and_then(Path::file_name)
+        .is_some_and(|name| name == "debug" || name == "release")
 }
 
 /// Path to the per-user systemd unit:
@@ -167,6 +165,17 @@ mod tests {
         )));
         assert!(is_cargo_built_agent(Path::new(
             "/home/dev/openlogi/target/debug/openlogi-agent"
+        )));
+        // `CARGO_TARGET_DIR` / `--target-dir` replace the `target` component.
+        assert!(is_cargo_built_agent(Path::new(
+            "/tmp/cargo-target/debug/openlogi-agent"
+        )));
+        assert!(is_cargo_built_agent(Path::new(
+            "/elsewhere/shared-target/release/openlogi-agent"
+        )));
+        // `--target <triple>` inserts a directory between `target` and the profile.
+        assert!(is_cargo_built_agent(Path::new(
+            "/home/dev/openlogi/target/x86_64-unknown-linux-gnu/debug/openlogi-agent"
         )));
         assert!(!is_cargo_built_agent(Path::new("/usr/bin/openlogi-agent")));
         assert!(!is_cargo_built_agent(Path::new(

--- a/crates/openlogi-agent/src/autostart/linux.rs
+++ b/crates/openlogi-agent/src/autostart/linux.rs
@@ -8,7 +8,7 @@
 
 use std::fmt;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tracing::{debug, info, warn};
 
@@ -22,8 +22,19 @@ pub(super) fn reconcile(enabled: bool) {
 }
 
 fn apply(enabled: bool) -> io::Result<()> {
-    let path = unit_path()?;
     let exe = std::env::current_exe()?;
+    // A `cargo build`/`cargo run` binary must not rewrite or delete the user's
+    // packaged unit. launch_at_login would otherwise point ExecStart at
+    // `target/release` (or wipe /usr/bin when the setting is off).
+    if is_cargo_built_agent(&exe) {
+        debug!(
+            enabled,
+            path = %exe.display(),
+            "cargo-built agent — leaving the systemd user unit unchanged"
+        );
+        return Ok(());
+    }
+    let path = unit_path()?;
     let desired = enabled.then(|| render_unit(&exe.to_string_lossy()));
 
     let current = std::fs::read_to_string(&path).ok();
@@ -52,6 +63,19 @@ fn apply(enabled: bool) -> io::Result<()> {
         (None, None) => debug!("systemd user unit already absent"),
     }
     Ok(())
+}
+
+/// True for binaries under a Cargo `target/{debug,release}/` directory.
+fn is_cargo_built_agent(exe: &Path) -> bool {
+    let mut saw_target = false;
+    for component in exe.components() {
+        let name = component.as_os_str();
+        if saw_target && (name == "release" || name == "debug") {
+            return true;
+        }
+        saw_target = name == "target";
+    }
+    false
 }
 
 /// Path to the per-user systemd unit:
@@ -135,6 +159,23 @@ impl fmt::Display for SystemctlArgsDisplay<'_, '_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cargo_built_agent_paths_are_detected() {
+        assert!(is_cargo_built_agent(Path::new(
+            "/home/dev/openlogi/target/release/openlogi-agent"
+        )));
+        assert!(is_cargo_built_agent(Path::new(
+            "/home/dev/openlogi/target/debug/openlogi-agent"
+        )));
+        assert!(!is_cargo_built_agent(Path::new("/usr/bin/openlogi-agent")));
+        assert!(!is_cargo_built_agent(Path::new(
+            "/usr/local/bin/openlogi-agent"
+        )));
+        assert!(!is_cargo_built_agent(Path::new(
+            "/home/dev/target-practice/openlogi-agent"
+        )));
+    }
 
     #[test]
     fn rendered_unit_targets_agent_and_restarts_on_failure() {

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -185,11 +185,14 @@ fn held_keys(combo: &KeyCombo) -> Vec<HeldKey> {
 /// handled at the hook/HID layer, logging a trace here.
 ///
 /// On Linux, key and scroll events are injected via a lazily-created `uinput`
-/// virtual device. Mouse clicks inject `BTN_*` events. macOS-only window
-/// manager actions (`MissionControl`, `AppExpose`, `ShowDesktop`,
-/// `LaunchpadShow`) have no universal Linux equivalent and are silently
-/// skipped (debug-logged). `CustomShortcut` maps macOS `kVK_*` codes to
-/// Linux key codes; macOS Cmd maps to Ctrl.
+/// virtual device. Mouse clicks inject `BTN_*` events. When
+/// `HYPRLAND_INSTANCE_SIGNATURE` is non-empty, `LaunchpadShow` runs
+/// `omarchy-menu toggle`, desktop switches run `hyprctl dispatch workspace`,
+/// and `LockScreen` prefers logind then `omarchy-system-lock` (never Super+L).
+/// Otherwise macOS-only window manager actions (`MissionControl`, `AppExpose`,
+/// `ShowDesktop`, `LaunchpadShow`) have no universal Linux equivalent and are
+/// silently skipped (debug-logged). `CustomShortcut` maps macOS `kVK_*` codes
+/// to Linux key codes; macOS Cmd maps to Ctrl.
 ///
 /// On Windows, key and mouse events are synthesised via `SendInput`. The
 /// macOS window-manager actions map to their Windows equivalents (e.g.

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -188,8 +188,8 @@ fn held_keys(combo: &KeyCombo) -> Vec<HeldKey> {
 /// virtual device. Mouse clicks inject `BTN_*` events. When
 /// `HYPRLAND_INSTANCE_SIGNATURE` is non-empty, `LaunchpadShow` runs
 /// `omarchy-menu toggle`, desktop switches run `hyprctl dispatch workspace`,
-/// and `LockScreen` prefers logind then `omarchy-system-lock` (never Super+L).
-/// Otherwise macOS-only window manager actions (`MissionControl`, `AppExpose`,
+/// and `LockScreen` runs `omarchy-system-lock` (never Super+L; logind is not
+/// treated as locked on Hyprland). Otherwise macOS-only window manager actions (`MissionControl`, `AppExpose`,
 /// `ShowDesktop`, `LaunchpadShow`) have no universal Linux equivalent and are
 /// silently skipped (debug-logged). `CustomShortcut` maps macOS `kVK_*` codes
 /// to Linux key codes; macOS Cmd maps to Ctrl.

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -8,7 +8,8 @@
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::thread;
 
 use evdev::uinput::VirtualDevice;
 use evdev::{AttributeSet, EventType, InputEvent, KeyCode, RelativeAxisCode};
@@ -288,23 +289,51 @@ fn generic_linux_lock_fallback_chord() -> ChordSpec {
 }
 
 fn run_helper_or_chord(helper: HelperSpec, fallback: ChordSpec) {
-    if run_fixed_argv(helper.program, helper.args) {
-        return;
-    }
-    press_key(fallback.modifiers, fallback.key);
+    run_helper_or_else(helper, &HELPER_PREFIXES, move || {
+        press_key(fallback.modifiers, fallback.key);
+    });
 }
 
-/// Spawn an allowlisted absolute helper. Never searches `PATH` and never
-/// shells out through `/bin/sh -c` (that path is only for user `RunShellCommand`).
-fn run_fixed_argv(program: &str, args: &[&str]) -> bool {
-    let Some(path) = resolve_allowlisted(program) else {
+/// Resolve an allowlisted helper, then wait for it off the action/button
+/// worker. Missing helpers fall back on this thread (stat only); a helper
+/// that is slow or never exits must not stall remap dispatch.
+fn run_helper_or_else(
+    helper: HelperSpec,
+    prefixes: &[&str],
+    on_failure: impl Fn() + Send + Sync + 'static,
+) {
+    let Some(path) = resolve_allowlisted_under(helper.program, prefixes) else {
         tracing::debug!(
-            program,
+            program = helper.program,
             "Hyprland helper not in /usr/bin or /usr/local/bin — using chord fallback"
         );
-        return false;
+        on_failure();
+        return;
     };
-    match Command::new(&path).args(args).status() {
+    let args = helper.args;
+    let on_failure = Arc::new(on_failure);
+    let waiter_failure = Arc::clone(&on_failure);
+    match thread::Builder::new()
+        .name("openlogi-hypr-helper".into())
+        .spawn(move || {
+            if !run_resolved(&path, args) {
+                waiter_failure();
+            }
+        }) {
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(
+                program = helper.program,
+                %error,
+                "failed to spawn Hyprland helper waiter — using chord fallback"
+            );
+            on_failure();
+        }
+    }
+}
+
+fn run_resolved(path: &Path, args: &[&str]) -> bool {
+    match Command::new(path).args(args).status() {
         Ok(status) if status.success() => true,
         Ok(status) => {
             tracing::debug!(
@@ -323,10 +352,6 @@ fn run_fixed_argv(program: &str, args: &[&str]) -> bool {
             false
         }
     }
-}
-
-fn resolve_allowlisted(name: &str) -> Option<PathBuf> {
-    resolve_allowlisted_under(name, &HELPER_PREFIXES)
 }
 
 fn resolve_allowlisted_under(name: &str, prefixes: &[&str]) -> Option<PathBuf> {
@@ -820,12 +845,11 @@ fn lock_screen() {
 /// that chord toggles workspace layout on Omarchy.
 fn lock_screen_hyprland() {
     let helper = hyprland_lock_helper();
-    if run_fixed_argv(helper.program, helper.args) {
-        return;
-    }
-    tracing::debug!("LockScreen via Super+Ctrl+L (Hyprland / Omarchy)");
-    let chord = hyprland_lock_fallback_chord();
-    press_key(chord.modifiers, chord.key);
+    run_helper_or_else(helper, &HELPER_PREFIXES, || {
+        tracing::debug!("LockScreen via Super+Ctrl+L (Hyprland / Omarchy)");
+        let chord = hyprland_lock_fallback_chord();
+        press_key(chord.modifiers, chord.key);
+    });
 }
 
 /// Suspend the system via logind's `Suspend()` on the system bus. The
@@ -911,10 +935,10 @@ mod tests {
     use openlogi_core::binding::{KeyCombo, NativeAction, Shortcut};
 
     use super::{
-        HELPER_PREFIXES, combo, generic_linux_lock_fallback_chord, hid_usage_to_linux,
+        HELPER_PREFIXES, HelperSpec, combo, generic_linux_lock_fallback_chord, hid_usage_to_linux,
         hyprland_helper, hyprland_lock_fallback_chord, hyprland_lock_helper,
         hyprland_session_from_signature, key_ev, key_phase_events, modifiers_to_keycodes,
-        resolve_allowlisted_under, syn,
+        resolve_allowlisted_under, run_helper_or_else, syn,
     };
     use crate::inject::KeyPhase;
 
@@ -1088,5 +1112,85 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn helper_wait_does_not_block_the_caller() {
+        let dir = std::env::temp_dir().join(format!(
+            "openlogi-inject-helper-wait-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp helper dir");
+        let helper = dir.join("slow-helper");
+        std::fs::write(&helper, "#!/bin/sh\nexec sleep 2\n").expect("slow helper script");
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755))
+                .expect("executable helper");
+        }
+        let prefix = dir.to_str().expect("utf-8 temp path");
+        let started = std::time::Instant::now();
+        run_helper_or_else(
+            HelperSpec {
+                program: "slow-helper",
+                args: &[],
+            },
+            &[prefix],
+            || panic!("slow helper should start successfully"),
+        );
+        let elapsed = started.elapsed();
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            elapsed < std::time::Duration::from_millis(200),
+            "caller waited for the helper ({elapsed:?})"
+        );
+    }
+
+    #[test]
+    fn missing_helper_falls_back_on_the_caller() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        run_helper_or_else(
+            HelperSpec {
+                program: "no-such-openlogi-helper",
+                args: &[],
+            },
+            &["/no/such/openlogi-prefix"],
+            move || {
+                let _ = tx.send(());
+            },
+        );
+        rx.try_recv()
+            .expect("missing helper must fall back before returning");
+    }
+
+    #[test]
+    fn unsuccessful_helper_still_falls_back() {
+        let dir = std::env::temp_dir().join(format!(
+            "openlogi-inject-helper-fail-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp helper dir");
+        let helper = dir.join("failing-helper");
+        std::fs::write(&helper, "#!/bin/sh\nexit 1\n").expect("failing helper script");
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755))
+                .expect("executable helper");
+        }
+        let prefix = dir.to_str().expect("utf-8 temp path");
+        let (tx, rx) = std::sync::mpsc::channel();
+        run_helper_or_else(
+            HelperSpec {
+                program: "failing-helper",
+                args: &[],
+            },
+            &[prefix],
+            move || {
+                let _ = tx.send(());
+            },
+        );
+        let arrived = rx.recv_timeout(std::time::Duration::from_secs(1));
+        let _ = std::fs::remove_dir_all(&dir);
+        arrived.expect("fallback must still run after a helper non-zero exit");
     }
 }

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -6,6 +6,8 @@
 //! without panicking.
 
 use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{LazyLock, Mutex};
 
 use evdev::uinput::VirtualDevice;
@@ -141,6 +143,21 @@ fn dispatch_media(key: MediaKey) {
 /// Dispatch a window-manager or power [`NativeAction`]. `action` is only
 /// used for its label in the "no Linux equivalent" debug log.
 fn dispatch_native(action: &Action, native: NativeAction) {
+    if hyprland_session() {
+        tracing::debug!(
+            desktop = std::env::var("XDG_CURRENT_DESKTOP")
+                .ok()
+                .as_deref()
+                .unwrap_or(""),
+            "Hyprland native table selected"
+        );
+        dispatch_hyprland_native(action, native);
+        return;
+    }
+    dispatch_generic_linux_native(action, native);
+}
+
+fn dispatch_generic_linux_native(action: &Action, native: NativeAction) {
     let ctrl = KeyCode::KEY_LEFTCTRL;
     let alt = KeyCode::KEY_LEFTALT;
     match native {
@@ -148,12 +165,7 @@ fn dispatch_native(action: &Action, native: NativeAction) {
         NativeAction::MissionControl
         | NativeAction::AppExpose
         | NativeAction::ShowDesktop
-        | NativeAction::LaunchpadShow => {
-            tracing::debug!(
-                action = action.label(),
-                "no Linux equivalent — action skipped"
-            );
-        }
+        | NativeAction::LaunchpadShow => skip_unsupported_native(action),
         // Ctrl+Alt+←/→ is the default in GNOME and KDE.
         NativeAction::PreviousDesktop => press_key(&[ctrl, alt], KeyCode::KEY_LEFT),
         NativeAction::NextDesktop => press_key(&[ctrl, alt], KeyCode::KEY_RIGHT),
@@ -167,6 +179,157 @@ fn dispatch_native(action: &Action, native: NativeAction) {
         // logind Suspend() via the system bus.
         NativeAction::Sleep => sleep_system(),
     }
+}
+
+fn dispatch_hyprland_native(action: &Action, native: NativeAction) {
+    match native {
+        NativeAction::MissionControl | NativeAction::AppExpose | NativeAction::ShowDesktop => {
+            skip_unsupported_native(action)
+        }
+        NativeAction::LaunchpadShow | NativeAction::PreviousDesktop | NativeAction::NextDesktop => {
+            if let Some((helper, fallback)) = hyprland_helper(native) {
+                run_helper_or_chord(helper, fallback);
+            }
+        }
+        NativeAction::LockScreen => lock_screen_hyprland(),
+        NativeAction::Screenshot | NativeAction::CaptureRegion => {
+            press_key(&[], KeyCode::KEY_SYSRQ);
+        }
+        NativeAction::Sleep => sleep_system(),
+    }
+}
+
+fn skip_unsupported_native(action: &Action) {
+    tracing::debug!(
+        action = action.label(),
+        "no Linux equivalent — action skipped"
+    );
+}
+
+/// Hyprland compositor session. Gate is the instance signature only —
+/// `XDG_CURRENT_DESKTOP` is logged for diagnostics and must not select the table.
+fn hyprland_session() -> bool {
+    hyprland_session_from_signature(std::env::var("HYPRLAND_INSTANCE_SIGNATURE").ok().as_deref())
+}
+
+fn hyprland_session_from_signature(signature: Option<&str>) -> bool {
+    signature.is_some_and(|value| !value.is_empty())
+}
+
+const HELPER_PREFIXES: [&str; 2] = ["/usr/bin", "/usr/local/bin"];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HelperSpec {
+    program: &'static str,
+    args: &'static [&'static str],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ChordSpec {
+    modifiers: &'static [KeyCode],
+    key: KeyCode,
+}
+
+fn hyprland_helper(native: NativeAction) -> Option<(HelperSpec, ChordSpec)> {
+    match native {
+        NativeAction::LaunchpadShow => Some((
+            HelperSpec {
+                program: "omarchy-menu",
+                args: &["toggle"],
+            },
+            ChordSpec {
+                modifiers: &[KeyCode::KEY_LEFTMETA],
+                key: KeyCode::KEY_SPACE,
+            },
+        )),
+        NativeAction::NextDesktop => Some((
+            HelperSpec {
+                program: "hyprctl",
+                args: &["dispatch", "workspace", "e+1"],
+            },
+            ChordSpec {
+                modifiers: &[KeyCode::KEY_LEFTMETA],
+                key: KeyCode::KEY_TAB,
+            },
+        )),
+        NativeAction::PreviousDesktop => Some((
+            HelperSpec {
+                program: "hyprctl",
+                args: &["dispatch", "workspace", "e-1"],
+            },
+            ChordSpec {
+                modifiers: &[KeyCode::KEY_LEFTMETA, KeyCode::KEY_LEFTSHIFT],
+                key: KeyCode::KEY_TAB,
+            },
+        )),
+        _ => None,
+    }
+}
+
+fn hyprland_lock_fallback_chord() -> ChordSpec {
+    ChordSpec {
+        modifiers: &[KeyCode::KEY_LEFTMETA, KeyCode::KEY_LEFTCTRL],
+        key: KeyCode::KEY_L,
+    }
+}
+
+fn generic_linux_lock_fallback_chord() -> ChordSpec {
+    ChordSpec {
+        modifiers: &[KeyCode::KEY_LEFTMETA],
+        key: KeyCode::KEY_L,
+    }
+}
+
+fn run_helper_or_chord(helper: HelperSpec, fallback: ChordSpec) {
+    if run_fixed_argv(helper.program, helper.args) {
+        return;
+    }
+    press_key(fallback.modifiers, fallback.key);
+}
+
+/// Spawn an allowlisted absolute helper. Never searches `PATH` and never
+/// shells out through `/bin/sh -c` (that path is only for user `RunShellCommand`).
+fn run_fixed_argv(program: &str, args: &[&str]) -> bool {
+    let Some(path) = resolve_allowlisted(program) else {
+        tracing::debug!(
+            program,
+            "Hyprland helper not in /usr/bin or /usr/local/bin — using chord fallback"
+        );
+        return false;
+    };
+    match Command::new(&path).args(args).status() {
+        Ok(status) if status.success() => true,
+        Ok(status) => {
+            tracing::debug!(
+                program = %path.display(),
+                %status,
+                "Hyprland helper exited unsuccessfully — using chord fallback"
+            );
+            false
+        }
+        Err(error) => {
+            tracing::warn!(
+                program = %path.display(),
+                %error,
+                "failed to spawn Hyprland helper — using chord fallback"
+            );
+            false
+        }
+    }
+}
+
+fn resolve_allowlisted(name: &str) -> Option<PathBuf> {
+    resolve_allowlisted_under(name, &HELPER_PREFIXES)
+}
+
+fn resolve_allowlisted_under(name: &str, prefixes: &[&str]) -> Option<PathBuf> {
+    if name.is_empty() || name.contains('/') || name.contains('\\') {
+        return None;
+    }
+    prefixes
+        .iter()
+        .map(|prefix| Path::new(prefix).join(name))
+        .find(|path| path.is_file())
 }
 
 fn dispatch_script(script: Script<'_>) {
@@ -268,7 +431,7 @@ const KEY_CAPABILITIES: &[KeyCode] = &[
     KeyCode::KEY_HOME,  KeyCode::KEY_END,   KeyCode::KEY_PAGEUP,   KeyCode::KEY_PAGEDOWN,
     KeyCode::KEY_TAB,   KeyCode::KEY_ENTER, KeyCode::KEY_BACKSPACE, KeyCode::KEY_DELETE,
     KeyCode::KEY_ESC,   KeyCode::KEY_SPACE,
-    // Modifiers (KEY_LEFTMETA used by the LockScreen Super+L fallback)
+    // Modifiers (KEY_LEFTMETA used by LockScreen Super+L and Hyprland Super+Ctrl+L)
     KeyCode::KEY_LEFTCTRL, KeyCode::KEY_LEFTSHIFT, KeyCode::KEY_LEFTALT, KeyCode::KEY_LEFTMETA,
     // Function keys
     KeyCode::KEY_F1,  KeyCode::KEY_F2,  KeyCode::KEY_F3,  KeyCode::KEY_F4,
@@ -603,32 +766,57 @@ static SYSTEM_BUS: LazyLock<Option<DbusConn>> = LazyLock::new(|| {
         .ok()
 });
 
+/// Lock the session identified by `$XDG_SESSION_ID` via logind. Returns
+/// `true` when the D-Bus call succeeded. Skips the bus entirely when the
+/// session id is unset so we never lock every session on the machine.
+fn try_logind_lock() -> bool {
+    let (Some(conn), Ok(id)) = (SYSTEM_BUS.as_ref(), std::env::var("XDG_SESSION_ID")) else {
+        return false;
+    };
+    match conn.call_method(
+        Some("org.freedesktop.login1"),
+        "/org/freedesktop/login1",
+        Some("org.freedesktop.login1.Manager"),
+        "LockSession",
+        &(id.as_str(),),
+    ) {
+        Ok(_) => {
+            tracing::debug!("LockScreen via logind");
+            true
+        }
+        Err(e) => {
+            tracing::warn!("logind LockSession failed: {e}");
+            false
+        }
+    }
+}
+
 /// Lock the screen via logind `LockSession($XDG_SESSION_ID)` on the system
 /// bus, falling back to Super+L.
 ///
-/// Only the session identified by `$XDG_SESSION_ID` is locked; if the
-/// variable is unset the D-Bus path is skipped entirely to avoid locking
-/// all sessions on the machine. Super+L covers non-systemd systems and the
-/// no-session-id case.
+/// Super+L covers non-systemd systems and the no-session-id case on GNOME/KDE.
 fn lock_screen() {
-    if let (Some(conn), Ok(id)) = (SYSTEM_BUS.as_ref(), std::env::var("XDG_SESSION_ID")) {
-        match conn.call_method(
-            Some("org.freedesktop.login1"),
-            "/org/freedesktop/login1",
-            Some("org.freedesktop.login1.Manager"),
-            "LockSession",
-            &(id.as_str(),),
-        ) {
-            Ok(_) => {
-                tracing::debug!("LockScreen via logind");
-                return;
-            }
-            Err(e) => tracing::warn!("logind LockSession failed: {e}"),
-        }
+    if try_logind_lock() {
+        return;
     }
     // Super+L is the standard lock shortcut on GNOME and KDE.
     tracing::debug!("LockScreen via Super+L key combo");
-    press_key(&[KeyCode::KEY_LEFTMETA], KeyCode::KEY_L);
+    let chord = generic_linux_lock_fallback_chord();
+    press_key(chord.modifiers, chord.key);
+}
+
+/// Hyprland lock: logind, then `omarchy-system-lock`, then Super+Ctrl+L.
+/// Never Super+L — that chord toggles workspace layout on Omarchy.
+fn lock_screen_hyprland() {
+    if try_logind_lock() {
+        return;
+    }
+    if run_fixed_argv("omarchy-system-lock", &[]) {
+        return;
+    }
+    tracing::debug!("LockScreen via Super+Ctrl+L (Hyprland / Omarchy)");
+    let chord = hyprland_lock_fallback_chord();
+    press_key(chord.modifiers, chord.key);
 }
 
 /// Suspend the system via logind's `Suspend()` on the system bus. The
@@ -711,9 +899,13 @@ fn try_mpris_command(command: &str) -> Option<()> {
 #[cfg(test)]
 mod tests {
     use evdev::KeyCode;
-    use openlogi_core::binding::{KeyCombo, Shortcut};
+    use openlogi_core::binding::{KeyCombo, NativeAction, Shortcut};
 
-    use super::{combo, hid_usage_to_linux, key_ev, key_phase_events, modifiers_to_keycodes, syn};
+    use super::{
+        HELPER_PREFIXES, combo, generic_linux_lock_fallback_chord, hid_usage_to_linux,
+        hyprland_helper, hyprland_lock_fallback_chord, hyprland_session_from_signature, key_ev,
+        key_phase_events, modifiers_to_keycodes, resolve_allowlisted_under, syn,
+    };
     use crate::inject::KeyPhase;
 
     #[test]
@@ -786,5 +978,97 @@ mod tests {
                 "{shortcut:?} table entry has no Linux keycode mapping"
             );
         }
+    }
+
+    #[test]
+    fn hyprland_gate_is_signature_only() {
+        assert!(!hyprland_session_from_signature(None));
+        assert!(!hyprland_session_from_signature(Some("")));
+        assert!(hyprland_session_from_signature(Some(
+            "wayland-1_1234567890_1111111111"
+        )));
+    }
+
+    #[test]
+    fn hyprland_launchpad_maps_to_absolute_omarchy_menu_toggle() {
+        let (helper, fallback) = hyprland_helper(NativeAction::LaunchpadShow)
+            .expect("LaunchpadShow must have a Hyprland helper");
+        assert_eq!(helper.program, "omarchy-menu");
+        assert_eq!(helper.args, ["toggle"]);
+        assert_eq!(HELPER_PREFIXES, ["/usr/bin", "/usr/local/bin"]);
+        assert_eq!(fallback.modifiers, [KeyCode::KEY_LEFTMETA]);
+        assert_eq!(fallback.key, KeyCode::KEY_SPACE);
+    }
+
+    #[test]
+    fn hyprland_desktops_map_to_hyprctl_workspace() {
+        let (next, next_fallback) = hyprland_helper(NativeAction::NextDesktop)
+            .expect("NextDesktop must have a Hyprland helper");
+        assert_eq!(next.program, "hyprctl");
+        assert_eq!(next.args, ["dispatch", "workspace", "e+1"]);
+        assert_eq!(next_fallback.modifiers, [KeyCode::KEY_LEFTMETA]);
+        assert_eq!(next_fallback.key, KeyCode::KEY_TAB);
+
+        let (prev, prev_fallback) = hyprland_helper(NativeAction::PreviousDesktop)
+            .expect("PreviousDesktop must have a Hyprland helper");
+        assert_eq!(prev.program, "hyprctl");
+        assert_eq!(prev.args, ["dispatch", "workspace", "e-1"]);
+        assert_eq!(
+            prev_fallback.modifiers,
+            [KeyCode::KEY_LEFTMETA, KeyCode::KEY_LEFTSHIFT]
+        );
+        assert_eq!(prev_fallback.key, KeyCode::KEY_TAB);
+    }
+
+    #[test]
+    fn hyprland_mac_only_natives_stay_skipped() {
+        assert_eq!(hyprland_helper(NativeAction::MissionControl), None);
+        assert_eq!(hyprland_helper(NativeAction::AppExpose), None);
+        assert_eq!(hyprland_helper(NativeAction::ShowDesktop), None);
+        assert_eq!(hyprland_helper(NativeAction::LockScreen), None);
+        assert_eq!(hyprland_helper(NativeAction::Screenshot), None);
+    }
+
+    #[test]
+    fn hyprland_lock_fallback_is_never_super_l() {
+        let hyprland = hyprland_lock_fallback_chord();
+        assert_eq!(
+            hyprland.modifiers,
+            [KeyCode::KEY_LEFTMETA, KeyCode::KEY_LEFTCTRL]
+        );
+        assert_eq!(hyprland.key, KeyCode::KEY_L);
+
+        let generic = generic_linux_lock_fallback_chord();
+        assert_eq!(generic.modifiers, [KeyCode::KEY_LEFTMETA]);
+        assert_eq!(generic.key, KeyCode::KEY_L);
+        assert_ne!(hyprland.modifiers, generic.modifiers);
+    }
+
+    #[test]
+    fn allowlisted_helpers_are_absolute_and_reject_path_escape() {
+        let dir =
+            std::env::temp_dir().join(format!("openlogi-inject-allowlist-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp allowlist dir");
+        let helper = dir.join("omarchy-menu");
+        std::fs::write(&helper, []).expect("placeholder helper file");
+
+        let prefix = dir.to_str().expect("utf-8 temp path");
+        let resolved = resolve_allowlisted_under("omarchy-menu", &[prefix]);
+        assert_eq!(resolved.as_deref(), Some(helper.as_path()));
+        assert!(resolved.expect("resolved helper").is_absolute());
+        assert_eq!(
+            resolve_allowlisted_under("../omarchy-menu", &[prefix]),
+            None
+        );
+        assert_eq!(
+            resolve_allowlisted_under("omarchy-menu/../../bin/sh", &[prefix]),
+            None
+        );
+        assert_eq!(
+            resolve_allowlisted_under("omarchy-menu", &["/no/such/openlogi-prefix"]),
+            None
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -184,7 +184,7 @@ fn dispatch_generic_linux_native(action: &Action, native: NativeAction) {
 fn dispatch_hyprland_native(action: &Action, native: NativeAction) {
     match native {
         NativeAction::MissionControl | NativeAction::AppExpose | NativeAction::ShowDesktop => {
-            skip_unsupported_native(action)
+            skip_unsupported_native(action);
         }
         NativeAction::LaunchpadShow | NativeAction::PreviousDesktop | NativeAction::NextDesktop => {
             if let Some((helper, fallback)) = hyprland_helper(native) {
@@ -263,6 +263,13 @@ fn hyprland_helper(native: NativeAction) -> Option<(HelperSpec, ChordSpec)> {
             },
         )),
         _ => None,
+    }
+}
+
+fn hyprland_lock_helper() -> HelperSpec {
+    HelperSpec {
+        program: "omarchy-system-lock",
+        args: &[],
     }
 }
 
@@ -805,13 +812,15 @@ fn lock_screen() {
     press_key(chord.modifiers, chord.key);
 }
 
-/// Hyprland lock: logind, then `omarchy-system-lock`, then Super+Ctrl+L.
-/// Never Super+L — that chord toggles workspace layout on Omarchy.
+/// Hyprland lock: `omarchy-system-lock`, then Super+Ctrl+L.
+///
+/// Do not call logind `LockSession` here. A successful D-Bus reply only
+/// signals the session; Hyprland does not listen, so treating OK as locked
+/// skips the Omarchy helper and leaves the screen unlocked. Never Super+L —
+/// that chord toggles workspace layout on Omarchy.
 fn lock_screen_hyprland() {
-    if try_logind_lock() {
-        return;
-    }
-    if run_fixed_argv("omarchy-system-lock", &[]) {
+    let helper = hyprland_lock_helper();
+    if run_fixed_argv(helper.program, helper.args) {
         return;
     }
     tracing::debug!("LockScreen via Super+Ctrl+L (Hyprland / Omarchy)");
@@ -903,8 +912,9 @@ mod tests {
 
     use super::{
         HELPER_PREFIXES, combo, generic_linux_lock_fallback_chord, hid_usage_to_linux,
-        hyprland_helper, hyprland_lock_fallback_chord, hyprland_session_from_signature, key_ev,
-        key_phase_events, modifiers_to_keycodes, resolve_allowlisted_under, syn,
+        hyprland_helper, hyprland_lock_fallback_chord, hyprland_lock_helper,
+        hyprland_session_from_signature, key_ev, key_phase_events, modifiers_to_keycodes,
+        resolve_allowlisted_under, syn,
     };
     use crate::inject::KeyPhase;
 
@@ -1027,6 +1037,14 @@ mod tests {
         assert_eq!(hyprland_helper(NativeAction::ShowDesktop), None);
         assert_eq!(hyprland_helper(NativeAction::LockScreen), None);
         assert_eq!(hyprland_helper(NativeAction::Screenshot), None);
+    }
+
+    #[test]
+    fn hyprland_lock_uses_omarchy_helper_not_logind() {
+        let helper = hyprland_lock_helper();
+        assert_eq!(helper.program, "omarchy-system-lock");
+        assert_eq!(helper.args, [] as [&str; 0]);
+        assert_eq!(HELPER_PREFIXES, ["/usr/bin", "/usr/local/bin"]);
     }
 
     #[test]

--- a/docs/solutions/logic-errors/hyprland-logind-locksession-is-not-a-lock.md
+++ b/docs/solutions/logic-errors/hyprland-logind-locksession-is-not-a-lock.md
@@ -1,0 +1,48 @@
+---
+title: Hyprland logind LockSession success is not a screen lock
+date: 2026-08-29
+category: logic-errors
+module: openlogi-inject
+problem_type: logic_error
+component: tooling
+symptoms:
+  - LockScreen binding logs success via logind but the Hyprland session stays unlocked
+  - omarchy-system-lock never runs after LockSession returns OK
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags: [hyprland, logind, lock-screen, linux-inject, omarchy]
+---
+
+# Hyprland logind LockSession success is not a screen lock
+
+## Problem
+
+On Hyprland/Omarchy, treating a successful logind `LockSession` D-Bus call as "the screen is locked" skips the compositor lock helper. The call can return OK without hyprlock (or `omarchy-system-lock`) ever running.
+
+## Symptoms
+
+- Debug log `LockScreen via logind` with no lock UI
+- Super+L is wrong on Omarchy (workspace layout toggle), so the GNOME/KDE fallback must not run either
+
+## What Didn't Work
+
+- Sharing GNOME/KDE's logind-first path on the Hyprland arm (plan originally required logind first). D-Bus success is not the same as a listener locking the session.
+
+## Solution
+
+Hyprland `LockScreen` calls `omarchy-system-lock`, then Super+Ctrl+L. It does not call `try_logind_lock`. Generic Linux lock still uses logind then Super+L. Pending in #1162.
+
+## Why This Works
+
+`try_logind_lock` returns true on any successful `LockSession` reply (`crates/openlogi-inject/src/inject/linux.rs`). GNOME/KDE listen for that signal; Hyprland typically does not. Early-return therefore looks successful and never reaches the Omarchy helper.
+
+## Prevention
+
+- Do not treat compositor-agnostic D-Bus OK as "the DE did the user-visible action" unless that DE is known to subscribe.
+- Keep a unit test that Hyprland lock's helper is `omarchy-system-lock`, not Super+L.
+
+## Related Issues
+
+- Related: #1042 (same Linux native skip class on GNOME, different DE mapping)
+- PR: #1162


### PR DESCRIPTION
## Summary

A DPI (or other) binding to LaunchpadShow saved and captured, then did nothing: Linux inject treated it as macOS-only and skipped it. On a Hyprland session (`HYPRLAND_INSTANCE_SIGNATURE` set) that press now opens the Omarchy menu. Workspace next/prev run `hyprctl`; lock runs `omarchy-system-lock` (not Super+L, which is layout-toggle on Omarchy). Other Linux desktops keep the old skip / Ctrl+Alt / Super+L table.

A cargo-built agent no longer rewrites the user systemd unit — including under `CARGO_TARGET_DIR`, `--target-dir`, and `--target` triples, not only a literal `target/{debug,release}` path — so a local run cannot steal `ExecStart` from the packaged binary.

Hyprland helpers are reaped off the serial action/button workers. A hung lock helper no longer stalls later remaps or fills those bounded queues.

## Changes

- `openlogi-inject`: Hyprland native table; allowlisted absolute helpers (`/usr/bin`, `/usr/local/bin`); Hyprland lock skips logind because `LockSession` OK does not mean hyprlock ran; helper wait runs on a sidecar thread, with chord fallback still on missing helper, spawn failure, or non-zero exit.
- `openlogi-agent`: Linux `launch_at_login` reconcile is a no-op when the running binary's parent directory is a Cargo `debug` or `release` profile directory.

## Testing

- `cargo test -p openlogi-inject`
- `cargo test -p openlogi-agent cargo_built_agent_paths`
- `cargo clippy -p openlogi-inject -p openlogi-agent --all-targets -- -D warnings`
- Hardware: MX Master 3S on Omarchy/Hyprland; DPI → LaunchpadShow opened the Omarchy menu against a locally built agent. LockScreen was not re-tested on hardware after skipping logind. Helper-wait is unit-tested (`helper_wait_does_not_block_the_caller`); not re-exercised on hardware.

## Related

Related: #1042

Overlaps the GNOME native-dispatch work in #1044 (same `dispatch_native` skip). This branch only takes the Hyprland arm.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Made with [Cursor](https://cursor.com)
