### PR TITLE
fix(macos): refresh Input Monitoring after permission changes

### DIFF
--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -141,7 +141,7 @@ every grant on that machine is being ignored.
   answers, so it must not run on the async runtime. It is also not real-time:
   after a grant or revoke the calling process keeps seeing the old answer until
   it restarts. That is why the agent calls
-  `binary_watch::relaunch_after_input_monitoring_grant()`.
+  `binary_watch::relaunch_after_input_monitoring_change()`.
 - `IOHIDDeviceOpen` — **denial is silent**. There is no TCC-specific error, so
   the transport pairs every open failure with
   `openlogi_hid::permissions::has_access()` and says which case it is (§1).

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -797,6 +797,10 @@ impl Agent for MockAgent {
         Ok(())
     }
 
+    async fn request_input_monitoring(self, _: Context) {
+        info!("request_input_monitoring (no-op in the mock)");
+    }
+
     // The mock has no Actions Ring hardware: long-polls idle until the
     // overlay's request deadline (returning immediately would hot-loop it),
     // and interaction commands answer like an expired session.

--- a/crates/openlogi-agent/src/binary_watch.rs
+++ b/crates/openlogi-agent/src/binary_watch.rs
@@ -35,7 +35,7 @@ use tracing::{info, warn};
 mod relaunch;
 
 #[cfg(target_os = "macos")]
-pub use relaunch::relaunch_after_input_monitoring_grant;
+pub use relaunch::relaunch_after_input_monitoring_change;
 
 /// How often to stat the executable: one `metadata` call per tick — noise next
 /// to the 2 s HID enumerate — while keeping the update-to-restart window short.

--- a/crates/openlogi-agent/src/binary_watch/relaunch.rs
+++ b/crates/openlogi-agent/src/binary_watch/relaunch.rs
@@ -64,24 +64,24 @@ pub(super) fn restart(path: &Path) {
     }
 }
 
-/// Relaunch the macOS agent after Input Monitoring is granted.
+/// Relaunch the macOS agent after an Input Monitoring decision may have changed.
 ///
-/// macOS does not apply a new Input Monitoring grant to the running process.
+/// macOS does not apply a changed Input Monitoring decision to the running process.
 /// The successor starts only after this process exits and releases its
 /// singleton lock and IPC socket. If the relaunch cannot be scheduled, the
 /// current process stays alive so the user can restart it manually.
 #[cfg(target_os = "macos")]
