### PR TITLE
fix(windows): scale and frame the Actions Ring correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5713,12 +5713,14 @@ dependencies = [
  "openlogi-hook",
  "openlogi-ipc",
  "openlogi-ui",
+ "raw-window-handle",
  "rust-i18n",
  "succession",
  "tarpc",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/openlogi-overlay/Cargo.toml
+++ b/crates/openlogi-overlay/Cargo.toml
@@ -44,5 +44,14 @@ objc2-app-kit = { workspace = true, features = ["NSApplication", "NSResponder", 
 # NSEvent global-monitor handlers are ObjC blocks (click-away dismissal).
 block2 = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+raw-window-handle = "0.6"
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Dwm",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_HiDpi",
+] }
+
 [lints]
 workspace = true

--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -80,7 +80,9 @@ fn main() -> Result<()> {
                         cx.new(|_| RingView::new(invocation, commands, &live_session))
                     }) {
                         Ok(handle) => {
-                            platform::configure_windows();
+                            let _ = handle.update(cx, |_, window, _| {
+                                platform::configure_window(window);
+                            });
                             cx.spawn(async move |cx| {
                                 cx.background_executor().timer(DISPLAY_LIFETIME).await;
                                 if handle

--- a/crates/openlogi-overlay/src/platform.rs
+++ b/crates/openlogi-overlay/src/platform.rs
@@ -1,143 +1,189 @@
-//! Native window policy for the standalone Actions Ring overlay.
+//! Native window policy and cursor geometry for the Actions Ring overlay.
 
-/// Keep the overlay out of the Dock and app switcher.
 #[cfg(target_os = "macos")]
-pub fn configure_application() {
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+mod macos;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod other;
+#[cfg(target_os = "windows")]
+mod windows;
 
-    if let Some(marker) = MainThreadMarker::new() {
-        NSApplication::sharedApplication(marker)
-            .setActivationPolicy(NSApplicationActivationPolicy::Accessory);
-    }
+#[cfg(target_os = "macos")]
+use macos as imp;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+use other as imp;
+#[cfg(target_os = "windows")]
+use windows as imp;
+
+pub(crate) use imp::ClickAwayMonitor;
+
+/// Apply the platform's process-wide overlay application policy.
+pub(crate) fn configure_application() {
+    imp::configure_application();
 }
 
-/// Make the transparent ring panel borderless and remove its native shadow.
-#[cfg(target_os = "macos")]
-pub fn configure_windows() {
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSApplication, NSWindowStyleMask};
-
-    if let Some(marker) = MainThreadMarker::new() {
-        for window in NSApplication::sharedApplication(marker).windows() {
-            window.setStyleMask(NSWindowStyleMask::NonactivatingPanel);
-            window.setHasShadow(false);
-        }
-    }
+/// Apply native policy to the newly created transparent ring window.
+pub(crate) fn configure_window(window: &gpui::Window) {
+    imp::configure_window(window);
 }
 
-/// No native application policy is required away from macOS.
-#[cfg(not(target_os = "macos"))]
-pub fn configure_application() {}
-
-/// Other GPUI backends need no additional native window configuration here.
-#[cfg(not(target_os = "macos"))]
-pub fn configure_windows() {}
-
-/// Owner of the native click-away event monitor; dropping it removes the
-/// monitor. Create and drop on the main thread.
-#[cfg(target_os = "macos")]
-pub struct ClickAwayMonitor(objc2::rc::Retained<objc2::runtime::AnyObject>);
-
-#[cfg(target_os = "macos")]
-impl Drop for ClickAwayMonitor {
-    #[expect(
-        unsafe_code,
-        reason = "NSEvent::removeMonitor is plain AppKit FFI; the token is exactly what addGlobalMonitor returned"
-    )]
-    fn drop(&mut self) {
-        // SAFETY: `self.0` is the monitor token returned by
-        // `addGlobalMonitorForEventsMatchingMask_handler`, removed only once.
-        unsafe { objc2_app_kit::NSEvent::removeMonitor(&self.0) };
-    }
+/// Watch mouse-down events that land outside this process's windows.
+pub(crate) fn watch_clicks_outside(on_mouse_down: impl Fn() + 'static) -> Option<ClickAwayMonitor> {
+    imp::watch_clicks_outside(on_mouse_down)
 }
 
-/// Invoke `on_mouse_down` for every mouse-down that macOS delivers to *other*
-/// applications, for as long as the returned monitor is held.
+/// A cursor and its display expressed in the coordinate space GPUI expects for
+/// `WindowOptions`.
 ///
-/// Global `NSEvent` monitors never see events routed to this process's own
-/// windows and cannot consume the events they observe — together exactly the
-/// ring's click-away contract: clicks on the ring keep hitting the GPUI
-/// handlers they always did, while a click anywhere else can dismiss the ring
-/// without being swallowed. Must be called on the main thread (returns `None`
-/// off it); the handler runs on the main run loop.
-#[cfg(target_os = "macos")]
-pub fn watch_clicks_outside(on_mouse_down: impl Fn() + 'static) -> Option<ClickAwayMonitor> {
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSEvent, NSEventMask};
-
-    MainThreadMarker::new()?;
-    let handler: block2::RcBlock<dyn Fn(std::ptr::NonNull<NSEvent>)> =
-        block2::RcBlock::new(move |_event| on_mouse_down());
-    NSEvent::addGlobalMonitorForEventsMatchingMask_handler(
-        NSEventMask::LeftMouseDown | NSEventMask::RightMouseDown | NSEventMask::OtherMouseDown,
-        &handler,
-    )
-    .map(ClickAwayMonitor)
+/// Windows uses global logical coordinates because GPUI's Windows backend
+/// scales both the display bounds and the window bounds from that space. macOS
+/// uses display-relative coordinates because its GPUI display bounds are
+/// display-relative. Linux does not construct this type: its existing GPUI
+/// fallback remains responsible for the global-coordinate mapping.
+pub(crate) struct CursorPlacement {
+    /// Native display id, numerically equal to the GPUI `DisplayId`.
+    pub(crate) display_id: u64,
+    /// Cursor position in GPUI logical coordinates.
+    pub(crate) center: (f64, f64),
+    /// Display bounds origin in GPUI logical coordinates.
+    pub(crate) display_origin: (f64, f64),
+    /// Display bounds size in GPUI logical coordinates.
+    pub(crate) display_size: (f64, f64),
 }
 
-/// Away from macOS no global click monitor is available; the ring keeps its
-/// in-window dismissal paths (center ×, slot activation, timeout).
-#[cfg(not(target_os = "macos"))]
-pub struct ClickAwayMonitor(());
-
-#[cfg(not(target_os = "macos"))]
-pub fn watch_clicks_outside(_on_mouse_down: impl Fn() + 'static) -> Option<ClickAwayMonitor> {
-    None
+/// Resolve the native cursor placement for the current platform.
+pub(crate) fn cursor_placement(x: f64, y: f64) -> Option<CursorPlacement> {
+    imp::cursor_placement(x, y)
 }
 
-/// One display's global geometry, in the same top-left-origin global point
-/// space that `openlogi_hook::cursor_position()` reports.
-pub struct CursorDisplay {
-    /// Native display id; on macOS the `CGDirectDisplayID`, numerically equal
-    /// to GPUI's `DisplayId` for the same display.
-    pub id: u64,
-    /// Global origin (top-left corner) of the display, in points.
-    pub origin: (f64, f64),
-    /// Display size in points.
-    pub size: (f64, f64),
-}
-
-/// Find the display whose global bounds contain the point `(x, y)`.
+/// Whether a failed native lookup must fall back to the primary display.
 ///
-/// GPUI's `PlatformDisplay::bounds()` zeroes every display's origin (window
-/// bounds are display-relative), so mapping a global cursor position to its
-/// display has to go through CoreGraphics.
-#[cfg(target_os = "macos")]
-#[expect(
-    unsafe_code,
-    reason = "CGGetActiveDisplayList/CGDisplayBounds are plain C FFI; GPUI exposes no global display bounds"
-)]
-pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
-    use core_graphics::display::{CGDisplayBounds, CGGetActiveDisplayList};
+/// Windows and macOS hook coordinates are not safe to feed directly into GPUI
+/// when their native display lookup fails. Linux retains its existing
+/// global-coordinate fallback.
+pub(crate) const fn native_cursor_placement_requires_primary_fallback() -> bool {
+    cfg!(any(target_os = "macos", target_os = "windows"))
+}
 
-    const MAX_DISPLAYS: u32 = 32;
-    let mut ids = [0u32; MAX_DISPLAYS as usize];
-    let mut count = 0u32;
-    // SAFETY: the list write is bounded by the capacity we pass; `count`
-    // reports how many entries were actually filled.
-    let result = unsafe { CGGetActiveDisplayList(MAX_DISPLAYS, ids.as_mut_ptr(), &raw mut count) };
-    if result != 0 {
+/// Convert a physical global cursor/display geometry pair into GPUI's global
+/// logical coordinate space.
+///
+/// Kept independent of Win32 so scale and negative-origin cases can be tested
+/// on every host platform.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn scaled_cursor_placement(
+    display_id: u64,
+    cursor: (f64, f64),
+    display_origin: (f64, f64),
+    display_size: (f64, f64),
+    scale_factor: f64,
+) -> Option<CursorPlacement> {
+    if !valid_geometry(cursor, display_origin, display_size)
+        || !scale_factor.is_finite()
+        || scale_factor <= 0.0
+    {
         return None;
     }
-    ids.iter().take(count as usize).find_map(|&id| {
-        // SAFETY: side-effect-free C getter on an id from the active list.
-        let bounds = unsafe { CGDisplayBounds(id) };
-        let contains = x >= bounds.origin.x
-            && x < bounds.origin.x + bounds.size.width
-            && y >= bounds.origin.y
-            && y < bounds.origin.y + bounds.size.height;
-        contains.then(|| CursorDisplay {
-            id: u64::from(id),
-            origin: (bounds.origin.x, bounds.origin.y),
-            size: (bounds.size.width, bounds.size.height),
-        })
+
+    Some(CursorPlacement {
+        display_id,
+        center: (cursor.0 / scale_factor, cursor.1 / scale_factor),
+        display_origin: (
+            display_origin.0 / scale_factor,
+            display_origin.1 / scale_factor,
+        ),
+        display_size: (display_size.0 / scale_factor, display_size.1 / scale_factor),
     })
 }
 
-/// Away from macOS the GPUI display list already carries global origins, so
-/// there is nothing to resolve natively.
-#[cfg(not(target_os = "macos"))]
-pub fn display_containing(_x: f64, _y: f64) -> Option<CursorDisplay> {
-    None
+#[cfg(any(target_os = "macos", test))]
+fn relative_cursor_placement(
+    display_id: u64,
+    cursor: (f64, f64),
+    display_origin: (f64, f64),
+    display_size: (f64, f64),
+) -> Option<CursorPlacement> {
+    if !valid_geometry(cursor, display_origin, display_size) {
+        return None;
+    }
+
+    Some(CursorPlacement {
+        display_id,
+        center: (cursor.0 - display_origin.0, cursor.1 - display_origin.1),
+        display_origin: (0.0, 0.0),
+        display_size,
+    })
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
+fn valid_geometry(
+    cursor: (f64, f64),
+    display_origin: (f64, f64),
+    display_size: (f64, f64),
+) -> bool {
+    cursor.0.is_finite()
+        && cursor.1.is_finite()
+        && display_origin.0.is_finite()
+        && display_origin.1.is_finite()
+        && display_size.0.is_finite()
+        && display_size.1.is_finite()
+        && display_size.0 > 0.0
+        && display_size.1 > 0.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaling_at_100_percent_is_an_identity_conversion() {
+        let placement =
+            scaled_cursor_placement(7, (2560.0, 1080.0), (0.0, 0.0), (3840.0, 2160.0), 1.0)
+                .expect("valid display geometry");
+
+        assert_eq!(placement.display_id, 7);
+        assert_eq!(placement.center, (2560.0, 1080.0));
+        assert_eq!(placement.display_origin, (0.0, 0.0));
+        assert_eq!(placement.display_size, (3840.0, 2160.0));
+    }
+
+    #[test]
+    fn scaling_125_percent_converts_cursor_and_display_geometry() {
+        let placement =
+            scaled_cursor_placement(11, (2560.0, 1080.0), (0.0, 0.0), (5120.0, 2160.0), 1.25)
+                .expect("valid display geometry");
+
+        assert_eq!(placement.center, (2048.0, 864.0));
+        assert_eq!(placement.display_origin, (0.0, 0.0));
+        assert_eq!(placement.display_size, (4096.0, 1728.0));
+    }
+
+    #[test]
+    fn scaling_150_percent_preserves_negative_monitor_origins() {
+        let placement =
+            scaled_cursor_placement(13, (-1920.0, 810.0), (-3840.0, 0.0), (3840.0, 2160.0), 1.5)
+                .expect("valid display geometry");
+
+        assert_eq!(placement.center, (-1280.0, 540.0));
+        assert_eq!(placement.display_origin, (-2560.0, 0.0));
+        assert_eq!(placement.display_size, (2560.0, 1440.0));
+    }
+
+    #[test]
+    fn relative_placement_keeps_macos_display_coordinates() {
+        let placement =
+            relative_cursor_placement(17, (3000.0, 500.0), (2560.0, 0.0), (2560.0, 1440.0))
+                .expect("valid display geometry");
+
+        assert_eq!(placement.center, (440.0, 500.0));
+        assert_eq!(placement.display_origin, (0.0, 0.0));
+        assert_eq!(placement.display_size, (2560.0, 1440.0));
+    }
+
+    #[test]
+    fn invalid_native_geometry_returns_none_for_primary_fallback() {
+        assert!(
+            scaled_cursor_placement(19, (100.0, 100.0), (0.0, 0.0), (1920.0, 1080.0), 0.0,)
+                .is_none()
+        );
+    }
 }

--- a/crates/openlogi-overlay/src/platform/macos.rs
+++ b/crates/openlogi-overlay/src/platform/macos.rs
@@ -1,0 +1,102 @@
+//! macOS native policy and global display lookup.
+
+use super::{CursorPlacement, relative_cursor_placement};
+
+pub(super) fn configure_application() {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+
+    if let Some(marker) = MainThreadMarker::new() {
+        NSApplication::sharedApplication(marker)
+            .setActivationPolicy(NSApplicationActivationPolicy::Accessory);
+    }
+}
+
+/// Apply the ring window's native policy.
+///
+/// GPUI exposes no `NSWindow` behind a `gpui::Window`, so the policy is applied
+/// to every window this process owns. The overlay is an accessory process whose
+/// only window is the ring, so that is the same set.
+pub(super) fn configure_window(_window: &gpui::Window) {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSWindowStyleMask};
+
+    if let Some(marker) = MainThreadMarker::new() {
+        for window in NSApplication::sharedApplication(marker).windows() {
+            window.setStyleMask(NSWindowStyleMask::NonactivatingPanel);
+            window.setHasShadow(false);
+        }
+    }
+}
+
+/// Owner of the native click-away event monitor; dropping it removes the
+/// monitor. Create and drop on the main thread.
+pub(crate) struct ClickAwayMonitor(objc2::rc::Retained<objc2::runtime::AnyObject>);
+
+impl Drop for ClickAwayMonitor {
+    #[expect(
+        unsafe_code,
+        reason = "NSEvent::removeMonitor is plain AppKit FFI; the token is exactly what addGlobalMonitor returned"
+    )]
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is the monitor token returned by
+        // `addGlobalMonitorForEventsMatchingMask_handler`, removed only once.
+        unsafe { objc2_app_kit::NSEvent::removeMonitor(&self.0) };
+    }
+}
+
+pub(super) fn watch_clicks_outside(on_mouse_down: impl Fn() + 'static) -> Option<ClickAwayMonitor> {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSEvent, NSEventMask};
+
+    MainThreadMarker::new()?;
+    let handler: block2::RcBlock<dyn Fn(std::ptr::NonNull<NSEvent>)> =
+        block2::RcBlock::new(move |_event| on_mouse_down());
+    NSEvent::addGlobalMonitorForEventsMatchingMask_handler(
+        NSEventMask::LeftMouseDown | NSEventMask::RightMouseDown | NSEventMask::OtherMouseDown,
+        &handler,
+    )
+    .map(ClickAwayMonitor)
+}
+
+pub(super) fn cursor_placement(x: f64, y: f64) -> Option<CursorPlacement> {
+    let display = display_containing(x, y)?;
+    relative_cursor_placement(display.id, (x, y), display.origin, display.size)
+}
+
+struct CursorDisplay {
+    id: u64,
+    origin: (f64, f64),
+    size: (f64, f64),
+}
+
+#[expect(
+    unsafe_code,
+    reason = "CGGetActiveDisplayList/CGDisplayBounds are plain C FFI; GPUI exposes no global display bounds"
+)]
+fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
+    use core_graphics::display::{CGDisplayBounds, CGGetActiveDisplayList};
+
+    const MAX_DISPLAYS: u32 = 32;
+    let mut ids = [0u32; MAX_DISPLAYS as usize];
+    let mut count = 0u32;
+    // SAFETY: the list write is bounded by the capacity we pass; `count`
+    // reports how many entries were actually filled.
+    let result = unsafe { CGGetActiveDisplayList(MAX_DISPLAYS, ids.as_mut_ptr(), &raw mut count) };
+    if result != 0 {
+        return None;
+    }
+    ids.iter().take(count as usize).find_map(|&id| {
+        // SAFETY: side-effect-free C getter on an id from the active list.
+        let bounds = unsafe { CGDisplayBounds(id) };
+        let contains = x >= bounds.origin.x
+            && x < bounds.origin.x + bounds.size.width
+            && y >= bounds.origin.y
+            && y < bounds.origin.y + bounds.size.height;
+        contains.then(|| CursorDisplay {
+            id: u64::from(id),
+            origin: (bounds.origin.x, bounds.origin.y),
+            size: (bounds.size.width, bounds.size.height),
+        })
+    })
+}

