### PR TITLE
refactor(agent): consolidate capture manager slots

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/capture_session.rs
+++ b/crates/openlogi-agent-core/src/watchers/capture_session.rs
@@ -2,10 +2,12 @@
 //!
 //! Gesture and keyboard capture deliberately keep separate manager loops: their
 //! event ordering, cardinality and dispatch state differ. This module shares
-//! only the invariant they have in common — one tracked hardware epoch stays
-//! authoritative until its asynchronous teardown reports completion.
+//! only the invariants they have in common: one tracked hardware epoch stays
+//! authoritative until its asynchronous teardown reports completion, and a
+//! running epoch is mutually exclusive with post-session recovery.
 
 use tokio::sync::oneshot;
+use tokio::time::Instant;
 
 use crate::runtime::HidppSessionId;
 
@@ -44,6 +46,96 @@ pub(super) struct CaptureSession<Target, Dispatch> {
     target: Target,
     dispatch: Dispatch,
     phase: SessionPhase,
+}
+
+/// Firmware restoration and restart pacing retained after a capture task has
+/// completed. Both may be present after an unexpected completion.
+pub(super) struct CaptureRecovery<Restore> {
+    pub(super) pending_restore: Option<Restore>,
+    pub(super) restart_at: Option<Instant>,
+}
+
+impl<Restore> CaptureRecovery<Restore> {
+    pub(super) fn is_empty(&self) -> bool {
+        self.pending_restore.is_none() && self.restart_at.is_none()
+    }
+}
+
+/// One manager-owned hardware slot. A session remains in `Running` while it
+/// drains; only its matching ordered completion moves the slot to recovery.
+pub(super) enum CaptureSlot<Target, Dispatch, Restore> {
+    Running(CaptureSession<Target, Dispatch>),
+    Recovering(CaptureRecovery<Restore>),
+}
+
+impl<Target, Dispatch, Restore> CaptureSlot<Target, Dispatch, Restore> {
+    pub(super) fn running(session: CaptureSession<Target, Dispatch>) -> Self {
+        Self::Running(session)
+    }
+
+    pub(super) fn recovering(
+        pending_restore: Option<Restore>,
+        restart_at: Option<Instant>,
+    ) -> Self {
+        Self::Recovering(CaptureRecovery {
+            pending_restore,
+            restart_at,
+        })
+    }
+
+    pub(super) fn session(&self) -> Option<&CaptureSession<Target, Dispatch>> {
+        let Self::Running(session) = self else {
+            return None;
+        };
+        Some(session)
+    }
+
+    pub(super) fn session_mut(&mut self) -> Option<&mut CaptureSession<Target, Dispatch>> {
+        let Self::Running(session) = self else {
+            return None;
+        };
+        Some(session)
+    }
+
+    pub(super) fn recovery(&self) -> Option<&CaptureRecovery<Restore>> {
+        let Self::Recovering(recovery) = self else {
+            return None;
+        };
+        Some(recovery)
+    }
+
+    pub(super) fn recovery_mut(&mut self) -> Option<&mut CaptureRecovery<Restore>> {
+        let Self::Recovering(recovery) = self else {
+            return None;
+        };
+        Some(recovery)
+    }
+
+    /// Settle one ordered completion. Stale epochs and reports received after
+    /// the slot has already entered recovery leave the slot untouched.
+    pub(super) fn complete(
+        &mut self,
+        done_session: &HidppSessionId,
+        pending_restore: Option<Restore>,
+        restart_after_unexpected: Option<Instant>,
+    ) -> Option<(HidppSessionId, bool)> {
+        let Self::Running(session) = self else {
+            return None;
+        };
+        let CompletionAction::Remove { unexpected } = session.completion(done_session) else {
+            return None;
+        };
+        let dispatch_session = session.id().clone();
+        *self = Self::recovering(
+            pending_restore,
+            if unexpected {
+                restart_after_unexpected
+            } else {
+                None
+            },
+        );
+        Some((dispatch_session, unexpected))
+    }
 }
 
 impl<Target, Dispatch> CaptureSession<Target, Dispatch> {
@@ -202,5 +294,73 @@ mod tests {
             session.owns(&queued),
             "queued task events remain attributable after a hot config rekey"
         );
+    }
+
+    #[test]
+    fn matching_completion_moves_the_active_slot_to_recovery() {
+        let mut slot = CaptureSlot::<_, _, ()>::running(session());
+        let restart_at = Instant::now();
+
+        let (_, unexpected) = slot
+            .complete(
+                &HidppSessionId::with_epoch("mouse-a", 7),
+                Some(()),
+                Some(restart_at),
+            )
+            .expect("the current epoch should complete");
+
+        assert!(unexpected);
+        assert!(
+            slot.session().is_none(),
+            "recovery cannot retain a running epoch"
+        );
+        let recovery = slot.recovery().expect("the slot should now be recovering");
+        assert!(
+            recovery.pending_restore.is_some(),
+            "firmware restoration remains pending"
+        );
+        assert_eq!(
+            recovery.restart_at,
+            Some(restart_at),
+            "restore and restart pacing may legitimately coexist"
+        );
+    }
+
+    #[test]
+    fn stale_completion_cannot_displace_the_running_epoch_or_recovery() {
+        let mut slot = CaptureSlot::<_, _, &'static str>::running(session());
+
+        assert!(
+            slot.complete(
+                &HidppSessionId::with_epoch("mouse-a", 6),
+                Some("stale"),
+                Some(Instant::now()),
+            )
+            .is_none()
+        );
+        assert_eq!(
+            slot.session().map(CaptureSession::id),
+            Some(&HidppSessionId::with_epoch("mouse-a", 7))
+        );
+
+        assert!(
+            slot.complete(
+                &HidppSessionId::with_epoch("mouse-a", 7),
+                Some("current"),
+                None,
+            )
+            .is_some()
+        );
+        assert!(
+            slot.complete(
+                &HidppSessionId::with_epoch("mouse-a", 7),
+                Some("duplicate"),
+                Some(Instant::now()),
+            )
+            .is_none()
+        );
+        let recovery = slot.recovery().expect("the original recovery must remain");
+        assert_eq!(recovery.pending_restore, Some("current"));
+        assert_eq!(recovery.restart_at, None);
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -38,7 +38,7 @@ use tokio::time::Instant;
 use tracing::{debug, warn};
 
 use self::dispatch::InputDispatcher;
-use super::capture_session::{CaptureSession, CompletionAction, ReconcileAction};
+use super::capture_session::{CaptureRecovery, CaptureSession, CaptureSlot, ReconcileAction};
 use crate::capture_plan::{CaptureTarget, DeviceCapturePlan, DispatchPlan, SharedCapturePlans};
 use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
 use crate::runtime::hook::SharedHookMaps;
@@ -121,6 +121,7 @@ pub fn spawn(
 }
 
 type RunningSession = CaptureSession<CaptureTarget, DispatchPlan>;
+type GestureSlot = CaptureSlot<CaptureTarget, DispatchPlan, PendingRestore>;
 
 struct CapturedEvent {
     physical_key: PhysicalDeviceKey,
@@ -145,9 +146,7 @@ struct PendingRestore {
 }
 
 struct GestureManagerState {
-    sessions: HashMap<PhysicalDeviceKey, RunningSession>,
-    pending_restores: HashMap<PhysicalDeviceKey, PendingRestore>,
-    restart_after: HashMap<PhysicalDeviceKey, Instant>,
+    slots: HashMap<PhysicalDeviceKey, GestureSlot>,
     input_dispatcher: InputDispatcher,
     lease: std::sync::Weak<SessionReceiverLease>,
 }
@@ -283,27 +282,35 @@ fn acquire_session_lease(
 }
 
 async fn retry_pending_restores(
-    pending_restores: &mut HashMap<PhysicalDeviceKey, PendingRestore>,
+    slots: &mut HashMap<PhysicalDeviceKey, GestureSlot>,
     registry: &openlogi_hid::ChannelRegistry,
     now: Instant,
 ) {
-    let keys: Vec<_> = pending_restores
+    let keys: Vec<_> = slots
         .iter()
-        .filter(|(_, pending)| pending.retry_at <= now)
+        .filter(|(_, slot)| {
+            slot.recovery()
+                .and_then(|recovery| recovery.pending_restore.as_ref())
+                .is_some_and(|pending| pending.retry_at <= now)
+        })
         .map(|(key, _)| key.clone())
         .collect();
     for key in keys {
-        let Some(pending) = pending_restores.remove(&key) else {
+        let Some(GestureSlot::Recovering(mut recovery)) = slots.remove(&key) else {
+            continue;
+        };
+        let Some(pending) = recovery.pending_restore.take() else {
+            slots.insert(key, GestureSlot::Recovering(recovery));
             continue;
         };
         if let CaptureSessionOutcome::RestorePending(token) = pending.token.retry(registry).await {
-            pending_restores.insert(
-                key,
-                PendingRestore {
-                    token,
-                    retry_at: Instant::now() + RETRY_DELAY,
-                },
-            );
+            recovery.pending_restore = Some(PendingRestore {
+                token,
+                retry_at: Instant::now() + RETRY_DELAY,
+            });
+        }
+        if !recovery.is_empty() {
+            slots.insert(key, GestureSlot::Recovering(recovery));
         }
     }
 }
@@ -311,48 +318,55 @@ async fn retry_pending_restores(
 fn next_deadline(
     requests: ReceiverRequestState,
     device_io_allowed: bool,
-    pending_restores: &HashMap<PhysicalDeviceKey, PendingRestore>,
-    restart_after: &HashMap<PhysicalDeviceKey, Instant>,
+    slots: &HashMap<PhysicalDeviceKey, GestureSlot>,
 ) -> Option<Instant> {
     if requests.any() || !device_io_allowed {
         return None;
     }
-    pending_restores
+    slots
         .values()
-        .map(|pending| pending.retry_at)
-        .chain(restart_after.values().copied())
+        .filter_map(GestureSlot::recovery)
+        .flat_map(|recovery| {
+            recovery
+                .pending_restore
+                .as_ref()
+                .map(|pending| pending.retry_at)
+                .into_iter()
+                .chain(recovery.restart_at)
+        })
         .min()
-}
-
-fn restart_deadline(unexpected: bool, now: Instant) -> Option<Instant> {
-    unexpected.then_some(now + RETRY_DELAY)
 }
 
 impl GestureManagerState {
     fn new(outputs: GestureOutputs) -> Self {
         Self {
-            sessions: HashMap::new(),
-            pending_restores: HashMap::new(),
-            restart_after: HashMap::new(),
+            slots: HashMap::new(),
             input_dispatcher: InputDispatcher::new(outputs),
             lease: std::sync::Weak::new(),
         }
     }
 
     fn deadline(&self, requests: ReceiverRequestState, device_io_allowed: bool) -> Option<Instant> {
-        next_deadline(
-            requests,
-            device_io_allowed,
-            &self.pending_restores,
-            &self.restart_after,
-        )
+        next_deadline(requests, device_io_allowed, &self.slots)
     }
 
     fn expedite_pending_restores(&mut self) {
         let now = Instant::now();
-        for pending in self.pending_restores.values_mut() {
-            pending.retry_at = now;
+        for slot in self.slots.values_mut() {
+            if let Some(pending) = slot
+                .recovery_mut()
+                .and_then(|recovery| recovery.pending_restore.as_mut())
+            {
+                pending.retry_at = now;
+            }
         }
+    }
+
+    fn has_pending_restores(&self) -> bool {
+        self.slots.values().any(|slot| {
+            slot.recovery()
+                .is_some_and(|recovery| recovery.pending_restore.is_some())
+        })
     }
 
     async fn reconcile(
@@ -376,55 +390,68 @@ impl GestureManagerState {
         } else {
             published.as_slice()
         };
-        for (key, session) in &mut self.sessions {
+        for (key, slot) in &mut self.slots {
+            let Some(session) = slot.session_mut() else {
+                continue;
+            };
             let wanted = wanted
                 .iter()
                 .find(|plan| plan.target.physical_key == *key)
                 .map(|plan| (&plan.target, &plan.dispatch));
             reconcile_session(session, wanted, &mut self.input_dispatcher);
         }
-        self.restart_after.retain(|key, _| {
-            published
+        self.slots.retain(|key, slot| {
+            let Some(recovery) = slot.recovery_mut() else {
+                return true;
+            };
+            if !published
                 .iter()
                 .any(|plan| plan.target.physical_key == *key)
+            {
+                recovery.restart_at = None;
+            }
+            !recovery.is_empty()
         });
 
         // Firmware ownership outlives the desired plan. Keep the strong lease
         // through successor spawning so restore→rearm is uninterrupted.
-        let due_restore = self
-            .pending_restores
-            .values()
-            .any(|pending| pending.retry_at <= now);
+        let due_restore = self.slots.values().any(|slot| {
+            slot.recovery()
+                .and_then(|recovery| recovery.pending_restore.as_ref())
+                .is_some_and(|pending| pending.retry_at <= now)
+        });
         let restore_lease = if due_restore {
             acquire_session_lease(receiver_access, &mut self.lease)
         } else {
             None
         };
         if restore_lease.is_some() {
-            retry_pending_restores(&mut self.pending_restores, &channels.registry, now).await;
+            retry_pending_restores(&mut self.slots, &channels.registry, now).await;
         }
 
         for plan in wanted {
             let key = &plan.target.physical_key;
-            if self.sessions.contains_key(key) || self.pending_restores.contains_key(key) {
+            if self.slots.get(key).is_some_and(|slot| match slot {
+                GestureSlot::Running(_) => true,
+                GestureSlot::Recovering(recovery) => {
+                    recovery.pending_restore.is_some()
+                        || recovery.restart_at.is_some_and(|deadline| deadline > now)
+                }
+            }) {
                 continue;
             }
-            if self
-                .restart_after
-                .get(key)
-                .is_some_and(|deadline| *deadline > now)
-            {
-                continue;
-            }
-            self.restart_after.remove(key);
             let Some(session_lease) = acquire_session_lease(receiver_access, &mut self.lease)
             else {
-                self.restart_after.insert(key.clone(), now + RETRY_DELAY);
+                self.slots.insert(
+                    key.clone(),
+                    GestureSlot::recovering(None, Some(now + RETRY_DELAY)),
+                );
                 continue;
             };
             let id = HidppSessionId::new(&plan.dispatch.config_key);
             let session = spawn_session(id, plan.clone(), session_lease, channels);
-            self.sessions.insert(key.clone(), session);
+            self.slots
+                .insert(key.clone(), GestureSlot::running(session));
         }
     }
 
@@ -438,7 +465,10 @@ impl GestureManagerState {
         match event {
             SessionEvent::Input(event) => {
                 let key = &event.physical_key;
-                if device_io_allowed && let Some(session) = self.sessions.get_mut(key) {
+                if device_io_allowed
+                    && let Some(session) =
+                        self.slots.get_mut(key).and_then(GestureSlot::session_mut)
+                {
                     reconcile_published_session(
                         key,
                         session,
@@ -447,7 +477,7 @@ impl GestureManagerState {
                         &mut self.input_dispatcher,
                     );
                 }
-                let live = self.sessions.get(key);
+                let live = self.slots.get(key).and_then(GestureSlot::session);
                 let dispatch_context = dispatch_context_for(&event.session, live);
                 if let Some((session, plan)) = dispatch_context {
                     self.input_dispatcher.dispatch(session, plan, event.input);
@@ -466,33 +496,31 @@ impl GestureManagerState {
                 // Completion is queued behind every input the listener
                 // accepted during restoration, so cancellation cannot
                 // overtake the last diverted edge.
-                let Some((CompletionAction::Remove { unexpected }, dispatch_session)) = self
-                    .sessions
-                    .get(key)
-                    .map(|session| (session.completion(&done.session), session.id().clone()))
+                let now = Instant::now();
+                let pending_restore = done.pending_restore.map(|token| PendingRestore {
+                    token,
+                    retry_at: now + RETRY_DELAY,
+                });
+                let restart_at = device_io_allowed.then_some(now + RETRY_DELAY);
+                let Some(slot) = self.slots.get_mut(key) else {
+                    return false;
+                };
+                let Some((dispatch_session, unexpected)) =
+                    slot.complete(&done.session, pending_restore, restart_at)
                 else {
                     return false;
                 };
-                if let Some(pending) = done.pending_restore {
-                    self.pending_restores.insert(
-                        key.clone(),
-                        PendingRestore {
-                            token: pending,
-                            retry_at: Instant::now() + RETRY_DELAY,
-                        },
-                    );
-                }
+                let recovery_finished = slot.recovery().is_some_and(CaptureRecovery::is_empty);
                 self.input_dispatcher.cancel_session(&dispatch_session);
-                if device_io_allowed
-                    && let Some(deadline) = restart_deadline(unexpected, Instant::now())
-                {
-                    self.restart_after.insert(key.clone(), deadline);
+                if unexpected && device_io_allowed {
                     warn!(
                         key = key.as_str(),
                         "capture session ended unexpectedly, delaying re-arm"
                     );
                 }
-                self.sessions.remove(key);
+                if recovery_finished {
+                    self.slots.remove(key);
+                }
                 true
             }
         }
@@ -579,7 +607,7 @@ async fn manage(
             },
             open = wait_for_registry_change(
                 &mut registry_changes,
-                !state.pending_restores.is_empty(),
+                state.has_pending_restores(),
             ) => {
                 if !open {
                     return;

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -47,26 +47,30 @@ fn draining_session_with_epoch(epoch: u64) -> RunningSession {
 
 #[tokio::test(start_paused = true)]
 async fn planned_done_allows_an_immediate_successor_but_unexpected_done_is_paced() {
-    let planned = draining_session_with_epoch(7);
-    let CompletionAction::Remove {
-        unexpected: planned_unexpected,
-    } = planned.completion(&session_id(7))
-    else {
-        panic!("the tracked planned completion should remove its session");
-    };
+    let now = Instant::now();
+    let mut planned = GestureSlot::running(draining_session_with_epoch(7));
+    let (_, planned_unexpected) = planned
+        .complete(&session_id(7), None, Some(now + RETRY_DELAY))
+        .expect("the tracked planned completion should settle its session");
     assert!(
-        restart_deadline(planned_unexpected, Instant::now()).is_none(),
+        !planned_unexpected
+            && planned
+                .recovery()
+                .is_some_and(|recovery| recovery.restart_at.is_none()),
         "ordered Done after planned retirement must reconcile its successor immediately"
     );
 
-    let unexpected = live_session_with_epoch(8);
-    let CompletionAction::Remove { unexpected: failed } = unexpected.completion(&session_id(8))
-    else {
-        panic!("the tracked unexpected completion should remove its session");
-    };
-    let retry_at =
-        restart_deadline(failed, Instant::now()).expect("an unexpected completion must be paced");
-    assert_eq!(retry_at, Instant::now() + RETRY_DELAY);
+    let mut unexpected = GestureSlot::running(live_session_with_epoch(8));
+    let (_, failed) = unexpected
+        .complete(&session_id(8), None, Some(now + RETRY_DELAY))
+        .expect("the tracked unexpected completion should settle its session");
+    assert!(failed);
+    assert_eq!(
+        unexpected
+            .recovery()
+            .and_then(|recovery| recovery.restart_at),
+        Some(now + RETRY_DELAY)
+    );
 }
 
 #[tokio::test(start_paused = true)]
@@ -101,24 +105,17 @@ async fn retry_deadline_is_not_postponed_by_ready_input() {
 #[test]
 fn suspended_device_io_disables_retry_deadlines() {
     let retry_at = Instant::now() + RETRY_DELAY;
-    let restart_after = HashMap::from([(physical_key(), retry_at)]);
+    let slots = HashMap::from([(
+        physical_key(),
+        GestureSlot::recovering(None, Some(retry_at)),
+    )]);
 
     assert_eq!(
-        next_deadline(
-            ReceiverRequestState::default(),
-            true,
-            &HashMap::new(),
-            &restart_after,
-        ),
+        next_deadline(ReceiverRequestState::default(), true, &slots),
         Some(retry_at),
     );
     assert_eq!(
-        next_deadline(
-            ReceiverRequestState::default(),
-            false,
-            &HashMap::new(),
-            &restart_after,
-        ),
+        next_deadline(ReceiverRequestState::default(), false, &slots),
         None,
         "capture retries must stay dormant until visible resume",
     );

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -24,7 +24,7 @@ use openlogi_hid::{
 use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, info, warn};
 
-use super::capture_session::{CaptureSession, CompletionAction, ReconcileAction};
+use super::capture_session::{CaptureRecovery, CaptureSession, CaptureSlot, ReconcileAction};
 use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
 use crate::runtime::{ActionDispatcher, HidppSessionId};
 
@@ -71,6 +71,7 @@ struct KeyboardDispatchPlan {
     bindings: BTreeMap<ButtonId, Binding>,
 }
 type RunningKeyboardSession = CaptureSession<KeyboardTarget, KeyboardDispatchPlan>;
+type KeyboardSlot = CaptureSlot<KeyboardTarget, KeyboardDispatchPlan, PendingRestore>;
 
 struct KeyboardInput {
     session: HidppSessionId,
@@ -93,9 +94,7 @@ struct PendingRestore {
 }
 
 struct KeyboardManagerState {
-    current: Option<RunningKeyboardSession>,
-    pending_restore: Option<PendingRestore>,
-    restart_at: Option<tokio::time::Instant>,
+    slot: Option<KeyboardSlot>,
     dispatcher: ActionDispatcher,
 }
 
@@ -220,9 +219,7 @@ fn reconcile_session(
 impl KeyboardManagerState {
     fn new(dispatcher: ActionDispatcher) -> Self {
         Self {
-            current: None,
-            pending_restore: None,
-            restart_at: None,
+            slot: None,
             dispatcher,
         }
     }
@@ -232,20 +229,25 @@ impl KeyboardManagerState {
         requests: ReceiverRequestState,
         device_io_allowed: bool,
     ) -> Option<tokio::time::Instant> {
-        next_deadline(
-            requests,
-            device_io_allowed,
-            self.pending_restore
-                .as_ref()
-                .map(|pending| pending.retry_at),
-            self.restart_at,
-        )
+        next_deadline(requests, device_io_allowed, self.slot.as_ref())
     }
 
     fn expedite_pending_restore(&mut self) {
-        if let Some(pending) = self.pending_restore.as_mut() {
+        if let Some(pending) = self
+            .slot
+            .as_mut()
+            .and_then(KeyboardSlot::recovery_mut)
+            .and_then(|recovery| recovery.pending_restore.as_mut())
+        {
             pending.retry_at = tokio::time::Instant::now();
         }
+    }
+
+    fn has_pending_restore(&self) -> bool {
+        self.slot
+            .as_ref()
+            .and_then(KeyboardSlot::recovery)
+            .is_some_and(|recovery| recovery.pending_restore.is_some())
     }
 
     async fn reconcile(
@@ -264,10 +266,15 @@ impl KeyboardManagerState {
             return;
         }
         let now = tokio::time::Instant::now();
-        if !published {
-            self.restart_at = None;
+        if !published
+            && let Some(recovery) = self.slot.as_mut().and_then(KeyboardSlot::recovery_mut)
+        {
+            recovery.restart_at = None;
+            if recovery.is_empty() {
+                self.slot = None;
+            }
         }
-        if let Some(running) = self.current.as_mut() {
+        if let Some(running) = self.slot.as_mut().and_then(KeyboardSlot::session_mut) {
             reconcile_session(running, wanted.as_ref(), &self.dispatcher);
             return;
         }
@@ -278,25 +285,40 @@ impl KeyboardManagerState {
         // Restoration remains mandatory when the spec disappears. A due
         // retry hands its lease directly to a successor.
         let mut handoff_lease = None;
-        if self
-            .pending_restore
+        let restore_due = self
+            .slot
             .as_ref()
-            .is_some_and(|pending| pending.retry_at <= now)
-            && let Some(lease) = receiver_access.try_acquire_for_session()
-            && let Some(pending) = self.pending_restore.take()
-        {
+            .and_then(KeyboardSlot::recovery)
+            .and_then(|recovery| recovery.pending_restore.as_ref())
+            .is_some_and(|pending| pending.retry_at <= now);
+        if restore_due && let Some(lease) = receiver_access.try_acquire_for_session() {
             handoff_lease = Some(lease);
+            let Some(KeyboardSlot::Recovering(mut recovery)) = self.slot.take() else {
+                return;
+            };
+            let Some(pending) = recovery.pending_restore.take() else {
+                self.slot = Some(KeyboardSlot::Recovering(recovery));
+                return;
+            };
             if let CaptureSessionOutcome::RestorePending(token) =
                 pending.token.retry(&channels.registry).await
             {
-                self.pending_restore = Some(PendingRestore {
+                recovery.pending_restore = Some(PendingRestore {
                     token,
                     retry_at: tokio::time::Instant::now() + RETRY_DELAY,
                 });
             }
+            if !recovery.is_empty() {
+                self.slot = Some(KeyboardSlot::Recovering(recovery));
+            }
         }
-        if self.pending_restore.is_some() || self.restart_at.is_some_and(|deadline| deadline > now)
-        {
+        if self.slot.as_ref().is_some_and(|slot| match slot {
+            KeyboardSlot::Running(_) => true,
+            KeyboardSlot::Recovering(recovery) => {
+                recovery.pending_restore.is_some()
+                    || recovery.restart_at.is_some_and(|deadline| deadline > now)
+            }
+        }) {
             return;
         }
         let Some((target, dispatch)) = wanted else {
@@ -304,10 +326,14 @@ impl KeyboardManagerState {
         };
         let receiver_lease = handoff_lease.or_else(|| receiver_access.try_acquire_for_session());
         if let Some(receiver_lease) = receiver_lease {
-            self.restart_at = None;
-            self.current = Some(spawn_session(target, dispatch, receiver_lease, channels));
+            self.slot = Some(KeyboardSlot::running(spawn_session(
+                target,
+                dispatch,
+                receiver_lease,
+                channels,
+            )));
         } else {
-            self.restart_at = Some(now + RETRY_DELAY);
+            self.slot = Some(KeyboardSlot::recovering(None, Some(now + RETRY_DELAY)));
         }
     }
 
@@ -322,14 +348,15 @@ impl KeyboardManagerState {
             KeyboardSessionEvent::Input(input) => {
                 if device_io_allowed {
                     let wanted = wanted_session(*receiver_requests.borrow(), spec);
-                    if let Some(running) = self.current.as_mut() {
+                    if let Some(running) = self.slot.as_mut().and_then(KeyboardSlot::session_mut) {
                         reconcile_session(running, wanted.as_ref(), &self.dispatcher);
                     }
                 }
 
                 let Some(running) = self
-                    .current
+                    .slot
                     .as_ref()
+                    .and_then(KeyboardSlot::session)
                     .filter(|running| running.owns(&input.session))
                 else {
                     self.dispatcher.cancel_hidpp_session(&input.session);
@@ -352,23 +379,28 @@ impl KeyboardManagerState {
                 // drained before Done is sent. A tracked draining session
                 // therefore remains the sole input owner until firmware
                 // restoration is complete.
-                let Some((CompletionAction::Remove { unexpected }, dispatch_session)) = self
-                    .current
-                    .as_ref()
-                    .map(|running| (running.completion(&done.session), running.id().clone()))
+                let now = tokio::time::Instant::now();
+                let pending_restore = done.pending_restore.map(|token| PendingRestore {
+                    token,
+                    retry_at: now + RETRY_DELAY,
+                });
+                let restart_at = device_io_allowed.then_some(now + RETRY_DELAY);
+                let Some(slot) = self.slot.as_mut() else {
+                    return false;
+                };
+                let Some((dispatch_session, unexpected)) =
+                    slot.complete(&done.session, pending_restore, restart_at)
                 else {
                     return false;
                 };
+                let recovery_finished = slot.recovery().is_some_and(CaptureRecovery::is_empty);
                 self.dispatcher.cancel_hidpp_session(&dispatch_session);
-                self.pending_restore = done.pending_restore.map(|token| PendingRestore {
-                    token,
-                    retry_at: tokio::time::Instant::now() + RETRY_DELAY,
-                });
                 if unexpected && device_io_allowed {
-                    self.restart_at = Some(tokio::time::Instant::now() + RETRY_DELAY);
                     warn!("keyboard capture session ended unexpectedly, delaying re-arm");
                 }
-                self.current = None;
+                if recovery_finished {
+                    self.slot = None;
+                }
                 true
             }
         }
@@ -378,13 +410,19 @@ impl KeyboardManagerState {
 fn next_deadline(
     requests: ReceiverRequestState,
     device_io_allowed: bool,
-    pending_restore: Option<tokio::time::Instant>,
-    restart_at: Option<tokio::time::Instant>,
+    slot: Option<&KeyboardSlot>,
 ) -> Option<tokio::time::Instant> {
     if requests.any() || !device_io_allowed {
         return None;
     }
-    pending_restore.into_iter().chain(restart_at).min()
+    let recovery = slot.and_then(KeyboardSlot::recovery)?;
+    recovery
+        .pending_restore
+        .as_ref()
+        .map(|pending| pending.retry_at)
+        .into_iter()
+        .chain(recovery.restart_at)
+        .min()
 }
 
 /// Keep one keyboard capture session alive for the published spec, restarting
@@ -462,7 +500,7 @@ async fn manage(
             },
             open = wait_for_registry_change(
                 &mut registry_changes,
-                state.pending_restore.is_some(),
+                state.has_pending_restore(),
             ) => {
                 if !open {
                     return;

--- a/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
@@ -132,13 +132,14 @@ fn target_changes_freeze_dispatch_until_teardown_finishes() {
 #[test]
 fn suspended_device_io_disables_retry_deadlines() {
     let retry_at = tokio::time::Instant::now() + RETRY_DELAY;
+    let slot = KeyboardSlot::recovering(None, Some(retry_at));
 
     assert_eq!(
-        next_deadline(ReceiverRequestState::default(), true, None, Some(retry_at)),
+        next_deadline(ReceiverRequestState::default(), true, Some(&slot)),
         Some(retry_at),
     );
     assert_eq!(
-        next_deadline(ReceiverRequestState::default(), false, None, Some(retry_at)),
+        next_deadline(ReceiverRequestState::default(), false, Some(&slot)),
         None,
         "keyboard retries must stay dormant until visible resume",
     );


### PR DESCRIPTION
## Summary

Consolidate each gesture/keyboard capture owner into one runtime slot so a running capture epoch cannot coexist with post-session recovery state. This is an ownership-state refactor only; HID behavior, ordered input draining, and recovery policy remain unchanged.

## Changes

- **openlogi-agent-core:** add a shared `CaptureSlot` with mutually exclusive running and recovering variants while retaining pending firmware restore and restart pacing as independent recovery facts
- **openlogi-agent-core:** migrate the multi-device gesture manager from three parallel maps to one physical-device slot map
- **openlogi-agent-core:** migrate the keyboard manager from three independent options to one optional slot
- **openlogi-agent-core:** cover active-to-recovery transitions, restore/backoff coexistence, stale completion rejection, planned versus unexpected completion pacing, and suspended retry deadlines

## Testing

- `cargo test -p openlogi-agent-core capture_session::tests` — 6 passed
- `cargo test -p openlogi-agent-core watchers::gesture::tests` — 13 passed
- `cargo test -p openlogi-agent-core watchers::keyboard::tests` — 5 passed
- `cargo test -p openlogi-agent-core` — 221 passed
- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check` — passed
- `RUSTFLAGS="-D warnings" cargo clippy -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings` — passed
- `RUSTFLAGS="-D warnings" cargo test -p openlogi-agent-core -p openlogi-agent` — 254 tests passed (221 agent-core, 33 agent binaries); doc-tests passed
- Not runtime-tested on hardware; verify gesture controls and bound keyboard keys across config changes, pairing/exclusive requests, disconnect/reconnect recovery, and display sleep/wake.

No linked issue.