-pub fn relaunch_after_input_monitoring_grant() {
+pub fn relaunch_after_input_monitoring_change() {
     let path = match std::env::current_exe() {
         Ok(path) => path,
         Err(e) => {
-            warn!(error = %e, "could not resolve own executable after Input Monitoring was granted — restart the agent manually");
+            warn!(error = %e, "could not resolve own executable after Input Monitoring changed — restart the agent manually");
             return;
         }
     };
-    info!("Input Monitoring granted — relaunching the macOS agent");
+    info!("Input Monitoring may have changed — relaunching the macOS agent");
     if let Err(e) = schedule_macos_relaunch_and_exit(&path) {
-        warn!(error = %e, "could not schedule agent relaunch after Input Monitoring was granted — restart the agent manually");
+        warn!(error = %e, "could not schedule agent relaunch after Input Monitoring changed — restart the agent manually");
     }
 }
 

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -459,24 +459,39 @@ fn prompt_missing_accessibility(capture_mouse_events: bool) {
 /// binary the user authorizes. A newly granted permission requires a process
 /// relaunch before macOS lets the agent open HID devices.
 #[cfg(target_os = "macos")]
-async fn request_input_monitoring() {
+pub(crate) async fn request_input_monitoring() {
     // Without this, macOS never registers a decision at all:
     // `IOHIDDeviceOpen` is silently denied, the permission never appears in
     // System Settings for the user to grant, and no HID++ device is ever
     // discovered. Wait for the blocking consent dialog before starting the
     // inventory so it cannot cache the pre-grant access state.
-    if !openlogi_hid::permissions::has_access() {
-        let access_after_prompt = tokio::task::spawn_blocking(|| {
-            openlogi_hid::permissions::request_access();
-            openlogi_hid::permissions::has_access()
-        })
-        .await;
-        match access_after_prompt {
-            Ok(true) => binary_watch::relaunch_after_input_monitoring_grant(),
-            Ok(false) => {}
-            Err(e) => {
-                warn!(error = %e, "Input Monitoring permission request task failed");
-            }
+    if !openlogi_hid::permissions::has_access()
+        && matches!(request_input_monitoring_access().await, Some(true))
+    {
+        binary_watch::relaunch_after_input_monitoring_change();
+    }
+}
+
+/// Refresh Input Monitoring after the user returns from System Settings.
+///
+/// Unlike startup, this deliberately requests unconditionally: the running
+/// process can retain either the old granted or denied answer after a manual
+/// checkbox change, and only a successor can observe the authoritative state.
+#[cfg(target_os = "macos")]
+pub(crate) async fn refresh_input_monitoring() {
+    if request_input_monitoring_access().await.is_some() {
+        binary_watch::relaunch_after_input_monitoring_change();
+    }
+}
+
+#[cfg(target_os = "macos")]
+async fn request_input_monitoring_access() -> Option<bool> {
+    let requested = tokio::task::spawn_blocking(openlogi_hid::permissions::request_access).await;
+    match requested {
+        Ok(granted) => Some(granted),
+        Err(e) => {
+            warn!(error = %e, "Input Monitoring permission request task failed");
+            None
         }
     }
 }

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -213,6 +213,11 @@ impl Agent for AgentServer {
         Hook::prompt_accessibility();
     }
 
+    async fn request_input_monitoring(self, _: Context) {
+        #[cfg(target_os = "macos")]
+        let _request = tokio::spawn(crate::lifecycle::refresh_input_monitoring());
+    }
+
     async fn start_pairing(
         self,
         _: Context,

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -118,6 +118,9 @@ pub enum Command {
     /// CGEventTap, so the system dialog must name (and authorize) the *agent*
     /// binary, not the GUI — prompting locally would grant the wrong process.
     RequestAccessibilityPrompt,
+    /// Ask the agent to request Input Monitoring and relaunch itself if macOS
+    /// grants access. The agent, not the GUI, owns every HID device open.
+    RequestInputMonitoring,
     /// Pairing (agent-owned, since it opens the receiver): begin a session,
     /// pair a discovered device by address, or cancel. Events stream back via
     /// the separate [`IpcClient::pairing`] long-poll, not these commands.
@@ -578,6 +581,9 @@ async fn handle(
             .request_accessibility_prompt(ctx)
             .await
             .map_err(|_| ())?,
+        Command::RequestInputMonitoring => {
+            client.request_input_monitoring(ctx).await.map_err(|_| ())?
+        }
         Command::StartPairing(selector) => {
             pairing_command_result(update_tx, client.start_pairing(ctx, selector).await)?;
         }

--- a/crates/openlogi-desktop/src/state/agent.rs
+++ b/crates/openlogi-desktop/src/state/agent.rs
@@ -65,6 +65,11 @@ impl AppState {
     pub fn request_accessibility_prompt(&self) {
         self.send_ipc(crate::services::ipc::Command::RequestAccessibilityPrompt);
     }
+    /// Ask the agent to request Input Monitoring and relaunch after a grant.
+    /// The agent owns HID access, so the GUI must not request this for itself.
+    pub fn request_input_monitoring(&self) {
+        self.send_ipc(crate::services::ipc::Command::RequestInputMonitoring);
+    }
     /// The agent connection state the render path branches on.
     #[must_use]
     pub fn agent_link(&self) -> &AgentLink {

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -108,6 +108,9 @@ pub struct SettingsView {
     appearance_obs: Option<Subscription>,
     /// Refreshes host-owned snapshots when Settings becomes active again.
     _activation_obs: Subscription,
+    /// Consume one Input Monitoring recheck after returning from System Settings.
+    #[cfg(target_os = "macos")]
+    input_monitoring_return_pending: bool,
     _state_obs: Subscription,
     /// Which themes the Appearance grid shows (All / Light / Dark).
     theme_filter: ThemeFilter,
@@ -256,6 +259,8 @@ impl SettingsView {
             appearance_obs: None,
             _activation_obs: activation_obs,
             _state_obs: state_obs,
+            #[cfg(target_os = "macos")]
+            input_monitoring_return_pending: false,
             theme_filter: ThemeFilter::All,
             theme_search,
             initial_page,
@@ -286,6 +291,12 @@ impl SettingsView {
         cx.observe_window_activation(window, |this, window, cx| {
             if window.is_window_active() {
                 this.refresh_registration_status(cx);
+                #[cfg(target_os = "macos")]
+                if std::mem::take(&mut this.input_monitoring_return_pending)
+                    && let Some(state) = AppState::try_global(cx)
+                {
+                    state.read(cx).request_input_monitoring();
+                }
             }
         })
     }
@@ -500,7 +511,9 @@ impl Render for SettingsView {
             .page(updates::updates_page(self.updater.clone()));
         // Registered only where grants exist to manage — see the `mod
         // permissions` cfg for why Windows skips it.
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        #[cfg(target_os = "macos")]
+        let settings = settings.page(permissions::permissions_page(has_camera, view.clone()));
+        #[cfg(target_os = "linux")]
         let settings = settings.page(permissions::permissions_page(has_camera));
         let settings = settings
             .page(appearance::appearance_page(

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -1,7 +1,7 @@
 //! Permissions settings page (macOS / Linux).
 
 #[cfg(target_os = "macos")]
-use super::{App, AppState, InteractiveElement, Permission};
+use super::{App, AppState, Entity, InteractiveElement, Permission, SettingsView};
 use super::{IconName, Palette, SettingPage};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use super::{
@@ -21,7 +21,10 @@ use openlogi_permissions as permissions;
         reason = "`has_camera` only gates a macOS/Linux row; elsewhere the page is empty"
     )
 )]
-pub(super) fn permissions_page(has_camera: bool) -> SettingPage {
+pub(super) fn permissions_page(
+    has_camera: bool,
+    #[cfg(target_os = "macos")] view: Entity<SettingsView>,
+) -> SettingPage {
     let page = SettingPage::new(tr!("permissions.permissions"))
         .icon(IconName::Info)
         .resettable(false);
@@ -48,7 +51,7 @@ pub(super) fn permissions_page(has_camera: bool) -> SettingPage {
                     }
                 },
             ))
-            .item(input_monitoring_item())
+            .item(input_monitoring_item(view))
             .item(permission_item(
                 "perm-bluetooth",
                 tr!("permissions.bluetooth"),
@@ -108,7 +111,7 @@ pub(super) fn permissions_page(has_camera: bool) -> SettingPage {
 }
 
 #[cfg(target_os = "macos")]
-fn input_monitoring_item() -> SettingItem {
+fn input_monitoring_item(view: Entity<SettingsView>) -> SettingItem {
     SettingItem::new(
         tr!("permissions.input_monitoring"),
         SettingField::render(move |_, _, cx| {
@@ -131,6 +134,7 @@ fn input_monitoring_item() -> SettingItem {
                 "perm-input-monitoring",
                 badge,
                 Permission::InputMonitoring,
+                Some(view.clone()),
                 cx,
             ));
             let pal = theme::palette(cx);
@@ -159,7 +163,9 @@ fn permission_item(
 ) -> SettingItem {
     SettingItem::new(
         title,
-        SettingField::render(move |_, _, cx| permission_field(id, status(cx), permission, cx)),
+        SettingField::render(move |_, _, cx| {
+            permission_field(id, status(cx), permission, None, cx)
+        }),
     )
     .description(description)
 }
@@ -192,6 +198,7 @@ fn permission_field(
     id: &'static str,
     status: PermissionStatus,
     permission: Permission,
+    settings_view: Option<Entity<SettingsView>>,
     cx: &App,
 ) -> gpui::Div {
     let pal = theme::palette(cx);
@@ -238,6 +245,13 @@ fn permission_field(
                         && let Some(state) = crate::state::AppState::try_global(cx)
                     {
                         state.read(cx).request_accessibility_prompt();
+                    }
+                    if matches!(permission, Permission::InputMonitoring)
+                        && let Some(view) = settings_view.as_ref()
+                    {
+                        view.update(cx, |this, _| {
+                            this.input_monitoring_return_pending = true;
+                        });
                     }
                     // The Camera pane only lists an app after its first
                     // AVFoundation request, so a deep link can't grant it.

--- a/crates/openlogi-hid/src/permissions.rs
+++ b/crates/openlogi-hid/src/permissions.rs
@@ -23,12 +23,12 @@ mod macos {
         )
     }
 
-    pub(super) fn request_access() {
+    pub(super) fn request_access() -> bool {
         // Unlike `AXIsProcessTrustedWithOptions`, `IOHIDRequestAccess` blocks
         // the calling thread until the user answers the consent dialog (or
         // returns immediately if the status is already determined) — callers
         // must run this off the async runtime.
-        let _granted = IOHIDRequestAccess(IOHIDRequestType::ListenEvent);
+        IOHIDRequestAccess(IOHIDRequestType::ListenEvent)
     }
 }
 
@@ -48,10 +48,12 @@ pub fn has_access() -> bool {
 /// under System Settings → Privacy & Security → Input Monitoring.
 ///
 /// Blocks the calling thread until the user responds — run it off the async
-/// runtime (e.g. `tokio::task::spawn_blocking`). No-op off macOS.
-pub fn request_access() {
+/// runtime (e.g. `tokio::task::spawn_blocking`). Returns `true` off macOS,
+/// where there is no privacy gate.
+#[must_use]
+pub fn request_access() -> bool {
     cfg_select! {
-        target_os = "macos" => { macos::request_access(); }
-        _ => {}
+        target_os = "macos" => { macos::request_access() }
+        _ => { true }
     }
 }

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -61,7 +61,8 @@ pub use succession::Identity;
 /// v28: `Action::HoldShortcut` appended for lifecycle-held keyboard output.
 /// v29: `Agent::declare_client` + [`ClientKind`] appended — typed demand for
 ///      the macOS dormancy gate.
-pub const PROTOCOL_VERSION: u32 = 29;
+/// v30: `Agent::request_input_monitoring` appended for agent-owned TCC recovery.
+pub const PROTOCOL_VERSION: u32 = 30;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -560,4 +561,8 @@ pub trait Agent {
     /// arms only on [`ClientKind::Gui`]. The takeover probe never declares —
     /// it speaks only [`Agent::protocol_version`] — and so never arms.
     async fn declare_client(kind: ClientKind);
+    /// Request Input Monitoring from the agent and relaunch it when macOS
+    /// grants access. The agent owns HID device access, so prompting or
+    /// checking from the GUI would inspect the wrong TCC identity.
+    async fn request_input_monitoring();
 }

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -101,7 +101,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 29);
+    assert_eq!(PROTOCOL_VERSION, 30);
 }
 
 #[test]
@@ -206,6 +206,7 @@ fn request_variant_order() {
         },
         "1902",
     );
+    assert_wire(&AgentRequest::RequestInputMonitoring {}, "1a");
 }
 
 /// The agent identity is frozen: a helper from any build has to be able to


### PR DESCRIPTION
I wanted to use the openlogi app, but the macos permission for input was boken. Even tho I gave it input permissions it still showed like it doesn't have it. llm told me that an agent app inside openlogi needed to have the permission. I've vibe fixed the issue in my end, but I don't know if its the right way. Anyway here is my input and what codex had summarised about the issue. 

Summary
Fixes a macOS Input Monitoring issue where OpenLogi continued reporting that permission was missing even after the user granted it in System Settings.


Changes
- Uses the Boolean result returned directly by IOHIDRequestAccess instead of immediately performing a follow-up IOHIDCheckAccess, which can return stale permission state for the current process.
- Relaunches the OpenLogi agent after an Input Monitoring decision changes, allowing the new process to receive the authoritative macOS TCC state.
- Rechecks Input Monitoring after the user returns from System Settings, covering permissions enabled or disabled manually.
- Keeps permission requests inside the agent process because the agent owns HID device access. This prevents macOS from granting permission to the GUI’s separate code-signing identity.
- Adds an agent IPC request for the permission refresh flow, updates the mock agent, bumps the protocol version, and extends the wire-format test.