### PR TITLE
Fix typo in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Download the package for your distribution from the
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i openlogi_*.deb
+sudo dpkg -i openlogi-*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm


### PR DESCRIPTION
Noted by copy-pasting I ran into an small typo issue. Corrected it for other users.