### PR TITLE
feat(agent): add held horizontal scroll modifier

### DIFF
--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -11,6 +11,7 @@ pub mod scroll;
 
 use std::collections::HashMap;
 use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
@@ -26,33 +27,78 @@ use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
 use crate::receiver_access::ReceiverAccess;
 use crate::{DpiCycleState, DpiCycles};
 
-/// Held output owned by accepted press capabilities rather than by a capture
+/// Cloneable read-mostly horizontal-scroll hold state. The OS-hook callback
+/// cannot consistently map a wheel event to a stable config key on every
+/// platform, so any accepted live hold enables the modifier for wheel sources
+/// that have already passed the hook's Logitech/non-trackpad safety policy.
+#[derive(Clone, Default)]
+struct HorizontalScrollState {
+    active: Arc<AtomicBool>,
+}
+
+impl HorizontalScrollState {
+    fn publish(&self, active: bool) {
+        self.active.store(active, Ordering::Release);
+    }
+
+    fn active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+}
+
+enum HeldOutput {
+    Chord { _held: openlogi_inject::HeldChord },
+    HorizontalScroll,
+}
+
+/// Held outputs owned by accepted press capabilities rather than by a capture
 /// backend. Because every [`PressToken`] has exactly one terminal event, this
 /// map gives release, cancellation, invalidation, shutdown, and unwinding one
 /// RAII path.
