### PR TITLE
fix(macos): release global input hook for inactive sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5537,6 +5537,7 @@ dependencies = [
  "gpui-updater",
  "gpui_platform",
  "image",
+ "libc",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -14,6 +14,7 @@ use openlogi_core::binding::{
     Action, Binding, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
 };
 use openlogi_core::config::{KeyModifiers, KeyTrigger};
+use openlogi_hid::DeviceIoGate;
 use openlogi_hook::{
     EventDevice, EventDisposition, Hook, HookEvent, KeyEvent, MouseEvent, source_is_remappable,
 };
@@ -438,6 +439,7 @@ pub fn start(
     dispatcher: ActionDispatcher,
     scroll: ScrollInputHandle,
     monitor: SharedEventMonitor,
+    device_io: DeviceIoGate,
 ) -> Option<Hook> {
     if !Hook::has_accessibility() {
         warn!(
@@ -452,52 +454,62 @@ pub fn start(
 
     // The per-hold pointer accumulator lives in the thread-local `HOLD`; the
     // callback must never block — see the freeze-hazard note in `macos.rs`.
-    let result = Hook::start(move |event| match event {
-        HookEvent::Mouse(event) => {
-            monitor.record(&event);
-            match event {
-                MouseEvent::Button {
-                    id,
-                    pressed,
-                    device,
-                } => handle_button(id, pressed, device.as_ref(), &hooks, &dispatcher),
-                MouseEvent::Moved { delta_x, delta_y } => {
-                    handle_moved(delta_x, delta_y, &hooks, &dispatcher)
-                }
-                MouseEvent::CaptureInterrupted => {
-                    HOLD.with_borrow_mut(HoldState::cancel);
-                    HELD_KEYS.with_borrow_mut(HashSet::clear);
-                    dispatcher.cancel_hook_thread_buttons();
-                    scroll.cancel_hooks();
-                    EventDisposition::PassThrough
-                }
-                MouseEvent::Scroll {
-                    delta,
-                    from_trackpad,
-                    device,
-                } => {
-                    #[cfg(target_os = "windows")]
-                    if delta.y() == 0.0
-                        && let Some((button, action)) = hooks
-                            .try_read()
-                            .ok()
-                            .and_then(|maps| rebound_thumbwheel_action(&maps, delta.x()))
-                    {
-                        info!(button = %button, action = %action.label(), "native thumb wheel → executing bound action");
-                        return queued_event_disposition(try_queue_action(&action_tx, action));
+    let result = Hook::start(move |event| {
+        // The macOS session observer closes this gate before notifying the
+        // lifecycle task. Fail open here as well, so a tap that is still being
+        // torn down can never suppress or synthesize input for another login
+        // session. The same guard is harmless on platforms with per-device
+        // hooks and keeps the callback policy consistent everywhere.
+        if !device_io.allows_io() {
+            return EventDisposition::PassThrough;
+        }
+        match event {
+            HookEvent::Mouse(event) => {
+                monitor.record(&event);
+                match event {
+                    MouseEvent::Button {
+                        id,
+                        pressed,
+                        device,
+                    } => handle_button(id, pressed, device.as_ref(), &hooks, &dispatcher),
+                    MouseEvent::Moved { delta_x, delta_y } => {
+                        handle_moved(delta_x, delta_y, &hooks, &dispatcher)
                     }
-                    if scroll_source_may_intercept(from_trackpad, device.as_ref()) {
-                        return queued_event_disposition(scroll.try_hook_scroll(delta));
+                    MouseEvent::CaptureInterrupted => {
+                        HOLD.with_borrow_mut(HoldState::cancel);
+                        HELD_KEYS.with_borrow_mut(HashSet::clear);
+                        dispatcher.cancel_hook_thread_buttons();
+                        scroll.cancel_hooks();
+                        EventDisposition::PassThrough
                     }
-                    EventDisposition::PassThrough
+                    MouseEvent::Scroll {
+                        delta,
+                        from_trackpad,
+                        device,
+                    } => {
+                        #[cfg(target_os = "windows")]
+                        if delta.y() == 0.0
+                            && let Some((button, action)) = hooks
+                                .try_read()
+                                .ok()
+                                .and_then(|maps| rebound_thumbwheel_action(&maps, delta.x()))
+                        {
+                            info!(button = %button, action = %action.label(), "native thumb wheel → executing bound action");
+                            return queued_event_disposition(try_queue_action(&action_tx, action));
+                        }
+                        if scroll_source_may_intercept(from_trackpad, device.as_ref()) {
+                            return queued_event_disposition(scroll.try_hook_scroll(delta));
+                        }
+                        EventDisposition::PassThrough
+                    }
                 }
             }
+            // Function-key remapper: ordinary actions remain one-shot, while a
+            // HoldShortcut enters the same down/up/cancel lifecycle as a mouse
+            // button. The active set pairs key-up even if modifier state or config
+            // changes while the key is down.
+            HookEvent::Key(event) => handle_key(event, &keyboard_bindings, &action_tx, &dispatcher),
         }
-        // Function-key remapper: ordinary actions remain one-shot, while a
-        // HoldShortcut enters the same down/up/cancel lifecycle as a mouse
-        // button. The active set pairs key-up even if modifier state or config
-        // changes while the key is down.
-        HookEvent::Key(event) => handle_key(event, &keyboard_bindings, &action_tx, &dispatcher),
     });
 
     match result {

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -21,6 +21,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "macos")]
+use std::sync::{Mutex as StdMutex, PoisonError, TryLockError};
+
 use futures::StreamExt as _;
 use openlogi_agent_core::event_monitor::EventMonitor;
 use openlogi_agent_core::observable::ObservableState;
@@ -30,6 +35,8 @@ use openlogi_agent_core::watchers::foreground_app::ForegroundUpdate;
 use openlogi_agent_core::watchers::inventory::{InventoryEvent, InventoryRefresh};
 use openlogi_core::config::Config;
 use openlogi_hook::Hook;
+#[cfg(target_os = "macos")]
+use openlogi_hook::HookStopHandle;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{debug, info, warn};
@@ -75,12 +82,74 @@ impl DeviceIoTransition {
     }
 }
 
+/// Non-blocking bridge from the AppKit session callback to the hook owner.
+///
+/// The callback cannot wait for the lifecycle task to receive its watch
+/// notification: that task may be inside native hook setup or an async lock.
+/// A pending bit covers the interval before a newly-created hook registers its
+/// handle; once registered, the request wakes the tap thread directly.
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+pub(crate) struct HookStopRequest {
+    current: StdMutex<Option<HookStopHandle>>,
+    pending: AtomicBool,
+}
+
+#[cfg(target_os = "macos")]
+impl HookStopRequest {
+    fn prepare_install(&self) {
+        self.pending.store(false, Ordering::Release);
+    }
+
+    fn install(&self, handle: &HookStopHandle) {
+        let mut current = self.current.lock().unwrap_or_else(PoisonError::into_inner);
+        *current = Some(handle.clone());
+        if self.pending.swap(false, Ordering::AcqRel) {
+            handle.request_stop();
+        }
+        drop(current);
+
+        // A callback that lost the try_lock race while the slot was being
+        // installed leaves `pending` set. Consume that edge after unlocking;
+        // callbacks arriving later can see and call the installed handle.
+        if self.pending.swap(false, Ordering::AcqRel) {
+            handle.request_stop();
+        }
+    }
+
+    fn clear(&self) {
+        let mut current = self.current.lock().unwrap_or_else(PoisonError::into_inner);
+        *current = None;
+    }
+
+    pub(crate) fn request_stop(&self) {
+        self.pending.store(true, Ordering::Release);
+        match self.current.try_lock() {
+            Ok(current) => self.request_locked(current.as_ref()),
+            Err(TryLockError::Poisoned(error)) => {
+                let current = error.into_inner();
+                self.request_locked(current.as_ref());
+            }
+            Err(TryLockError::WouldBlock) => {}
+        }
+    }
+
+    fn request_locked(&self, current: Option<&HookStopHandle>) {
+        if let Some(handle) = current
+            && self.pending.swap(false, Ordering::AcqRel)
+        {
+            handle.request_stop();
+        }
+    }
+}
+
 /// Walk the whole lifecycle: bootstrap, gate, arm, run. This is the async
 /// core's entry point; `main` only decides which thread it runs on.
 pub(crate) async fn run(
     config: Config,
     uninstalled: UnboundedReceiver<()>,
     #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
+    #[cfg(target_os = "macos")] hook_stop: Arc<HookStopRequest>,
     device_io_gate: openlogi_hid::DeviceIoGate,
 ) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
@@ -92,6 +161,8 @@ pub(crate) async fn run(
         uninstalled,
         #[cfg(target_os = "macos")]
         armed_tx,
+        #[cfg(target_os = "macos")]
+        hook_stop,
         device_io_gate,
     )
     .await
@@ -122,6 +193,8 @@ struct Booted {
     /// Releases the main thread's tray loop once the agent arms.
     #[cfg(target_os = "macos")]
     armed_tx: std::sync::mpsc::Sender<()>,
+    #[cfg(target_os = "macos")]
+    hook_stop: Arc<HookStopRequest>,
     device_io_gate: openlogi_hid::DeviceIoGate,
 }
 
@@ -130,6 +203,7 @@ impl Booted {
         config: Config,
         uninstalled: UnboundedReceiver<()>,
         #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
+        #[cfg(target_os = "macos")] hook_stop: Arc<HookStopRequest>,
         device_io_gate: openlogi_hid::DeviceIoGate,
     ) -> Option<Self> {
         // Read before `config` moves into the orchestrator.
@@ -146,6 +220,8 @@ impl Booted {
             launch_at_login,
             #[cfg(target_os = "macos")]
             armed_tx,
+            #[cfg(target_os = "macos")]
+            hook_stop,
             device_io_gate,
         })
     }
@@ -216,6 +292,8 @@ impl Wanted {
             capture_mouse_events,
             #[cfg(target_os = "macos")]
             armed_tx,
+            #[cfg(target_os = "macos")]
+            hook_stop,
             device_io_gate,
             ..
         } = self.0;
@@ -251,6 +329,8 @@ impl Wanted {
                 hook: None,
                 capture_mouse_events,
                 accessibility_granted,
+                #[cfg(target_os = "macos")]
+                hook_stop,
                 device_io_gate,
             },
         }
@@ -279,6 +359,8 @@ struct Running {
     hook: Option<Hook>,
     capture_mouse_events: bool,
     accessibility_granted: bool,
+    #[cfg(target_os = "macos")]
+    hook_stop: Arc<HookStopRequest>,
     device_io_gate: openlogi_hid::DeviceIoGate,
 }
 
@@ -533,6 +615,8 @@ impl Running {
             self.stop_hook();
         }
         if should_install && self.hook.is_none() {
+            #[cfg(target_os = "macos")]
+            self.hook_stop.prepare_install();
             self.hook = self.start_hook();
         }
         // The session callback can publish a suspend while the synchronous
@@ -562,17 +646,26 @@ impl Running {
             self.inputs.dispatcher.clone(),
             self.inputs.scroll_input.clone(),
             Arc::clone(&self.event_monitor),
+            self.shared.device_io.clone(),
         )
+        .inspect(|hook| {
+            #[cfg(target_os = "macos")]
+            self.hook_stop.install(&hook.stop_handle());
+        })
     }
 
     /// Stop the hook so no new edge can race the lifecycle cancellation.
     fn stop_hook(&mut self) {
+        #[cfg(target_os = "macos")]
+        self.hook_stop.clear();
         self.hook = None;
         self.inputs.dispatcher.cancel_hook_buttons();
         self.inputs.scroll_input.cancel_hooks();
     }
 
     fn shut_down(&mut self, reason: &str) -> ! {
+        #[cfg(target_os = "macos")]
+        self.hook_stop.clear();
         shutdown::release_hook_and_exit(self.hook.take(), &mut self.inputs, reason)
     }
 }

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -515,6 +515,13 @@ impl Running {
     /// observation can claim the hook is installed without the permission it
     /// requires.
     async fn apply_accessibility(&mut self, granted: bool) {
+        // Acquire the publication lock before changing the native hook. The
+        // final device-I/O check below must be followed only by synchronous
+        // publication; otherwise a suspend can arrive while this future is
+        // waiting for the lock and leave a newly installed tap armed.
+        let orchestrator = Arc::clone(&self.orchestrator);
+        let mut orchestrator = orchestrator.lock().await;
+
         self.accessibility_granted = granted;
         let should_install = hook_should_be_installed(
             self.capture_mouse_events,
@@ -534,10 +541,7 @@ impl Running {
         if should_install && !self.device_io_gate.allows_io() {
             self.stop_hook();
         }
-        self.orchestrator
-            .lock()
-            .await
-            .set_os_mouse_hook_available(self.hook.is_some());
+        orchestrator.set_os_mouse_hook_available(self.hook.is_some());
         self.observable
             .set_accessibility_and_hook(granted, self.hook.is_some());
     }

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -19,7 +19,6 @@
 //! and Linux only ever start wanted, so their gate passes unconditionally.
 
 use std::sync::Arc;
-#[cfg(target_os = "macos")]
 use std::time::Duration;
 
 use futures::StreamExt as _;
@@ -49,6 +48,11 @@ use crate::{autostart, overlay, server};
 /// process that has opened no device and prompted for nothing.
 #[cfg(target_os = "macos")]
 const DORMANT_DEADLINE: Duration = Duration::from_secs(60);
+
+/// A failed event-tap install is normally transient (for example while the
+/// session's Accessibility service is settling). Keep trying while the hook
+/// is still wanted instead of waiting for another permission edge.
+const HOOK_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Walk the whole lifecycle: bootstrap, gate, arm, run. This is the async
 /// core's entry point; `main` only decides which thread it runs on.
@@ -208,6 +212,8 @@ impl Wanted {
             ring_haptics,
             demand,
         } = core;
+        let accessibility_granted =
+            observable.read(|snapshot| snapshot.status.accessibility_granted);
         // Closing the channel turns post-arming declarations into no-ops in
         // the server's `declare_client` handler.
         drop(demand);
@@ -223,6 +229,7 @@ impl Wanted {
                 uninstalled,
                 hook: None,
                 capture_mouse_events,
+                accessibility_granted,
                 device_io_gate,
             },
         }
@@ -250,6 +257,7 @@ struct Running {
     /// revoke or session inactivation (dropping the handle stops its thread).
     hook: Option<Hook>,
     capture_mouse_events: bool,
+    accessibility_granted: bool,
     device_io_gate: openlogi_hid::DeviceIoGate,
 }
 
@@ -261,6 +269,8 @@ impl Armed {
         #[cfg(target_os = "macos")]
         request_input_monitoring().await;
         let mut device_io_gate = running.device_io_gate.clone();
+        let mut hook_retry = tokio::time::interval(HOOK_RETRY_INTERVAL);
+        hook_retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         // HID++ watchers need no Accessibility — start them up front.
         startup::spawn_hidpp_watchers(&running.shared, &running.inputs);
@@ -276,7 +286,7 @@ impl Armed {
                     #[cfg(target_os = "macos")]
                     {
                         match device_io {
-                            Some(allowed) => running.apply_device_io(allowed).await,
+                            Some(_) => running.apply_device_io().await,
                             None => running.shut_down("device I/O lifecycle ended"),
                         }
                     }
@@ -284,6 +294,9 @@ impl Armed {
                     if device_io.is_none() {
                         break;
                     }
+                }
+                _ = hook_retry.tick(), if running.should_retry_hook() => {
+                    running.apply_accessibility(Hook::has_accessibility()).await;
                 }
                 Some(device_key) = running.inputs.triggers.recv() => {
                     running.begin_action_ring(device_key.as_deref()).await;
@@ -366,9 +379,9 @@ impl Running {
     /// in an inactive user's agent lets that agent suppress the active user's
     /// physical wheel and post the replacement into the wrong session.
     #[cfg(target_os = "macos")]
-    async fn apply_device_io(&mut self, allowed: bool) {
-        if allowed {
-            self.apply_accessibility(Hook::has_accessibility()).await;
+    async fn apply_device_io(&mut self) {
+        if self.device_io_gate.allows_io() {
+            self.apply_accessibility(self.accessibility_granted).await;
             return;
         }
 
@@ -378,8 +391,30 @@ impl Running {
             .await
             .set_os_mouse_hook_available(false);
         self.observable
-            .set_accessibility_and_hook(Hook::has_accessibility(), false);
+            .set_accessibility_and_hook(self.accessibility_granted, false);
         info!("inactive session — OS input hook released");
+    }
+
+    /// Whether a missing macOS hook still has all prerequisites and should be
+    /// retried. The Accessibility watcher reports only stable permission
+    /// changes, so a transient install failure needs this independent retry
+    /// path to recover without another session or permission transition.
+    fn should_retry_hook(&self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            hook_should_retry(
+                hook_should_be_installed(
+                    self.capture_mouse_events,
+                    self.accessibility_granted,
+                    self.device_io_gate.allows_io(),
+                ),
+                self.hook.as_ref().is_some_and(Hook::is_running),
+            )
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
+        }
     }
 
     /// Fold one inventory-watcher event into the orchestrator.
@@ -443,16 +478,24 @@ impl Running {
     /// observation can claim the hook is installed without the permission it
     /// requires.
     async fn apply_accessibility(&mut self, granted: bool) {
+        self.accessibility_granted = granted;
         let should_install = hook_should_be_installed(
             self.capture_mouse_events,
             granted,
             self.device_io_gate.allows_io(),
         );
-        if !should_install {
+        let hook_stopped = self.hook.as_ref().is_some_and(|hook| !hook.is_running());
+        if !should_install || hook_stopped {
             self.stop_hook();
         }
         if should_install && self.hook.is_none() {
             self.hook = self.start_hook();
+        }
+        // The session callback can publish a suspend while the synchronous
+        // native install is in progress. Never leave a newly created global
+        // tap behind once the gate has closed.
+        if should_install && !self.device_io_gate.allows_io() {
+            self.stop_hook();
         }
         self.orchestrator
             .lock()
@@ -504,6 +547,12 @@ const fn hook_should_be_installed(
     capture_mouse_events && accessibility_granted && device_io_allowed
 }
 
+/// A failed install is retryable only while the hook is still wanted and no
+/// live handle exists.
+const fn hook_should_retry(hook_wanted: bool, hook_running: bool) -> bool {
+    hook_wanted && !hook_running
+}
+
 /// Prompt for Accessibility when the enabled mouse hook needs it.
 fn prompt_missing_accessibility(capture_mouse_events: bool) {
     // With the hook disabled the agent needs no Accessibility at all, so the
@@ -543,7 +592,7 @@ async fn request_input_monitoring() {
 
 #[cfg(test)]
 mod tests {
-    use super::hook_should_be_installed;
+    use super::{hook_should_be_installed, hook_should_retry};
 
     #[test]
     fn hook_requires_capture_permission_and_active_session() {
@@ -551,5 +600,12 @@ mod tests {
         assert!(!hook_should_be_installed(false, true, true));
         assert!(!hook_should_be_installed(true, false, true));
         assert!(!hook_should_be_installed(true, true, false));
+    }
+
+    #[test]
+    fn failed_hook_install_is_retryable_while_prerequisites_hold() {
+        assert!(hook_should_retry(true, false));
+        assert!(!hook_should_retry(true, true));
+        assert!(!hook_should_retry(false, false));
     }
 }

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -56,6 +56,7 @@ pub(crate) async fn run(
     config: Config,
     uninstalled: UnboundedReceiver<()>,
     #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
+    device_io_gate: openlogi_hid::DeviceIoGate,
 ) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
     // LaunchAgent, before `config` moves into the orchestrator.
@@ -66,6 +67,7 @@ pub(crate) async fn run(
         uninstalled,
         #[cfg(target_os = "macos")]
         armed_tx,
+        device_io_gate,
     )
     .await
     else {
@@ -95,6 +97,7 @@ struct Booted {
     /// Releases the main thread's tray loop once the agent arms.
     #[cfg(target_os = "macos")]
     armed_tx: std::sync::mpsc::Sender<()>,
+    device_io_gate: openlogi_hid::DeviceIoGate,
 }
 
 impl Booted {
@@ -102,6 +105,7 @@ impl Booted {
         config: Config,
         uninstalled: UnboundedReceiver<()>,
         #[cfg(target_os = "macos")] armed_tx: std::sync::mpsc::Sender<()>,
+        device_io_gate: openlogi_hid::DeviceIoGate,
     ) -> Option<Self> {
         // Read before `config` moves into the orchestrator.
         let capture_mouse_events = config.app_settings.capture_mouse_events;
@@ -117,6 +121,7 @@ impl Booted {
             launch_at_login,
             #[cfg(target_os = "macos")]
             armed_tx,
+            device_io_gate,
         })
     }
 
@@ -186,6 +191,7 @@ impl Wanted {
             capture_mouse_events,
             #[cfg(target_os = "macos")]
             armed_tx,
+            device_io_gate,
             ..
         } = self.0;
         #[cfg(target_os = "macos")]
@@ -217,6 +223,7 @@ impl Wanted {
                 uninstalled,
                 hook: None,
                 capture_mouse_events,
+                device_io_gate,
             },
         }
     }
@@ -240,9 +247,10 @@ struct Running {
     signals: ShutdownSignals,
     uninstalled: UnboundedReceiver<()>,
     /// The OS hook, installed once Accessibility is granted and dropped on
-    /// revoke (dropping the handle stops its thread).
+    /// revoke or session inactivation (dropping the handle stops its thread).
     hook: Option<Hook>,
     capture_mouse_events: bool,
+    device_io_gate: openlogi_hid::DeviceIoGate,
 }
 
 impl Armed {
@@ -252,6 +260,7 @@ impl Armed {
         let Self { mut running } = self;
         #[cfg(target_os = "macos")]
         request_input_monitoring().await;
+        let mut device_io_gate = running.device_io_gate.clone();
 
         // HID++ watchers need no Accessibility — start them up front.
         startup::spawn_hidpp_watchers(&running.shared, &running.inputs);
@@ -262,6 +271,19 @@ impl Armed {
             tokio::select! {
                 Some(event) = watchers.next() => {
                     running.apply_watcher(event, &inventory_refresh).await;
+                }
+                device_io = device_io_gate.changed() => {
+                    #[cfg(target_os = "macos")]
+                    {
+                        match device_io {
+                            Some(allowed) => running.apply_device_io(allowed).await,
+                            None => running.shut_down("device I/O lifecycle ended"),
+                        }
+                    }
+                    #[cfg(not(target_os = "macos"))]
+                    if device_io.is_none() {
+                        break;
+                    }
                 }
                 Some(device_key) = running.inputs.triggers.recv() => {
                     running.begin_action_ring(device_key.as_deref()).await;
@@ -338,6 +360,28 @@ impl Running {
         }
     }
 
+    /// Keep the global macOS event tap owned only by the active login session.
+    /// The HID gate already protects device I/O during sleep/session changes,
+    /// but an event tap is a separate machine-wide input path: leaving it live
+    /// in an inactive user's agent lets that agent suppress the active user's
+    /// physical wheel and post the replacement into the wrong session.
+    #[cfg(target_os = "macos")]
+    async fn apply_device_io(&mut self, allowed: bool) {
+        if allowed {
+            self.apply_accessibility(Hook::has_accessibility()).await;
+            return;
+        }
+
+        self.stop_hook();
+        self.orchestrator
+            .lock()
+            .await
+            .set_os_mouse_hook_available(false);
+        self.observable
+            .set_accessibility_and_hook(Hook::has_accessibility(), false);
+        info!("inactive session — OS input hook released");
+    }
+
     /// Fold one inventory-watcher event into the orchestrator.
     async fn apply_inventory(&self, event: InventoryEvent, refresh: &InventoryRefresh) {
         match event {
@@ -399,10 +443,15 @@ impl Running {
     /// observation can claim the hook is installed without the permission it
     /// requires.
     async fn apply_accessibility(&mut self, granted: bool) {
-        if !granted {
+        let should_install = hook_should_be_installed(
+            self.capture_mouse_events,
+            granted,
+            self.device_io_gate.allows_io(),
+        );
+        if !should_install {
             self.stop_hook();
         }
-        if granted && self.hook.is_none() {
+        if should_install && self.hook.is_none() {
             self.hook = self.start_hook();
         }
         self.orchestrator
@@ -444,6 +493,17 @@ impl Running {
     }
 }
 
+/// The event tap is a global input filter on macOS. It must be active only
+/// when the agent is configured to capture input, has Accessibility, and its
+/// login session is currently allowed to use host I/O.
+const fn hook_should_be_installed(
+    capture_mouse_events: bool,
+    accessibility_granted: bool,
+    device_io_allowed: bool,
+) -> bool {
+    capture_mouse_events && accessibility_granted && device_io_allowed
+}
+
 /// Prompt for Accessibility when the enabled mouse hook needs it.
 fn prompt_missing_accessibility(capture_mouse_events: bool) {
     // With the hook disabled the agent needs no Accessibility at all, so the
@@ -478,5 +538,18 @@ async fn request_input_monitoring() {
                 warn!(error = %e, "Input Monitoring permission request task failed");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hook_should_be_installed;
+
+    #[test]
+    fn hook_requires_capture_permission_and_active_session() {
+        assert!(hook_should_be_installed(true, true, true));
+        assert!(!hook_should_be_installed(false, true, true));
+        assert!(!hook_should_be_installed(true, false, true));
+        assert!(!hook_should_be_installed(true, true, false));
     }
 }

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -54,6 +54,27 @@ const DORMANT_DEADLINE: Duration = Duration::from_secs(60);
 /// is still wanted instead of waiting for another permission edge.
 const HOOK_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
+/// An ordered device-I/O edge consumed by the lifecycle loop.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeviceIoTransition {
+    /// The login session became inactive; release its global event tap.
+    Suspended,
+    /// The login session became active; reconcile the event tap prerequisites.
+    Resumed,
+}
+
+#[cfg(target_os = "macos")]
+impl DeviceIoTransition {
+    const fn from_allowed(allowed: bool) -> Self {
+        if allowed {
+            Self::Resumed
+        } else {
+            Self::Suspended
+        }
+    }
+}
+
 /// Walk the whole lifecycle: bootstrap, gate, arm, run. This is the async
 /// core's entry point; `main` only decides which thread it runs on.
 pub(crate) async fn run(
@@ -286,7 +307,9 @@ impl Armed {
                     #[cfg(target_os = "macos")]
                     {
                         match device_io {
-                            Some(_) => running.apply_device_io().await,
+                            Some(allowed) => running
+                                .apply_device_io(DeviceIoTransition::from_allowed(allowed))
+                                .await,
                             None => running.shut_down("device I/O lifecycle ended"),
                         }
                     }
@@ -379,20 +402,22 @@ impl Running {
     /// in an inactive user's agent lets that agent suppress the active user's
     /// physical wheel and post the replacement into the wrong session.
     #[cfg(target_os = "macos")]
-    async fn apply_device_io(&mut self) {
-        if self.device_io_gate.allows_io() {
-            self.apply_accessibility(self.accessibility_granted).await;
-            return;
+    async fn apply_device_io(&mut self, transition: DeviceIoTransition) {
+        match transition {
+            DeviceIoTransition::Resumed => {
+                self.apply_accessibility(self.accessibility_granted).await;
+            }
+            DeviceIoTransition::Suspended => {
+                self.stop_hook();
+                self.orchestrator
+                    .lock()
+                    .await
+                    .set_os_mouse_hook_available(false);
+                self.observable
+                    .set_accessibility_and_hook(self.accessibility_granted, false);
+                info!("inactive session — OS input hook released");
+            }
         }
-
-        self.stop_hook();
-        self.orchestrator
-            .lock()
-            .await
-            .set_os_mouse_hook_available(false);
-        self.observable
-            .set_accessibility_and_hook(self.accessibility_granted, false);
-        info!("inactive session — OS input hook released");
     }
 
     /// Whether a missing macOS hook still has all prerequisites and should be
@@ -607,5 +632,32 @@ mod tests {
         assert!(hook_should_retry(true, false));
         assert!(!hook_should_retry(true, true));
         assert!(!hook_should_retry(false, false));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn fast_session_transitions_replay_suspend_before_resume() {
+        use super::DeviceIoTransition::{Resumed, Suspended};
+
+        let (signal, mut gate) = openlogi_hid::device_io_channel();
+        assert!(signal.suspend());
+        assert!(signal.resume());
+
+        assert_eq!(
+            super::DeviceIoTransition::from_allowed(
+                gate.changed()
+                    .await
+                    .expect("the suspended edge should be replayed"),
+            ),
+            Suspended
+        );
+        assert_eq!(
+            super::DeviceIoTransition::from_allowed(
+                gate.changed()
+                    .await
+                    .expect("the resumed edge should follow the suspension"),
+            ),
+            Resumed
+        );
     }
 }

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -319,7 +319,7 @@ impl Armed {
                     }
                 }
                 _ = hook_retry.tick(), if running.should_retry_hook() => {
-                    running.apply_accessibility(Hook::has_accessibility()).await;
+                    running.retry_hook().await;
                 }
                 Some(device_key) = running.inputs.triggers.recv() => {
                     running.begin_action_ring(device_key.as_deref()).await;
@@ -439,6 +439,18 @@ impl Running {
         #[cfg(not(target_os = "macos"))]
         {
             false
+        }
+    }
+
+    /// Retry a missing hook using the last stable Accessibility observation.
+    /// A fresh native probe can transiently return `false` while the permission
+    /// service settles; feeding that sample into `apply_accessibility` would
+    /// poison the cached state and disable this retry path.
+    async fn retry_hook(&mut self) {
+        #[cfg(target_os = "macos")]
+        {
+            let accessibility_granted = self.accessibility_granted;
+            self.apply_accessibility(accessibility_granted).await;
         }
     }
 

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -105,6 +105,7 @@ fn main() {
     // hook) runs on the tokio runtime on a dedicated thread, and the main thread
     // runs AppKit. Elsewhere there is no tray, so just block on the core.
     let device_io_signal = openlogi_hid::host::device_io_signal();
+    let device_io_gate = openlogi_hid::host::device_io_gate();
     #[cfg(target_os = "macos")]
     {
         // Fail closed before the core thread can enumerate or open HID devices.
@@ -125,7 +126,12 @@ fn main() {
         if let Err(e) = std::thread::Builder::new()
             .name("openlogi-agent-core".into())
             .spawn(move || {
-                runtime.block_on(lifecycle::run(config, uninstalled, armed_tx));
+                runtime.block_on(lifecycle::run(
+                    config,
+                    uninstalled,
+                    armed_tx,
+                    device_io_gate,
+                ));
             })
         {
             warn!(error = %e, "could not spawn the agent core thread; exiting");
@@ -151,7 +157,7 @@ fn main() {
         resume_linux::register(device_io_signal.clone());
         #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         drop(device_io_signal);
-        runtime.block_on(lifecycle::run(config, uninstalled));
+        runtime.block_on(lifecycle::run(config, uninstalled, device_io_gate));
     }
 }
 

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -117,6 +117,8 @@ fn main() {
         // thread; the main thread hosts the tray.
         let show_in_menu_bar = config.app_settings.show_in_menu_bar;
         let app_icon = config.app_settings.app_icon;
+        let hook_stop = std::sync::Arc::new(lifecycle::HookStopRequest::default());
+        let core_hook_stop = std::sync::Arc::clone(&hook_stop);
         // The tray waits for the core to declare the agent *armed*: a dormant
         // agent (launch_at_login off, started at login, no client yet) must
         // not put an icon in the menu bar only to vanish seconds later. A
@@ -130,6 +132,7 @@ fn main() {
                     config,
                     uninstalled,
                     armed_tx,
+                    core_hook_stop,
                     device_io_gate,
                 ));
             })
@@ -138,7 +141,7 @@ fn main() {
             return;
         }
         if armed_rx.recv().is_ok() {
-            tray::run_app_loop(show_in_menu_bar, app_icon, device_io_signal);
+            tray::run_app_loop(show_in_menu_bar, app_icon, device_io_signal, hook_stop);
         }
     }
     #[cfg(not(target_os = "macos"))]

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -19,7 +19,7 @@
 )]
 
 use std::cell::RefCell;
-use std::sync::{Mutex, PoisonError};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use dispatch2::DispatchQueue;
 use objc2::rc::Retained;
@@ -43,6 +43,7 @@ use openlogi_core::config::AppIcon;
 use openlogi_hid::DeviceIoSignal;
 use tracing::{info, warn};
 
+use crate::lifecycle::HookStopRequest;
 use crate::status_item;
 
 /// The installed menu-bar item plus the action target its menu items weakly
@@ -112,6 +113,7 @@ pub fn relocalize() {
 
 struct ActivityTargetIvars {
     signal: DeviceIoSignal,
+    hook_stop: Arc<HookStopRequest>,
     suspended_by: Mutex<u8>,
 }
 
@@ -157,13 +159,16 @@ define_class!(
 );
 
 impl ActivityTarget {
-    fn new(signal: DeviceIoSignal) -> Retained<Self> {
+    fn new(signal: DeviceIoSignal, hook_stop: Arc<HookStopRequest>) -> Retained<Self> {
         // `main` closes the gate before spawning the core thread; repeat the
         // idempotent close here so the target's STARTUP source is self-contained
         // in tests and any future caller cannot accidentally start open.
-        let _ = signal.suspend();
+        if signal.suspend() {
+            hook_stop.request_stop();
+        }
         let this = Self::alloc().set_ivars(ActivityTargetIvars {
             signal,
+            hook_stop,
             suspended_by: Mutex::new(STARTUP),
         });
         // SAFETY: `init` initializes our freshly allocated NSObject subclass.
@@ -189,6 +194,7 @@ impl ActivityTarget {
             was_allowed && self.ivars().signal.suspend()
         };
         if changed {
+            self.ivars().hook_stop.request_stop();
             info!("display/session suspended — pausing device I/O");
         }
     }
@@ -322,6 +328,7 @@ pub fn run_app_loop(
     show_in_menu_bar: bool,
     app_icon: AppIcon,
     device_io_signal: DeviceIoSignal,
+    hook_stop: Arc<HookStopRequest>,
 ) -> ! {
     let Some(mtm) = MainThreadMarker::new() else {
         warn!("agent AppKit loop not started off the main thread — exiting");
@@ -334,7 +341,7 @@ pub fn run_app_loop(
     let app = NSApplication::sharedApplication(mtm);
     app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
 
-    let activity_target = install_activity_observer(device_io_signal);
+    let activity_target = install_activity_observer(device_io_signal, hook_stop);
     // Bind the status item (+ its target/menu) so they outlive `run()` — the
     // menu items only weakly reference the target. `None` when hidden.
     let _tray = show_in_menu_bar.then(|| install_status_item(mtm, app_icon));
@@ -360,8 +367,11 @@ pub fn run_app_loop(
 /// `NSWorkspaceDidWakeNotification` is deliberately not registered: macOS
 /// emits it for maintenance DarkWake, where opening BLE HID is exactly what can
 /// promote an otherwise invisible wake into a full display wake (#656).
-fn install_activity_observer(signal: DeviceIoSignal) -> Retained<ActivityTarget> {
-    let target = ActivityTarget::new(signal);
+fn install_activity_observer(
+    signal: DeviceIoSignal,
+    hook_stop: Arc<HookStopRequest>,
+) -> Retained<ActivityTarget> {
+    let target = ActivityTarget::new(signal, hook_stop);
     let workspace = NSWorkspace::sharedWorkspace();
     let center = workspace.notificationCenter();
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
@@ -505,7 +515,7 @@ mod tests {
     #[test]
     fn overlapping_suspend_sources_all_clear_before_device_io_resumes() {
         let (signal, gate) = device_io_channel();
-        let target = install_activity_observer(signal);
+        let target = install_activity_observer(signal, Arc::new(HookStopRequest::default()));
         target.finish_startup(false);
         let workspace = NSWorkspace::sharedWorkspace();
         let center = workspace.notificationCenter();
@@ -559,7 +569,7 @@ mod tests {
     #[test]
     fn startup_stays_suspended_when_the_display_is_already_asleep() {
         let (signal, gate) = device_io_channel();
-        let target = install_activity_observer(signal);
+        let target = install_activity_observer(signal, Arc::new(HookStopRequest::default()));
         assert!(!gate.allows_io(), "startup must fail closed");
 
         target.finish_startup(true);

--- a/crates/openlogi-desktop/Cargo.toml
+++ b/crates/openlogi-desktop/Cargo.toml
@@ -69,6 +69,7 @@ objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSApplication", "NSAppearance"] }
 objc2-foundation = { workspace = true, features = ["NSProcessInfo", "NSString", "NSError"] }
 objc2-service-management = { workspace = true, features = ["std", "SMAppService", "SMErrors", "objc2", "objc2-foundation"] }
+libc = "0.2"
 
 [lints]
 workspace = true

--- a/crates/openlogi-desktop/src/runtime.rs
+++ b/crates/openlogi-desktop/src/runtime.rs
@@ -262,7 +262,7 @@ impl Runtime {
                     // the fail-closed "agent is not running" screen even
                     // though the agent connects moments later.
                     let should_reload = cx.update(|cx| {
-                        AppState::try_read(cx).is_some_and(|state| state.should_reload_agent())
+                        AppState::try_read(cx).is_some_and(AppState::should_reload_agent)
                     });
                     if should_reload {
                         cx.update(|cx| {

--- a/crates/openlogi-desktop/src/runtime.rs
+++ b/crates/openlogi-desktop/src/runtime.rs
@@ -251,8 +251,27 @@ impl Runtime {
     fn on_agent_update(&mut self, update: ipc::GuiUpdate, cx: &AsyncApp) {
         match update {
             ipc::GuiUpdate::Snapshot(snapshot) => {
+                let first_snapshot = self.snapshot.is_none();
                 self.apply_snapshot(&snapshot, cx);
                 self.snapshot = Some(snapshot);
+                if first_snapshot {
+                    // `AppState::with_runtime` runs before the IPC client has
+                    // necessarily completed its handshake. Defer the initial
+                    // reload until this snapshot proves that the link is live;
+                    // otherwise a cold-start race can leave the GUI stuck on
+                    // the fail-closed "agent is not running" screen even
+                    // though the agent connects moments later.
+                    let should_reload = cx.update(|cx| {
+                        AppState::try_read(cx).is_some_and(|state| state.should_reload_agent())
+                    });
+                    if should_reload {
+                        cx.update(|cx| {
+                            AppState::update(cx, |state, _| {
+                                state.reload_agent_config();
+                            });
+                        });
+                    }
+                }
             }
             ipc::GuiUpdate::Unreachable => {
                 cx.update(|cx| set_agent_link(state::AgentLink::Unreachable, cx));

--- a/crates/openlogi-desktop/src/services/ipc/launch.rs
+++ b/crates/openlogi-desktop/src/services/ipc/launch.rs
@@ -123,9 +123,7 @@ fn kickstart_registered_agent() -> bool {
     if registration::status() != registration::ServiceStatus::Enabled {
         return false;
     }
-    let Some(uid) = current_uid() else {
-        return false;
-    };
+    let uid = current_uid();
     let target = format!("gui/{uid}/{}", registration::agent_service_label());
     match std::process::Command::new("/bin/launchctl")
         .arg("kickstart")
@@ -152,15 +150,19 @@ fn kickstart_registered_agent() -> bool {
     }
 }
 
-/// The current user's uid, read from the home directory's owner: `launchctl`
-/// addresses the per-user launchd domain as `gui/<uid>`, and std exposes no
-/// direct getuid.
+/// The current process's real uid: `launchctl` addresses the per-user launchd
+/// domain as `gui/<uid>`. Do not infer it from `$HOME` or the home directory's
+/// owner — a stale environment in a second user session can otherwise target
+/// another user's bootstrap domain.
 #[cfg(target_os = "macos")]
-fn current_uid() -> Option<u32> {
-    use std::os::unix::fs::MetadataExt as _;
-
-    let home = openlogi_core::paths::home_dir().ok()?;
-    std::fs::metadata(home).ok().map(|meta| meta.uid())
+#[expect(
+    unsafe_code,
+    reason = "libc provides the process uid without a safe std wrapper"
+)]
+fn current_uid() -> u32 {
+    // SAFETY: `getuid` takes no arguments, dereferences no pointers, and
+    // returns the real uid of this process.
+    unsafe { libc::getuid() }
 }
 
 /// The `.app` root of a packaged helper binary, `None` for a bare dev binary.

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -276,17 +276,12 @@ impl AppState {
         };
         // Plain `persist_config`, not `persist_and_reload` as
         // `refresh_inventories` uses for the same fold: there is no agent
-        // connection to reload yet this early in startup, and the
-        // unconditional `ReloadConfig` send at the end of this constructor
-        // (below) already covers both branches once `state` is fully built —
-        // sending it here too would just queue a second, redundant reload.
+        // connection to reload yet this early in startup. The first snapshot
+        // will request one reload after the IPC handshake is complete.
         if adopted {
             state.persist_config("adopt device route");
         } else if identities_changed {
             state.persist_config("device identity");
-        }
-        if state.config.should_reload_agent() {
-            state.send_ipc(crate::services::ipc::Command::ReloadConfig);
         }
         state
     }
@@ -298,6 +293,13 @@ impl AppState {
             return false;
         }
         true
+    }
+    /// Ask the agent to adopt the config after the GUI has a live IPC link.
+    pub(crate) fn reload_agent_config(&self) {
+        self.send_ipc(crate::services::ipc::Command::ReloadConfig);
+    }
+    pub(crate) fn should_reload_agent(&self) -> bool {
+        self.config.should_reload_agent()
     }
     /// Persist the in-memory config and — only if the write actually landed —
     /// have the agent reload it. `what` names the setting for the failure log.

--- a/crates/openlogi-device/src/device_io.rs
+++ b/crates/openlogi-device/src/device_io.rs
@@ -13,22 +13,47 @@ pub struct DeviceIoSignal {
 }
 
 /// Cheaply cloneable read capability for device-I/O producers.
-#[derive(Clone)]
 pub struct DeviceIoGate {
     receiver: watch::Receiver<DeviceIoState>,
+    /// The state represented by the last transition returned to this reader.
+    ///
+    /// `watch` retains only the latest value. The generation lets a reader
+    /// replay each alternating edge when multiple transitions arrive before it
+    /// gets polled, so a suspend edge cannot disappear behind a resume edge.
+    observed: DeviceIoState,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DeviceIoState {
-    Allowed,
-    Suspended,
+struct DeviceIoState {
+    allowed: bool,
+    generation: u64,
 }
 
 /// Create an initially-open device-I/O gate.
 #[must_use]
 pub fn device_io_channel() -> (DeviceIoSignal, DeviceIoGate) {
-    let (sender, receiver) = watch::channel(DeviceIoState::Allowed);
-    (DeviceIoSignal { sender }, DeviceIoGate { receiver })
+    let initial = DeviceIoState {
+        allowed: true,
+        generation: 0,
+    };
+    let (sender, receiver) = watch::channel(initial);
+    (
+        DeviceIoSignal { sender },
+        DeviceIoGate {
+            receiver,
+            observed: initial,
+        },
+    )
+}
+
+impl Clone for DeviceIoGate {
+    fn clone(&self) -> Self {
+        let receiver = self.receiver.clone();
+        // A new consumer subscribes to the current policy, not to the source
+        // reader's already-delivered history.
+        let observed = *receiver.borrow();
+        Self { receiver, observed }
+    }
 }
 
 impl DeviceIoSignal {
@@ -38,10 +63,11 @@ impl DeviceIoSignal {
     #[must_use]
     pub fn suspend(&self) -> bool {
         self.sender.send_if_modified(|state| {
-            if *state == DeviceIoState::Suspended {
+            if !state.allowed {
                 return false;
             }
-            *state = DeviceIoState::Suspended;
+            state.allowed = false;
+            state.generation = state.generation.wrapping_add(1);
             true
         })
     }
@@ -52,10 +78,11 @@ impl DeviceIoSignal {
     #[must_use]
     pub fn resume(&self) -> bool {
         self.sender.send_if_modified(|state| {
-            if *state == DeviceIoState::Allowed {
+            if state.allowed {
                 return false;
             }
-            *state = DeviceIoState::Allowed;
+            state.allowed = true;
+            state.generation = state.generation.wrapping_add(1);
             true
         })
     }
@@ -65,26 +92,48 @@ impl DeviceIoGate {
     /// Whether opening a node or sending a request is currently allowed.
     #[must_use]
     pub fn allows_io(&self) -> bool {
-        *self.receiver.borrow() == DeviceIoState::Allowed
+        self.receiver.borrow().allowed
     }
 
-    /// Wait for the next distinct gate transition.
+    /// Wait for the next distinct gate transition, in order.
     ///
-    /// Returns the new allow-state, or `None` if the lifecycle producer was
-    /// dropped.
+    /// The underlying watch channel retains only the latest state. A reader
+    /// that falls behind therefore replays the alternating transitions from
+    /// its local generation cursor before waiting for a new publication. This
+    /// preserves a suspend edge even when a resume follows it immediately.
+    /// Returns `None` if the lifecycle producer was dropped after all observed
+    /// transitions have been delivered.
     pub async fn changed(&mut self) -> Option<bool> {
-        self.receiver.changed().await.ok()?;
-        Some(self.allows_io())
+        loop {
+            let latest = *self.receiver.borrow();
+            if latest.generation != self.observed.generation {
+                let allowed = !self.observed.allowed;
+                self.observed = DeviceIoState {
+                    allowed,
+                    generation: self.observed.generation.wrapping_add(1),
+                };
+                return Some(allowed);
+            }
+            self.receiver.changed().await.ok()?;
+        }
+    }
+
+    /// Mark the currently published state as observed, discarding any older
+    /// transitions that a caller has already reconciled from [`Self::allows_io`].
+    pub fn synchronize(&mut self) {
+        self.observed = *self.receiver.borrow_and_update();
     }
 
     /// Wait until the gate is open. Returns `false` if its producer disappears
-    /// while it is closed.
+    /// while it is closed. On success, stale transitions are folded into the
+    /// current open state so the next [`Self::changed`] waits for a new edge.
     pub async fn wait_until_allowed(&mut self) -> bool {
         while !self.allows_io() {
             if self.changed().await.is_none() {
                 return false;
             }
         }
+        self.synchronize();
         true
     }
 }
@@ -96,22 +145,47 @@ mod tests {
     use super::device_io_channel;
 
     #[tokio::test]
-    async fn latest_transition_is_retained_and_duplicates_coalesce() {
+    async fn transitions_are_replayed_and_duplicates_coalesce() {
         let (signal, mut gate) = device_io_channel();
         assert!(gate.allows_io());
 
         assert!(signal.suspend());
         assert!(!signal.suspend());
-        gate.changed()
-            .await
-            .expect("the suspend transition should remain available");
-        assert!(!gate.allows_io());
+        assert!(signal.resume());
+        assert!(!signal.resume());
+
+        assert_eq!(gate.changed().await, Some(false));
+        assert_eq!(gate.changed().await, Some(true));
         tokio::time::timeout(Duration::from_millis(10), gate.changed())
             .await
-            .expect_err("duplicate suspend publications must coalesce");
+            .expect_err("duplicate state publications must coalesce");
+        assert!(gate.allows_io());
+    }
+
+    #[tokio::test]
+    async fn wait_until_allowed_folds_a_fast_resume_into_current_state() {
+        let (signal, mut gate) = device_io_channel();
+        assert!(signal.suspend());
+        assert!(signal.resume());
+
+        assert!(gate.wait_until_allowed().await);
+        tokio::time::timeout(Duration::from_millis(10), gate.changed())
+            .await
+            .expect_err("wait_until_allowed should consume stale transitions");
+    }
+
+    #[tokio::test]
+    async fn cloned_gate_starts_at_the_current_state() {
+        let (signal, gate) = device_io_channel();
+        assert!(signal.suspend());
+
+        let mut clone = gate.clone();
+        assert!(!clone.allows_io());
+        tokio::time::timeout(Duration::from_millis(10), clone.changed())
+            .await
+            .expect_err("a new gate should not replay pre-subscription history");
 
         assert!(signal.resume());
-        assert!(gate.wait_until_allowed().await);
-        assert!(gate.allows_io());
+        assert_eq!(clone.changed().await, Some(true));
     }
 }

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -341,6 +341,16 @@ trait HookBackend {
     /// Stop the hook and join its threads.
     fn stop(running: Self::Running);
 
+    /// Build a non-blocking stop request for the hook's owner.
+    ///
+    /// The default is a no-op for backends whose host lifecycle has no need to
+    /// interrupt the worker from another thread. macOS overrides this so its
+    /// session observer can release a global tap before the async lifecycle
+    /// task gets to join it.
+    fn stop_handle(_running: &Self::Running) -> HookStopHandle {
+        HookStopHandle::noop()
+    }
+
     /// Whether the platform worker is still delivering events. Backends whose
     /// workers are joined only during teardown have no separate terminal
     /// state, so their live handle is sufficient by default.
@@ -415,6 +425,34 @@ pub struct Hook {
     inner: Option<<Backend as HookBackend>::Running>,
 }
 
+/// A cloneable, non-blocking request to stop a running hook.
+///
+/// This is intentionally separate from [`Hook::stop`]: a host notification
+/// callback may request release from another thread, but must not wait for the
+/// hook worker to join. The owner still drops the [`Hook`] afterwards so the
+/// full teardown remains synchronous and observable there.
+#[derive(Clone)]
+pub struct HookStopHandle {
+    request: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl HookStopHandle {
+    /// Request that the hook worker detach as soon as its backend permits.
+    pub fn request_stop(&self) {
+        (self.request)();
+    }
+
+    pub(crate) fn new(request: impl Fn() + Send + Sync + 'static) -> Self {
+        Self {
+            request: Arc::new(request),
+        }
+    }
+
+    fn noop() -> Self {
+        Self::new(|| {})
+    }
+}
+
 impl Drop for Hook {
     fn drop(&mut self) {
         self.shutdown();
@@ -438,6 +476,15 @@ impl Hook {
         cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
     ) -> Result<Self, HookError> {
         Backend::start(cb).map(|inner| Self { inner: Some(inner) })
+    }
+
+    /// Return a non-blocking request that can interrupt this hook from another
+    /// thread. The request is a no-op once the hook has already been stopped.
+    #[must_use]
+    pub fn stop_handle(&self) -> HookStopHandle {
+        self.inner
+            .as_ref()
+            .map_or_else(HookStopHandle::noop, Backend::stop_handle)
     }
 
     /// Stop the hook and release OS resources.

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -662,6 +662,10 @@ impl HookBackend for Backend {
         }
     }
 
+    fn is_running(inner: &HookInner) -> bool {
+        inner.signals.phase() == TapPhase::Armed
+    }
+
     /// Check whether this process can still install the hook's event tap.
     ///
     /// `AXIsProcessTrusted()` alone is not that answer: it keeps returning `true`

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -40,8 +40,8 @@ use tracing::{debug, error, warn};
 
 use crate::{
     ButtonId, CursorPosition, EventDevice, EventDisposition, EventTapInfo, ForegroundApp,
-    HookBackend, HookError, HookEvent, KeyEvent, KeyModifiers, MouseEvent, ScrollDelta,
-    TapLocation,
+    HookBackend, HookError, HookEvent, HookStopHandle, KeyEvent, KeyModifiers, MouseEvent,
+    ScrollDelta, TapLocation,
 };
 use watchdog::{
     CallbackActivity, LifecycleDecision, LifecycleExitReason, LifecycleObservation,
@@ -66,6 +66,31 @@ pub(crate) struct HookInner {
 // documentation states that CFRunLoop objects can be passed between
 // threads; only CFRunLoopRun must be called on the owning thread.
 unsafe impl Send for HookInner {}
+
+/// The pieces needed to wake and stop the tap thread without joining it.
+///
+/// Core Foundation documents `CFRunLoopStop` as safe to call from another
+/// thread. `HookInner` already carries the same run loop across the lifecycle
+/// boundary for the synchronous stop path, so this small shared wrapper uses
+/// the identical thread-safety guarantee for the non-blocking stop handle.
+struct HookStopInner {
+    run_loop: CFRunLoop,
+    signals: Arc<WatchdogSignals>,
+}
+
+// SAFETY: `CFRunLoopStop` is the only operation exposed through this wrapper;
+// Core Foundation permits it from a thread other than the run loop owner.
+unsafe impl Send for HookStopInner {}
+// SAFETY: the shared wrapper only calls the thread-safe `CFRunLoopStop` and
+// atomic watchdog operations; it never accesses run-loop-owned sources.
+unsafe impl Sync for HookStopInner {}
+
+impl HookStopInner {
+    fn request_stop(&self) {
+        self.signals.request_stop();
+        self.run_loop.stop();
+    }
+}
 
 /// Owner of an `NSWorkspace` activation observer.
 ///
@@ -660,6 +685,14 @@ impl HookBackend for Backend {
         if let Err(e) = inner.lifecycle_watchdog.join() {
             error!("hook lifecycle watchdog panicked on shutdown: {e:?}");
         }
+    }
+
+    fn stop_handle(inner: &HookInner) -> HookStopHandle {
+        let stop = Arc::new(HookStopInner {
+            run_loop: inner.run_loop.clone(),
+            signals: Arc::clone(&inner.signals),
+        });
+        HookStopHandle::new(move || stop.request_stop())
     }
 
     fn is_running(inner: &HookInner) -> bool {

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -21,7 +21,9 @@ use identity::{Channel, Component};
 
 // The rest of the macOS domain reaches these through `bundle::`, which is the
 // module that owns them conceptually even now that the code sits deeper.
-pub(super) use embed::{HELPERS, Helper, agent_service_label, write_agent_launch_plist};
+pub(super) use embed::{
+    HELPERS, Helper, agent_service_label, verify_bundle, write_agent_launch_plist,
+};
 pub(super) use signing::quoted_identity;
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -116,7 +118,7 @@ fn run_with_channel(
     embed::embed_helpers(&root, &release_dir, &app, channel)?;
     embed::write_agent_launch_plist(&app, channel)?;
     embed::embed_cli(&release_dir, &app)?;
-    embed::verify_bundle_binaries(&app, channel)?;
+    embed::verify_bundle(&app, channel)?;
     info_plist::stamp_privacy_usage_descriptions(&app)?;
     // Identity first, then the checks, then signing — a signature seals the
     // `Info.plist` files, so nothing may rewrite them afterwards.

--- a/xtask/src/commands/macos/bundle/embed.rs
+++ b/xtask/src/commands/macos/bundle/embed.rs
@@ -4,7 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Context as _, Result, anyhow, bail};
 use openlogi_core::brand;
 use xshell::{Shell, cmd};
 
@@ -242,6 +242,33 @@ pub(super) fn verify_bundle_binaries(app: &Path, channel: Channel) -> Result<()>
     for path in required_bundle_binaries(app, channel) {
         ensure_file(&path)
             .with_context(|| format!("missing required bundle binary {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Verify the launchable contents of a finished bundle before it is signed.
+///
+/// The helper binaries can all be present while the service plist is missing —
+/// a bundle that looks complete in Finder but cannot be registered by
+/// `SMAppService`. Keep this check next to the writer so the production and
+/// dev assembly paths share the same invariant.
+pub(crate) fn verify_bundle(app: &Path, channel: Channel) -> Result<()> {
+    verify_bundle_binaries(app, channel)?;
+
+    let path = app
+        .join("Contents/Library/LaunchAgents")
+        .join(format!("{}.plist", agent_service_label(channel)));
+    ensure_file(&path)
+        .with_context(|| format!("missing required agent launch plist {}", path.display()))?;
+
+    let found = plist::Value::from_file(&path)
+        .with_context(|| format!("could not read agent launch plist {}", path.display()))?;
+    let expected = plist::Value::Dictionary(agent_launch_plist(channel)?);
+    if found != expected {
+        bail!(
+            "agent launch plist {} does not match the {channel} bundle layout",
+            path.display()
+        );
     }
     Ok(())
 }

--- a/xtask/src/commands/macos/bundle/embed/tests.rs
+++ b/xtask/src/commands/macos/bundle/embed/tests.rs
@@ -38,6 +38,57 @@ fn verify_bundle_binaries_accepts_a_complete_bundle() {
     }
 }
 
+#[test]
+fn final_bundle_verification_rejects_a_missing_agent_launch_plist() {
+    let channel = Channel::Production;
+    let app = tempfile::tempdir().unwrap();
+    touch_all(&required_bundle_binaries(app.path(), channel));
+
+    let error = verify_bundle(app.path(), channel).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("missing required agent launch plist"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn final_bundle_verification_accepts_a_matching_agent_launch_plist() {
+    for channel in [Channel::Production, Channel::Dev] {
+        let app = tempfile::tempdir().unwrap();
+        touch_all(&required_bundle_binaries(app.path(), channel));
+        write_agent_launch_plist(app.path(), channel).unwrap();
+
+        verify_bundle(app.path(), channel).unwrap();
+    }
+}
+
+#[test]
+fn final_bundle_verification_rejects_a_plist_for_the_wrong_channel() {
+    let channel = Channel::Production;
+    let app = tempfile::tempdir().unwrap();
+    touch_all(&required_bundle_binaries(app.path(), channel));
+    let path = app
+        .path()
+        .join("Contents/Library/LaunchAgents")
+        .join(format!("{}.plist", agent_service_label(channel)));
+    fs_err::create_dir_all(path.parent().unwrap()).unwrap();
+    plist::Value::Dictionary(agent_launch_plist(Channel::Dev).unwrap())
+        .to_file_xml(&path)
+        .unwrap();
+
+    let error = verify_bundle(app.path(), channel).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("does not match the production bundle layout"),
+        "unexpected error: {error}"
+    );
+}
+
 /// The checked-in helper plists are what a fresh bundle starts from, so a
 /// rename there that never reached the identity table would ship one name in
 /// the bundle and another in every verification.

--- a/xtask/src/commands/macos/dev_bundle.rs
+++ b/xtask/src/commands/macos/dev_bundle.rs
@@ -26,7 +26,7 @@ use strum::VariantArray as _;
 use xshell::{Shell, cmd};
 
 use super::bundle::identity::{self, Channel, Component};
-use super::bundle::{HELPERS, Helper, write_agent_launch_plist};
+use super::bundle::{HELPERS, Helper, verify_bundle, write_agent_launch_plist};
 use crate::icon::IconPipeline as _;
 use crate::icon::macos::AppBundle;
 use crate::support::fs::{ensure_file, repo_root};
@@ -93,6 +93,7 @@ pub(crate) fn run(args: &Args) -> Result<()> {
             embed_helper(&root, &app, &profile, helper, &icon, &signing)?;
         }
         write_agent_launch_plist(&app, CHANNEL)?;
+        verify_bundle(&app, CHANNEL)?;
         Component::VARIANTS
     } else {
         println!("==> helpers: skipped (OPENLOGI_DEV_AGENT=0)");


### PR DESCRIPTION
## Summary

When two macOS users are logged in, each OpenLogi Agent can install a global CGEventTap. The inactive user’s tap can continue suppressing the active user’s physical scroll events and inject replacements into the wrong session.

This change ties the macOS OS input hook lifecycle to the existing device-I/O session gate. The hook is released when the login session becomes inactive and reinstalled after the session resumes, while preserving the existing capture and Accessibility checks.

## Validation

- cargo fmt --all -- --check
- cargo test -p openlogi-agent --all-targets -- --test-threads=1 (26 unit tests plus mock-agent target)
- cargo test -p openlogi-agent-core --all-targets -- --test-threads=1 (218 tests)
- cargo build -p openlogi-agent --release --bin openlogi-agent
- Reproduced and verified with two logged-in macOS users; both Agents restart from the installed session-aware build.

Fixes #1121