--- a/crates/openlogi-overlay/src/platform/other.rs
+++ b/crates/openlogi-overlay/src/platform/other.rs
@@ -1,0 +1,19 @@
+//! Native overlay stubs for platforms without extra window policy.
+
+use super::CursorPlacement;
+
+pub(super) const fn configure_application() {}
+
+pub(super) fn configure_window(_window: &gpui::Window) {}
+
+pub(crate) struct ClickAwayMonitor;
+
+pub(super) fn watch_clicks_outside(
+    _on_mouse_down: impl Fn() + 'static,
+) -> Option<ClickAwayMonitor> {
+    None
+}
+
+pub(super) const fn cursor_placement(_x: f64, _y: f64) -> Option<CursorPlacement> {
+    None
+}

--- a/crates/openlogi-overlay/src/platform/windows.rs
+++ b/crates/openlogi-overlay/src/platform/windows.rs
@@ -8,7 +8,8 @@ pub(super) fn configure_window(window: &gpui::Window) {
     use raw_window_handle::RawWindowHandle;
     use tracing::debug;
     use windows_sys::Win32::Graphics::Dwm::{
-        DWMWA_BORDER_COLOR, DWMWA_COLOR_NONE, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DONOTROUND,
+        DWMNCRP_DISABLED, DWMWA_BORDER_COLOR, DWMWA_COLOR_NONE, DWMWA_NCRENDERING_POLICY,
+        DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DONOTROUND,
     };
 
     let Ok(handle) = raw_window_handle::HasWindowHandle::window_handle(window) else {
@@ -20,6 +21,10 @@ pub(super) fn configure_window(window: &gpui::Window) {
     let hwnd = handle.hwnd.get() as windows_sys::Win32::Foundation::HWND;
 
     for (name, result) in [
+        (
+            "non-client rendering",
+            set_dwm_window_attribute(hwnd, DWMWA_NCRENDERING_POLICY, &DWMNCRP_DISABLED),
+        ),
         (
             "border color",
             set_dwm_window_attribute(hwnd, DWMWA_BORDER_COLOR, &DWMWA_COLOR_NONE),

--- a/crates/openlogi-overlay/src/platform/windows.rs
+++ b/crates/openlogi-overlay/src/platform/windows.rs
@@ -1,0 +1,152 @@
+//! Windows native window policy and DPI-aware display lookup.
+
+use super::{CursorPlacement, scaled_cursor_placement};
+
+pub(super) const fn configure_application() {}
+
+pub(super) fn configure_window(window: &gpui::Window) {
+    use raw_window_handle::RawWindowHandle;
+    use tracing::debug;
+    use windows_sys::Win32::Graphics::Dwm::{
+        DWMWA_BORDER_COLOR, DWMWA_COLOR_NONE, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DONOTROUND,
+    };
+
+    let Ok(handle) = raw_window_handle::HasWindowHandle::window_handle(window) else {
+        return;
+    };
+    let RawWindowHandle::Win32(handle) = handle.as_raw() else {
+        return;
+    };
+    let hwnd = handle.hwnd.get() as windows_sys::Win32::Foundation::HWND;
+
+    for (name, result) in [
+        (
+            "border color",
+            set_dwm_window_attribute(hwnd, DWMWA_BORDER_COLOR, &DWMWA_COLOR_NONE),
+        ),
+        (
+            "corner preference",
+            set_dwm_window_attribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &DWMWCP_DONOTROUND),
+        ),
+    ] {
+        if result.is_some_and(|result| result < 0) {
+            debug!(
+                result,
+                attribute = name,
+                "DWM window attribute is unavailable"
+            );
+        }
+    }
+}
+
+#[expect(
+    unsafe_code,
+    reason = "DwmSetWindowAttribute synchronously copies the typed value for the live GPUI HWND"
+)]
+fn set_dwm_window_attribute<T>(
+    hwnd: windows_sys::Win32::Foundation::HWND,
+    attribute: i32,
+    value: &T,
+) -> Option<windows_sys::core::HRESULT> {
+    use std::mem::size_of_val;
+
+    use windows_sys::Win32::Graphics::Dwm::DwmSetWindowAttribute;
+
+    let attribute = u32::try_from(attribute).ok()?;
+    let value_size = u32::try_from(size_of_val(value)).ok()?;
+    // SAFETY: `hwnd` belongs to the live GPUI window, `value` remains valid
+    // for this synchronous call, and `value_size` is the exact pointee size.
+    Some(unsafe {
+        DwmSetWindowAttribute(
+            hwnd,
+            attribute,
+            std::ptr::from_ref(value).cast(),
+            value_size,
+        )
+    })
+}
+
+pub(crate) struct ClickAwayMonitor;
+
+pub(super) fn watch_clicks_outside(
+    _on_mouse_down: impl Fn() + 'static,
+) -> Option<ClickAwayMonitor> {
+    None
+}
+
+#[expect(
+    unsafe_code,
+    reason = "MonitorFromPoint/GetMonitorInfoW/GetDpiForMonitor are plain Win32 FFI"
+)]
+pub(super) fn cursor_placement(x: f64, y: f64) -> Option<CursorPlacement> {
+    use std::mem::size_of;
+
+    use windows_sys::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MONITOR_DEFAULTTONULL, MONITORINFO, MonitorFromPoint,
+    };
+    use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+
+    let point = win32_point(x, y)?;
+    // SAFETY: `point` is an initialized screen coordinate and the null flag
+    // asks Windows to return a null handle rather than selecting a nearby
+    // monitor if the coordinate is not covered by a display.
+    let monitor = unsafe { MonitorFromPoint(point, MONITOR_DEFAULTTONULL) };
+    if monitor.is_null() {
+        return None;
+    }
+
+    let mut info = MONITORINFO {
+        cbSize: u32::try_from(size_of::<MONITORINFO>()).ok()?,
+        ..MONITORINFO::default()
+    };
+    // SAFETY: `monitor` is the non-null handle returned above and `info` is a
+    // live MONITORINFO with its required size initialized.
+    if unsafe { GetMonitorInfoW(monitor, &raw mut info) } == 0 {
+        return None;
+    }
+
+    let mut dpi_x = 0u32;
+    let mut dpi_y = 0u32;
+    // SAFETY: `monitor` is valid for the duration of this synchronous query;
+    // both DPI outputs point to live initialized u32 storage.
+    let dpi_result =
+        unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &raw mut dpi_x, &raw mut dpi_y) };
+    if dpi_result != 0 || dpi_x == 0 || dpi_x != dpi_y {
+        return None;
+    }
+
+    let rect = info.rcMonitor;
+    let display_origin = (f64::from(rect.left), f64::from(rect.top));
+    let display_size = (
+        f64::from(rect.right) - f64::from(rect.left),
+        f64::from(rect.bottom) - f64::from(rect.top),
+    );
+    let display_id = u64::try_from(monitor.addr()).ok()?;
+    scaled_cursor_placement(
+        display_id,
+        (x, y),
+        display_origin,
+        display_size,
+        f64::from(dpi_x) / 96.0,
+    )
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "cursor_position preserves Win32 i32 coordinates as f64 and the range checks prove they fit back into POINT"
+)]
+fn win32_point(x: f64, y: f64) -> Option<windows_sys::Win32::Foundation::POINT> {
+    if !x.is_finite()
+        || !y.is_finite()
+        || x < f64::from(i32::MIN)
+        || x > f64::from(i32::MAX)
+        || y < f64::from(i32::MIN)
+        || y > f64::from(i32::MAX)
+    {
+        return None;
+    }
+    Some(windows_sys::Win32::Foundation::POINT {
+        x: x as i32,
+        y: y as i32,
+    })
+}

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -232,46 +232,50 @@ impl Render for RingView {
 pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
     let cursor = openlogi_hook::cursor_position();
     let size = Size::new(px(WINDOW_SIZE), px(WINDOW_SIZE));
-    // GPUI window bounds are display-relative (`display.bounds()` zeroes every
-    // origin) while the hook reports the cursor in global coordinates, so the
-    // cursor's display must be resolved natively and the cursor translated into
-    // that display's space. Feeding the global point straight into the clamp
-    // pins a ring triggered on a secondary display to the primary one's edge.
-    let native_display = cursor
+    // The hook reports native global coordinates. Resolve the cursor's display
+    // and translate both into GPUI's logical coordinate space before clamping.
+    let native_placement = cursor
         .as_ref()
-        .and_then(|cursor| platform::display_containing(cursor.x, cursor.y));
-    let (display_id, center, display_bounds) =
-        if let (Some(cursor), Some(display)) = (&cursor, native_display) {
-            (
-                Some(gpui::DisplayId::from(display.id)),
+        .and_then(|cursor| platform::cursor_placement(cursor.x, cursor.y));
+    let (display_id, center, display_bounds) = if let Some(placement) = native_placement {
+        (
+            Some(gpui::DisplayId::from(placement.display_id)),
+            point(px(placement.center.0 as f32), px(placement.center.1 as f32)),
+            Some(Bounds::new(
                 point(
-                    px((cursor.x - display.origin.0) as f32),
-                    px((cursor.y - display.origin.1) as f32),
+                    px(placement.display_origin.0 as f32),
+                    px(placement.display_origin.1 as f32),
                 ),
-                Some(Bounds::new(
-                    Point::default(),
-                    Size::new(px(display.size.0 as f32), px(display.size.1 as f32)),
-                )),
-            )
-        } else {
-            // No cursor or no native lookup (non-macOS): GPUI's own display
-            // list, centering on the display when the cursor is unknown.
-            let cursor_point = cursor
-                .as_ref()
-                .map(|cursor| point(px(cursor.x as f32), px(cursor.y as f32)));
-            let display = cursor_point
-                .and_then(|cursor| {
-                    cx.displays()
-                        .into_iter()
-                        .find(|display| display.bounds().contains(&cursor))
-                })
-                .or_else(|| cx.primary_display());
-            let center = cursor_point
-                .or_else(|| display.as_ref().map(|display| display.bounds().center()))
-                .unwrap_or_default();
-            let bounds = display.as_ref().map(|display| display.bounds());
-            (display.map(|display| display.id()), center, bounds)
-        };
+                Size::new(
+                    px(placement.display_size.0 as f32),
+                    px(placement.display_size.1 as f32),
+                ),
+            )),
+        )
+    } else {
+        // Linux hook coordinates already match GPUI's global space. A
+        // failed Windows/macOS native conversion cannot safely reuse its
+        // raw point, so center on the primary display instead.
+        let cursor_point = (!platform::native_cursor_placement_requires_primary_fallback())
+            .then(|| {
+                cursor
+                    .as_ref()
+                    .map(|cursor| point(px(cursor.x as f32), px(cursor.y as f32)))
+            })
+            .flatten();
+        let display = cursor_point
+            .and_then(|cursor| {
+                cx.displays()
+                    .into_iter()
+                    .find(|display| display.bounds().contains(&cursor))
+            })
+            .or_else(|| cx.primary_display());
+        let center = cursor_point
+            .or_else(|| display.as_ref().map(|display| display.bounds().center()))
+            .unwrap_or_default();
+        let bounds = display.as_ref().map(|display| display.bounds());
+        (display.map(|display| display.id()), center, bounds)
+    };
     let desired_origin = point(center.x - size.width / 2.0, center.y - size.height / 2.0);
     let origin = display_bounds.map_or(desired_origin, |display_bounds| {
         clamp_window_origin(desired_origin, size, display_bounds)


### PR DESCRIPTION
## Summary

On Windows the Actions Ring opened at the centre of the primary display instead
of at the cursor whenever display scaling was above 100% (#1027).

The overlay had no native display lookup on Windows, so `ring_window_options`
fell through to the GPUI display list and compared the hook's **physical**
cursor position against **logical** display bounds. Above 100% scaling the
physical point matches no display, the lookup falls back to the primary display,
and the ring is placed at that display's centre — the "opens at a fixed
position" symptom in the issue.

The fix resolves the cursor's monitor with `MonitorFromPoint` and converts the
cursor and the monitor bounds with that monitor's own effective DPI. That is
exactly the conversion GPUI's Windows backend applies when it builds its display
bounds (`logical_point(rcMonitor.left, top, scale)` with
`scale = GetDpiForMonitor(MDT_EFFECTIVE_DPI) / 96`), so the overlay and GPUI now
describe one coordinate space instead of two.

A second commit removes the DWM frame that Windows drew around the transparent
ring window.

## Changes

**`crates/openlogi-overlay`**

- `platform.rs` becomes a per-OS module tree (`macos.rs`, `windows.rs`,
  `other.rs`) behind a facade owning the shared `CursorPlacement` type. A second
  platform turns the interleaved `cfg` arms into the shape the workspace rules
  already reject.
- New Windows placement path: `MonitorFromPoint` + `GetMonitorInfoW` +
  `GetDpiForMonitor(MDT_EFFECTIVE_DPI)`. It returns `None` — and so falls back
  to the primary display — for a point no monitor covers, a failed query, or
  anisotropic DPI, rather than guessing.
- `scaled_cursor_placement` is kept free of Win32, so the 100/125/150% and
  negative-origin monitor cases are unit-tested on every host.
- `configure_windows()` becomes `configure_window(&Window)`, applying DWM
  `NCRENDERING_POLICY`, `BORDER_COLOR` and `WINDOW_CORNER_PREFERENCE` to the
  GPUI HWND so the transparent ring no longer sits inside a shadowed, rounded
  rectangle. Each attribute is set independently and a rejection is logged, not
  propagated: they are presentation hints, and a Windows build that does not
  recognise one should still get a working ring.
- macOS keeps its display-relative CoreGraphics lookup unchanged.
- New Windows-only dependencies: `raw-window-handle`, and `windows-sys` with the
  `Win32_Foundation`, `Win32_Graphics_Dwm`, `Win32_Graphics_Gdi` and
  `Win32_UI_HiDpi` features.

### One macOS behaviour change

When the native display lookup fails, macOS no longer falls back to matching the
raw global cursor point against GPUI's display list. That point is not in GPUI's
coordinate space, so any placement derived from it was accidental; the ring now
centres on the primary display, matching the new Windows path. Flagging it
because it is a macOS change inside a Windows fix.

## Testing

Full local gate on Windows 11 (x86_64-pc-windows-msvc), `RUSTFLAGS=-D warnings`:

- `cargo fmt --all -- --check` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo test --workspace` — one pre-existing failure, unrelated to this branch
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent` — pre-existing failure, unrelated to this branch

`cargo test -p openlogi-overlay` covers the new conversion directly: identity at
100%, 125% and 150% scaling, negative monitor origins preserved, and an invalid
scale factor falling through to the primary-display path.

The two failures above reproduce on master from a Windows checkout and are
untouched by this branch. Neither is visible in CI:

- `xtask`'s `ci_yml_runs_what_this_runner_runs` joins `ci.yml` line
  continuations by stripping a backslash followed by a bare LF, so a checkout
  with CRLF endings (the Git for Windows default, and there is no
  `.gitattributes` here) fails to match every multi-line `run:`.
- `openlogi-permissions` links to `PermissionStatus::Unknown` in its crate-level
  docs, but that type is gated to macOS and Linux, so the link resolves nowhere
  under a Windows rustdoc run. The CI rustdoc job runs on Linux.

Both were verified green with local one-line fixes applied, confirming they are
the only two failures and that this branch adds none.

Not run locally: the macOS and Linux CI lanes, MSRV, cargo-deny, typos, shell
lint, and wasm — this host cannot reproduce them. `cargo xtask ci` cannot
complete on Windows either: the `publish closure` job shells out to
`cargo xtask release check-publish`, which cannot relink the xtask binary under
`target/debug` while that binary is the running process.

### Hardware verification

Verified on Windows 11 at 125% display scaling: the Actions Ring opens centred
on the cursor, and the shadow, border and rounded corner previously drawn around
the transparent ring window are gone.

Not exercised: a multi-monitor setup where the ring's target display has a
different scale factor from the display a new window default-places on. GPUI
converts the requested window bounds with `GetDpiForWindow` sampled while the
window is still at `CW_USEDEFAULT` rather than with the target display's scale
factor, so that mixed-DPI case is worth a look from anyone who has the setup.

Fixes #1027