-#[derive(Default)]
-struct HeldShortcuts {
-    by_press: HashMap<PressToken, openlogi_inject::HeldChord>,
+struct HeldOutputs {
+    by_press: HashMap<PressToken, HeldOutput>,
+    horizontal_scroll: HorizontalScrollState,
 }
 
-impl HeldShortcuts {
-    fn start(&mut self, press: &PressToken, action: &Action) -> bool {
-        let Some(combo) = action.held_combo() else {
-            return false;
-        };
-        match self.by_press.entry(press.clone()) {
-            std::collections::hash_map::Entry::Occupied(mut held) => {
-                held.get_mut().replace(combo);
-            }
-            std::collections::hash_map::Entry::Vacant(slot) => {
-                slot.insert(openlogi_inject::press_hold(combo));
-            }
+impl HeldOutputs {
+    fn new(horizontal_scroll: HorizontalScrollState) -> Self {
+        Self {
+            by_press: HashMap::new(),
+            horizontal_scroll,
         }
+    }
+
+    fn start(&mut self, press: &PressToken, action: &Action) -> bool {
+        let output = match action {
+            Action::HoldShortcut(combo) => HeldOutput::Chord {
+                _held: openlogi_inject::press_hold(combo),
+            },
+            Action::HorizontalScroll => HeldOutput::HorizontalScroll,
+            _ => return false,
+        };
+        self.by_press.insert(press.clone(), output);
+        self.publish_horizontal_scroll();
         true
     }
 
     fn end(&mut self, press: &PressToken) {
-        self.by_press.remove(press);
+        if self.by_press.remove(press).is_some() {
+            self.publish_horizontal_scroll();
+        }
+    }
+
+    fn publish_horizontal_scroll(&self) {
+        self.horizontal_scroll.publish(
+            self.by_press
+                .values()
+                .any(|output| matches!(output, HeldOutput::HorizontalScroll)),
+        );
+    }
+}
+
+impl Drop for HeldOutputs {
+    fn drop(&mut self) {
+        self.horizontal_scroll.publish(false);
     }
 }
 
@@ -152,14 +198,14 @@ impl ActionExecutor {
 
 struct ButtonEventHandler {
     executor: ActionExecutor,
-    held: HeldShortcuts,
+    held: HeldOutputs,
 }
 
 impl ButtonEventHandler {
-    fn new(executor: ActionExecutor) -> Self {
+    fn new(executor: ActionExecutor, horizontal_scroll: HorizontalScrollState) -> Self {
         Self {
             executor,
-            held: HeldShortcuts::default(),
+            held: HeldOutputs::new(horizontal_scroll),
         }
     }
 
@@ -202,6 +248,7 @@ impl ButtonEventHandler {
 pub struct ActionDispatcher {
     executor: ActionExecutor,
     buttons: ButtonInputHandle,
+    horizontal_scroll: HorizontalScrollState,
 }
 
 /// Unique owner of the button worker plus its cloneable action dispatcher.
@@ -231,13 +278,16 @@ impl ActionRuntime {
             device_io,
             action_ring,
         };
-        let mut button_handler = ButtonEventHandler::new(executor.clone());
+        let horizontal_scroll = HorizontalScrollState::default();
+        let mut button_handler =
+            ButtonEventHandler::new(executor.clone(), horizontal_scroll.clone());
         let buttons = ButtonRuntimeOwner::spawn(move |event| button_handler.handle(event))?;
         let input = buttons.input();
         Ok(Self {
             dispatcher: ActionDispatcher {
                 executor,
                 buttons: input,
+                horizontal_scroll,
             },
             buttons,
         })
@@ -259,6 +309,12 @@ impl ActionDispatcher {
     /// Route one action without blocking the input callback.
     pub fn dispatch(&self, action: &Action, device_key: Option<&str>) {
         self.executor.dispatch(action, device_key);
+    }
+
+    /// Whether any accepted live press currently owns the
+    /// vertical-to-horizontal main-wheel modifier.
+    pub(crate) fn horizontal_scroll_active(&self) -> bool {
+        self.horizontal_scroll.active()
     }
 
     /// Queue one OS-hook down edge without blocking the callback. The returned
@@ -380,9 +436,34 @@ mod tests {
     #[test]
     fn instantaneous_actions_do_not_enter_held_state() {
         let press = PressToken::hook_for_test(1, ButtonId::Back);
-        let mut held = HeldShortcuts::default();
+        let mut held = HeldOutputs::new(HorizontalScrollState::default());
 
         assert!(!held.start(&press, &Action::Copy));
         held.end(&press);
+    }
+
+    #[test]
+    fn horizontal_scroll_holds_are_selection_independent_and_balanced() {
+        let state = HorizontalScrollState::default();
+        let mut held = HeldOutputs::new(state.clone());
+        let first = PressToken::hidpp_for_test(1, "mouse-a", 7, ButtonId::DpiToggle);
+        let second = PressToken::hidpp_for_test(2, "mouse-b", 3, ButtonId::DpiToggle);
+
+        assert!(!state.active());
+        assert!(held.start(&first, &Action::HorizontalScroll));
+        assert!(state.active());
+
+        assert!(held.start(&second, &Action::HorizontalScroll));
+        assert!(state.active());
+
+        held.end(&first);
+        assert!(state.active());
+
+        held.end(&second);
+        assert!(!state.active());
+
+        assert!(held.start(&first, &Action::HorizontalScroll));
+        drop(held);
+        assert!(!state.active());
     }
 }

--- a/crates/openlogi-agent-core/src/runtime/button.rs
+++ b/crates/openlogi-agent-core/src/runtime/button.rs
@@ -161,6 +161,17 @@ impl PressToken {
             generation: 0,
         }
     }
+
+    pub(crate) fn hidpp_for_test(id: u64, device_key: &str, epoch: u64, button: ButtonId) -> Self {
+        Self {
+            id: PressId(id),
+            key: PressKey::new(
+                ButtonSource::Hidpp(HidppSessionId::with_epoch(device_key, epoch)),
+                button,
+            ),
+            generation: 0,
+        }
+    }
 }
 
 /// State retained from `Down` until the exactly-once terminal event.

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -416,7 +416,7 @@ fn handle_key(
     };
 
     info!(keycode, action = %action.label(), "key → executing bound action");
-    let queued = if action.held_combo().is_some() {
+    let queued = if action.requires_press_lifecycle() {
         let queued = dispatcher.try_hook_key_down(keycode, &action);
         if queued {
             HELD_KEYS.with_borrow_mut(|keys| {
@@ -487,14 +487,19 @@ pub fn start(
                         return queued_event_disposition(try_queue_action(&action_tx, action));
                     }
                     if scroll_source_may_intercept(from_trackpad, device.as_ref()) {
-                        return queued_event_disposition(scroll.try_hook_scroll(delta));
+                        let queued = if dispatcher.horizontal_scroll_active() {
+                            scroll.try_hook_horizontal_scroll(delta)
+                        } else {
+                            scroll.try_hook_scroll(delta)
+                        };
+                        return queued_event_disposition(queued);
                     }
                     EventDisposition::PassThrough
                 }
             }
         }
         // Function-key remapper: ordinary actions remain one-shot, while a
-        // HoldShortcut enters the same down/up/cancel lifecycle as a mouse
+        // held action enters the same down/up/cancel lifecycle as a mouse
         // button. The active set pairs key-up even if modifier state or config
         // changes while the key is down.
         HookEvent::Key(event) => handle_key(event, &keyboard_bindings, &action_tx, &dispatcher),

--- a/crates/openlogi-agent-core/src/runtime/scroll.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll.rs
@@ -2,9 +2,10 @@
 //!
 //! Hook callbacks submit typed wheel impulses through [`ScrollInputHandle`]
 //! without blocking. The worker either scales and emits them directly or
-//! evaluates finite smooth motion from absolute timestamps. Pixel-precise input
-//! never enters this runtime, so native trackpad and continuous wheel streams
-//! cannot be mixed with wheel ticks.
+//! evaluates finite smooth motion from absolute timestamps. Eligible
+//! pixel-precise mouse-wheel input may use the worker's direct-output path, but
+//! never enters the wheel-tick smoothing model; native trackpads are rejected
+//! before submission.
 
 mod worker;
 
@@ -63,10 +64,6 @@ impl WheelDelta {
     fn with_vertical_scale(self, factor: f64) -> Option<Self> {
         let y = self.y * factor;
         y.is_finite().then_some(Self { x: self.x, y })
-    }
-
-    fn post(self) {
-        openlogi_inject::post_scroll(self.into());
     }
 }
 

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -86,16 +86,15 @@ impl ScrollPreferences {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum ScrollOutputMode {
-    Smooth { at: Instant },
-    Direct,
+    Smooth { impulse: WheelDelta, at: Instant },
+    Direct(ScrollDelta),
 }
 
 struct ScrollInput {
     generation: u64,
     source: ScrollSource,
-    impulse: WheelDelta,
     output: ScrollOutputMode,
 }
 
@@ -201,13 +200,50 @@ impl ScrollInputHandle {
             return false;
         };
         let output = if preferences.smooth_scroll {
-            ScrollOutputMode::Smooth { at: Instant::now() }
+            ScrollOutputMode::Smooth {
+                impulse: scaled,
+                at: Instant::now(),
+            }
         } else if scaled != impulse {
-            ScrollOutputMode::Direct
+            ScrollOutputMode::Direct(scaled.into())
         } else {
             return false;
         };
-        self.try_enqueue(ScrollSource::current_hook(), scaled, output)
+        self.try_enqueue(ScrollSource::current_hook(), output)
+    }
+
+    /// Queue a main-wheel impulse with its vertical axis rotated onto the
+    /// horizontal axis. Rolling up becomes left and rolling down becomes
+    /// right, matching the existing discrete horizontal-scroll actions.
+    ///
+    /// The physical event is suppressed only after this non-blocking enqueue
+    /// succeeds. Pixel-precise Logitech free-spin input keeps its native unit
+    /// and is emitted directly by the worker; ordinary wheel ticks still use
+    /// smooth scrolling when that setting is enabled.
+    #[must_use]
+    pub fn try_hook_horizontal_scroll(&self, delta: ScrollDelta) -> bool {
+        if !self.accepting.load(Ordering::Acquire) || !delta.is_finite() || delta.y() == 0.0 {
+            return false;
+        }
+        let preferences = self.preferences.load();
+        let horizontal = -(delta.y() * preferences.vertical_sensitivity.scroll_multiplier());
+        if !horizontal.is_finite() || horizontal == 0.0 {
+            return false;
+        }
+        let transformed = match delta {
+            ScrollDelta::Pixels { .. } => ScrollDelta::pixels(horizontal, 0.0),
+            ScrollDelta::WheelTicks { .. } => ScrollDelta::wheel_ticks(horizontal, 0.0),
+        };
+        let output = match transformed {
+            ScrollDelta::WheelTicks { x, y } if preferences.smooth_scroll => {
+                ScrollOutputMode::Smooth {
+                    impulse: WheelDelta { x, y },
+                    at: Instant::now(),
+                }
+            }
+            _ => ScrollOutputMode::Direct(transformed),
+        };
+        self.try_enqueue(ScrollSource::current_hook(), output)
     }
 
     /// Queue one diverted thumb-wheel impulse from an active HID++ session.
@@ -224,21 +260,17 @@ impl ScrollInputHandle {
         };
         self.try_enqueue(
             ScrollSource::Hidpp(session.clone()),
-            impulse,
-            ScrollOutputMode::Smooth { at: Instant::now() },
+            ScrollOutputMode::Smooth {
+                impulse,
+                at: Instant::now(),
+            },
         )
     }
 
-    fn try_enqueue(
-        &self,
-        source: ScrollSource,
-        impulse: WheelDelta,
-        output: ScrollOutputMode,
-    ) -> bool {
+    fn try_enqueue(&self, source: ScrollSource, output: ScrollOutputMode) -> bool {
         let input = ScrollInput {
             generation: self.generation.load(Ordering::Acquire),
             source,
-            impulse,
             output,
         };
         match self.commands.try_send(ScrollCommand::Input(input)) {
@@ -308,13 +340,13 @@ pub struct ScrollRuntime {
 impl ScrollRuntime {
     /// Start the dedicated output worker using the live scroll settings.
     pub fn spawn(preferences: Arc<ScrollPreferences>) -> io::Result<Self> {
-        Self::spawn_with(preferences, ScrollFrame::post, WheelDelta::post)
+        Self::spawn_with(preferences, ScrollFrame::post, openlogi_inject::post_scroll)
     }
 
     pub(super) fn spawn_with(
         preferences: Arc<ScrollPreferences>,
         mut emit_smooth: impl FnMut(ScrollFrame) + Send + 'static,
-        mut emit_direct: impl FnMut(WheelDelta) + Send + 'static,
+        mut emit_direct: impl FnMut(ScrollDelta) + Send + 'static,
     ) -> io::Result<Self> {
         let (commands, command_rx) = mpsc::sync_channel(INPUT_QUEUE_CAPACITY);
         let (controls, control_rx) = mpsc::channel();
@@ -397,7 +429,7 @@ fn run_worker(
     shared_generation: &AtomicU64,
     preferences: &ScrollPreferences,
     emit_smooth: &mut impl FnMut(ScrollFrame),
-    emit_direct: &mut impl FnMut(WheelDelta),
+    emit_direct: &mut impl FnMut(ScrollDelta),
 ) {
     let mut engine = ScrollEngine::default();
     // An overflow-cancelled incarnation stays tombstoned so accepted input that
@@ -444,12 +476,14 @@ fn run_worker(
         match command {
             Ok(ScrollCommand::Input(input)) if cancellations.accepts(&input) => {
                 match input.output {
-                    ScrollOutputMode::Smooth { at } if preferences.smooth_scroll_enabled() => {
-                        engine.impulse(input.source, input.impulse, at, emit_smooth);
+                    ScrollOutputMode::Smooth { impulse, at }
+                        if preferences.smooth_scroll_enabled() =>
+                    {
+                        engine.impulse(input.source, impulse, at, emit_smooth);
                     }
-                    ScrollOutputMode::Direct => {
+                    ScrollOutputMode::Direct(delta) => {
                         engine.cancel_source(&input.source, emit_smooth);
-                        emit_direct(input.impulse);
+                        emit_direct(delta);
                     }
                     ScrollOutputMode::Smooth { .. } => {}
                 }
@@ -538,8 +572,10 @@ mod tests {
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(2.0, 2.0)));
 
         let queued = queued_input(&receiver);
-        assert_eq!(queued.impulse, WheelDelta { x: 2.0, y: 1.0 });
-        assert!(matches!(queued.output, ScrollOutputMode::Direct));
+        assert_eq!(
+            queued.output,
+            ScrollOutputMode::Direct(ScrollDelta::wheel_ticks(2.0, 1.0))
+        );
     }
 
     #[test]
@@ -548,8 +584,13 @@ mod tests {
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(2.0, 2.0)));
 
         let queued = queued_input(&receiver);
-        assert_eq!(queued.impulse, WheelDelta { x: 2.0, y: 1.0 });
-        assert!(matches!(queued.output, ScrollOutputMode::Smooth { .. }));
+        assert!(matches!(
+            queued.output,
+            ScrollOutputMode::Smooth {
+                impulse: WheelDelta { x: 2.0, y: 1.0 },
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -559,8 +600,13 @@ mod tests {
         assert!(input.try_hidpp_scroll(&session, ScrollDelta::wheel_ticks(0.0, 2.0)));
 
         let queued = queued_input(&receiver);
-        assert_eq!(queued.impulse, WheelDelta { x: 0.0, y: 2.0 });
-        assert!(matches!(queued.output, ScrollOutputMode::Smooth { .. }));
+        assert!(matches!(
+            queued.output,
+            ScrollOutputMode::Smooth {
+                impulse: WheelDelta { x: 0.0, y: 2.0 },
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -573,14 +619,51 @@ mod tests {
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 2.0)));
         assert!(matches!(
             queued_input(&receiver).output,
-            ScrollOutputMode::Direct
+            ScrollOutputMode::Direct(ScrollDelta::WheelTicks { .. })
         ));
 
         preferences.publish(true, sensitivity(28));
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
         let queued = queued_input(&receiver);
-        assert_eq!(queued.impulse, WheelDelta { x: 0.0, y: 2.0 });
-        assert!(matches!(queued.output, ScrollOutputMode::Smooth { .. }));
+        assert!(matches!(
+            queued.output,
+            ScrollOutputMode::Smooth {
+                impulse: WheelDelta { x: 0.0, y: 2.0 },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn horizontal_modifier_rotates_scaled_wheel_ticks_and_smooths_when_enabled() {
+        let (direct, receiver, _controls) = standalone_input(1, preferences(false, 7));
+        assert!(direct.try_hook_horizontal_scroll(ScrollDelta::wheel_ticks(4.0, 2.0)));
+        assert_eq!(
+            queued_input(&receiver).output,
+            ScrollOutputMode::Direct(ScrollDelta::wheel_ticks(-1.0, 0.0))
+        );
+
+        let (smooth, receiver, _controls) = standalone_input(1, preferences(true, 28));
+        assert!(smooth.try_hook_horizontal_scroll(ScrollDelta::wheel_ticks(0.0, -1.0)));
+        assert!(matches!(
+            queued_input(&receiver).output,
+            ScrollOutputMode::Smooth {
+                impulse: WheelDelta { x: 2.0, y: 0.0 },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn horizontal_modifier_preserves_free_spin_pixel_units_and_fails_open() {
+        let (input, receiver, _controls) = standalone_input(1, preferences(true, 14));
+        assert!(!input.try_hook_horizontal_scroll(ScrollDelta::pixels(2.0, 0.0)));
+        assert!(input.try_hook_horizontal_scroll(ScrollDelta::pixels(2.0, 3.5)));
+        assert!(!input.try_hook_horizontal_scroll(ScrollDelta::pixels(0.0, 1.0)));
+        assert_eq!(
+            queued_input(&receiver).output,
+            ScrollOutputMode::Direct(ScrollDelta::pixels(-3.5, 0.0))
+        );
     }
 
     #[test]
@@ -669,8 +752,7 @@ mod tests {
         let input = |session: &HidppSessionId, generation| ScrollInput {
             generation,
             source: ScrollSource::Hidpp(session.clone()),
-            impulse: WheelDelta { x: 0.0, y: 1.0 },
-            output: ScrollOutputMode::Direct,
+            output: ScrollOutputMode::Direct(ScrollDelta::wheel_ticks(0.0, 1.0)),
         };
         let mut cancellations = OverflowCancellations::new(0);
         cancellations.cancel(&cancelled, 0);
@@ -724,8 +806,10 @@ mod tests {
             .send(ScrollCommand::Input(ScrollInput {
                 generation: 1,
                 source: ScrollSource::Hidpp(session.clone()),
-                impulse: WheelDelta { x: 0.0, y: 1.0 },
-                output: ScrollOutputMode::Smooth { at: Instant::now() },
+                output: ScrollOutputMode::Smooth {
+                    impulse: WheelDelta { x: 0.0, y: 1.0 },
+                    at: Instant::now(),
+                },
             }))
             .expect("worker command channel remains open");
         assert_eq!(
@@ -806,7 +890,7 @@ mod tests {
                 .recv_timeout(Duration::from_secs(1))
                 .expect("direct worker output")
                 .expect("output must be direct"),
-            WheelDelta { x: 3.0, y: 1.0 }
+            ScrollDelta::wheel_ticks(3.0, 1.0)
         );
         runtime.shutdown();
     }

--- a/crates/openlogi-core/src/binding/action.rs
+++ b/crates/openlogi-core/src/binding/action.rs
@@ -187,6 +187,15 @@ pub enum Action {
     /// cancellation and shutdown. Dispatchers without a release context must
     /// degrade this action to a balanced tap rather than leave keys held.
     HoldShortcut(KeyCombo),
+    /// While the originating physical control remains held, convert vertical
+    /// main-wheel input into horizontal scrolling. Rolling up scrolls left;
+    /// rolling down scrolls right. The modifier applies only to ordinary mouse
+    /// wheels, never trackpads.
+    ///
+    /// Lifecycle-aware runtimes clear the modifier on every terminal press
+    /// outcome. One-shot dispatchers deliberately do nothing because there is
+    /// no matching release with which to balance the state.
+    HorizontalScroll,
 }
 
 /// One step in a [`Action::Workflow`]. A workflow is a `Vec<WorkflowStep>`
@@ -285,6 +294,7 @@ macro_rules! for_each_unit_action {
             ScrollDown "Scroll Down" "actions.scroll_down" Scroll ArrowDown,
             HorizontalScrollLeft "Scroll Left" "actions.scroll_left" Scroll ScrollLeft,
             HorizontalScrollRight "Scroll Right" "actions.scroll_right" Scroll ScrollRight,
+            HorizontalScroll "Horizontal Scroll" "pointer.horizontal_scroll" Scroll ScrollLeft,
         }
     };
 }
@@ -401,5 +411,12 @@ impl Action {
             Self::HoldShortcut(combo) => Some(combo),
             _ => None,
         }
+    }
+
+    /// Whether this action needs the originating physical press to remain
+    /// alive until a matching release or cancellation arrives.
+    #[must_use]
+    pub const fn requires_press_lifecycle(&self) -> bool {
+        matches!(self, Self::HoldShortcut(_) | Self::HorizontalScroll)
     }
 }

--- a/crates/openlogi-core/src/binding/action_ring.rs
+++ b/crates/openlogi-core/src/binding/action_ring.rs
@@ -109,6 +109,10 @@ pub enum RingActionError {
     /// A ring cannot recursively open itself.
     #[error("Show Actions Ring cannot be assigned inside an Actions Ring")]
     RecursiveTrigger,
+    /// A ring activation has no physical release with which to balance a held
+    /// action's lifecycle.
+    #[error("actions that require a held press cannot be assigned inside an Actions Ring")]
+    RequiresHeldPress,
 }
 
 /// An action that is valid inside an Actions Ring.
@@ -145,6 +149,7 @@ fn validate_ring_action(action: &Action) -> Result<(), RingActionError> {
     match action {
         Action::None => Err(RingActionError::EmptyAction),
         Action::ShowActionsRing => Err(RingActionError::RecursiveTrigger),
+        Action::HorizontalScroll => Err(RingActionError::RequiresHeldPress),
         _ => Ok(()),
     }
 }
@@ -361,6 +366,10 @@ mod tests {
         assert_eq!(
             RingAction::new(Action::ShowActionsRing),
             Err(RingActionError::RecursiveTrigger)
+        );
+        assert_eq!(
+            RingAction::new(Action::HorizontalScroll),
+            Err(RingActionError::RequiresHeldPress)
         );
     }
 

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -1,6 +1,6 @@
 //! A platform-neutral synthesis IR.
 //!
-//! [`Action`] has one variant per user-facing behaviour (52 of them), but the
+//! [`Action`] has one variant per user-facing behaviour (54 of them), but the
 //! three `openlogi-inject` backends don't care about most of that
 //! granularity — they care about *mechanism*: "press this chord", "click
 //! this mouse button", "fire this media key", "there is no portable way to
@@ -62,8 +62,8 @@ pub enum Effect<'a> {
     /// Type this text via unicode input.
     Text(&'a str),
     /// Handled entirely by the agent/hook layer — DPI presets, SmartShift,
-    /// the Actions Ring, and launching an application. The injector logs
-    /// and does nothing.
+    /// the Actions Ring, held scroll modifiers, and launching an application.
+    /// The injector logs and does nothing.
     ///
     /// [`Action::OpenApplication`] is included here even though
     /// `openlogi_inject::execute` does open it: that happens in the
@@ -266,7 +266,8 @@ impl Action {
             | Action::SetDpiPreset(_)
             | Action::ToggleSmartShift
             | Action::ShowActionsRing
-            | Action::OpenApplication(_) => Effect::AgentSide,
+            | Action::OpenApplication(_)
+            | Action::HorizontalScroll => Effect::AgentSide,
 
             Action::ScrollUp => Effect::Scroll { dx: 0, dy: 1 },
             Action::ScrollDown => Effect::Scroll { dx: 0, dy: -1 },

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -48,7 +48,18 @@ fn hold_shortcut_has_distinct_lifecycle_semantics() {
     assert_eq!(held.category(), Category::Editing);
     assert_eq!(held.held_combo(), Some(&combo));
     assert_matches!(held.effect(), Effect::HeldKey(actual) if actual == &combo);
+    assert!(held.requires_press_lifecycle());
     assert_eq!(Action::CustomShortcut(combo).held_combo(), None);
+}
+
+#[test]
+fn horizontal_scroll_is_a_pickable_held_modifier() {
+    assert!(Action::catalog().contains(&Action::HorizontalScroll));
+    assert_eq!(Action::HorizontalScroll.category(), Category::Scroll);
+    assert_eq!(Action::HorizontalScroll.held_combo(), None);
+    assert!(Action::HorizontalScroll.requires_press_lifecycle());
+    assert_matches!(Action::HorizontalScroll.effect(), Effect::AgentSide);
+    assert!(!Action::Copy.requires_press_lifecycle());
 }
 
 #[test]
@@ -346,6 +357,7 @@ fn persisted_action_variant_names_are_stable() {
         "Find",
         "HorizontalScrollLeft",
         "HorizontalScrollRight",
+        "HorizontalScroll",
         "HoldShortcut",
         "LaunchpadShow",
         "LeftClick",
@@ -465,6 +477,7 @@ fn category_scroll_variants() {
     assert_eq!(Action::ScrollDown.category(), Category::Scroll);
     assert_eq!(Action::HorizontalScrollLeft.category(), Category::Scroll);
     assert_eq!(Action::HorizontalScrollRight.category(), Category::Scroll);
+    assert_eq!(Action::HorizontalScroll.category(), Category::Scroll);
 }
 
 #[test]
@@ -618,6 +631,7 @@ fn power_user_and_device_side_actions_lower_to_the_expected_bucket() {
         Action::SetDpiPreset(2),
         Action::ToggleSmartShift,
         Action::ShowActionsRing,
+        Action::HorizontalScroll,
     ] {
         assert_matches!(action.effect(), Effect::AgentSide);
     }

--- a/crates/openlogi-desktop/src/features/mouse/geometry.rs
+++ b/crates/openlogi-desktop/src/features/mouse/geometry.rs
@@ -230,9 +230,9 @@ fn map_slot_name(name: &str) -> Option<MouseControlId> {
         }
         "SLOT_NAME_BACK_BUTTON" => Some(MouseControlId::Button(ButtonId::Back)),
         "SLOT_NAME_FORWARD_BUTTON" => Some(MouseControlId::Button(ButtonId::Forward)),
-        "SLOT_NAME_MODESHIFT_BUTTON" | "SLOT_NAME_DPI_BUTTON" => {
-            Some(MouseControlId::Button(ButtonId::DpiToggle))
-        }
+        "SLOT_NAME_MODESHIFT_BUTTON"
+        | "SLOT_NAME_DPI_BUTTON"
+        | "SLOT_NAME_CHANGE_POINTER_SPEED" => Some(MouseControlId::Button(ButtonId::DpiToggle)),
         "SLOT_NAME_THUMBWHEEL" => Some(MouseControlId::ThumbwheelRotation),
         "SLOT_NAME_GESTURE_BUTTON" => Some(MouseControlId::Button(ButtonId::GestureButton)),
         // The MX Master 4 Haptic Sense Panel. Logi names the slot after its
@@ -280,6 +280,10 @@ mod tests {
         );
         assert_eq!(
             map_slot_name("SLOT_NAME_DPI_BUTTON"),
+            Some(MouseControlId::Button(ButtonId::DpiToggle))
+        );
+        assert_eq!(
+            map_slot_name("SLOT_NAME_CHANGE_POINTER_SPEED"),
             Some(MouseControlId::Button(ButtonId::DpiToggle))
         );
     }

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -101,6 +101,7 @@ pub(crate) fn action_icon_path(action: &Action) -> &'static str {
         Action::ScrollDown => "action-icons/chevrons-down.svg",
         Action::HorizontalScrollLeft => "action-icons/chevrons-left.svg",
         Action::HorizontalScrollRight => "action-icons/chevrons-right.svg",
+        Action::HorizontalScroll => "action-icons/scroll-text.svg",
         Action::CustomShortcut(_) | Action::HoldShortcut(_) | Action::TypeText(_) => {
             "action-icons/keyboard.svg"
         }

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -61,7 +61,8 @@ pub use succession::Identity;
 /// v28: `Action::HoldShortcut` appended for lifecycle-held keyboard output.
 /// v29: `Agent::declare_client` + [`ClientKind`] appended — typed demand for
 ///      the macOS dormancy gate.
-pub const PROTOCOL_VERSION: u32 = 29;
+/// v30: `Action::HorizontalScroll` appended for held main-wheel axis rotation.
+pub const PROTOCOL_VERSION: u32 = 30;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -31,7 +31,7 @@ use std::fmt::Write;
 
 use bincode::Options;
 use openlogi_core::app::ForegroundApp;
-use openlogi_core::binding::{ActionRingIcon, ActionRingSlot};
+use openlogi_core::binding::{Action, ActionRingIcon, ActionRingSlot};
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{
     BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
@@ -101,7 +101,12 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 29);
+    assert_eq!(PROTOCOL_VERSION, 30);
+}
+
+#[test]
+fn appended_action_variant_order() {
+    assert_wire(&Action::HorizontalScroll, "35");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add a lifecycle-held horizontal scroll modifier for Logitech controls, including the MX Ergo S pointer-speed button exposed by its asset metadata.

<img width="1279" height="844" alt="截屏2026-09-01 08 52 15" src="https://github.com/user-attachments/assets/0fd5c232-e984-413e-b91a-f3f64dbc3bf8" />

## Changes

- **openlogi-core**
  - add the append-only `HorizontalScroll` action and lifecycle metadata
  - reject it from Actions Ring slots that cannot provide a physical release
- **openlogi-agent-core**
  - track accepted held modifiers through release, cancellation, invalidation, shutdown, and unwind
  - rotate eligible main-wheel vertical input onto the horizontal axis
  - preserve ratchet smoothing and free-spin pixel units, skip trackpads, and fail open on queue rejection
  - keep the held state independent of the UI-selected device
- **openlogi-desktop**
  - expose an icon for the action picker
  - map MX Ergo S `SLOT_NAME_CHANGE_POINTER_SPEED` metadata to `DpiToggle`
- **openlogi-ipc**
  - bump the protocol to v30 and pin the appended action wire value

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace --no-fail-fast`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci clippy-windows wasm`
  - skipped: Windows proxy because the `x86_64-pc-windows-gnu` standard library is unavailable
  - skipped: WASM portability because the `wasm32-unknown-unknown` standard library is unavailable
- Verified that the action is present and selectable in the macOS dev UI for an attached MX Ergo S.
- Not runtime-tested on hardware. Manual check: bind the MX Ergo S pointer-speed button to Horizontal Scroll, hold it while rolling the main wheel, verify up maps left and down maps right, then release and confirm vertical scrolling resumes; confirm trackpad scrolling remains native.

Fixes #1053