### PR TITLE
feat: wire up ModeStatus (0x8090) performance/endurance switching

### DIFF
--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -50,8 +50,8 @@ use openlogi_core::hid::LOGITECH_VENDOR_ID;
 use openlogi_core::single_instance::{self, InstanceError};
 use openlogi_hid::{
     DIRECT_DEVICE_INDEX, DeviceRoute, Dpi, DpiCapabilities, DpiInfo, LITRA_GLOW_PRODUCT_ID,
-    LightCommand, PasskeyMethod, ReceiverSelector, SmartShiftAutoDisengage, SmartShiftMode,
-    SmartShiftStatus, TunableTorque, WriteError,
+    LightCommand, PasskeyMethod, PowerMode, PowerModeState, ReceiverSelector,
+    SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, TunableTorque, WriteError,
 };
 use openlogi_ipc::transport;
 use openlogi_ipc::{
@@ -235,6 +235,7 @@ struct DpiState {
 struct DeviceSettings {
     dpi: Option<DpiState>,
     smartshift: Option<SmartShiftStatus>,
+    power_mode: Option<PowerModeState>,
     lighting: bool,
 }
 
@@ -243,6 +244,7 @@ impl DeviceSettings {
         Self {
             dpi: None,
             smartshift: None,
+            power_mode: None,
             lighting: false,
         }
     }
@@ -302,6 +304,12 @@ impl State {
                     ),
                     tunable_torque: Some(MOCK_TORQUE),
                 }),
+                // A G305-shaped seed: ships in endurance, software switch only.
+                power_mode: Some(PowerModeState {
+                    mode: PowerMode::Endurance,
+                    software_switch: true,
+                    hardware_switch: false,
+                }),
                 lighting: false,
             },
         );
@@ -311,6 +319,7 @@ impl State {
             DeviceSettings {
                 dpi: None,
                 smartshift: None,
+                power_mode: None,
                 lighting: true,
             },
         );
@@ -322,6 +331,7 @@ impl State {
                     capabilities: DpiCapabilities::new((400u16..=4000).step_by(100).collect())?,
                 }),
                 smartshift: None,
+                power_mode: None,
                 lighting: false,
             },
         );
@@ -911,6 +921,39 @@ impl Agent for MockAgent {
             .ok_or(WriteError::FeatureUnsupported {
                 feature_hex: 0x2110,
             })
+    }
+
+    async fn read_power_mode(
+        self,
+        _: Context,
+        route: DeviceRoute,
+    ) -> Result<PowerModeState, WriteError> {
+        let state = self.state.lock().await;
+        state
+            .settings_for(&route)?
+            .power_mode
+            .ok_or(WriteError::FeatureUnsupported {
+                feature_hex: 0x8090,
+            })
+    }
+
+    async fn set_power_mode(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        mode: PowerMode,
+    ) -> Result<(), WriteError> {
+        let mut state = self.state.lock().await;
+        let settings = state.settings_for_mut(&route)?;
+        let power_mode = settings
+            .power_mode
+            .as_mut()
+            .ok_or(WriteError::FeatureUnsupported {
+                feature_hex: 0x8090,
+            })?;
+        power_mode.mode = mode;
+        info!(%route, ?mode, "set_power_mode");
+        Ok(())
     }
 
     async fn request_accessibility_prompt(self, _: Context) {

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -19,8 +19,8 @@ use openlogi_core::binding::ActionRingSlot;
 use openlogi_core::config::{Config, Lighting};
 use openlogi_core::device::DeviceInventory;
 use openlogi_hid::{
-    DeviceRoute, Dpi, DpiInfo, HapticWaveform, HidppOperation, LightCommand, ReceiverSelector,
-    SmartShiftStatus, WriteError,
+    DeviceRoute, Dpi, DpiInfo, HapticWaveform, HidppOperation, LightCommand, PowerMode,
+    PowerModeState, ReceiverSelector, SmartShiftStatus, WriteError,
 };
 use openlogi_ipc::transport;
 use openlogi_ipc::{
@@ -205,6 +205,33 @@ impl Agent for AgentServer {
             .device(&route)
             .run(HidppOperation::ReadSmartShift, |c| async move {
                 openlogi_hid::get_smartshift_status_on(&c).await
+            })
+            .await
+    }
+
+    async fn read_power_mode(
+        self,
+        _: Context,
+        route: DeviceRoute,
+    ) -> Result<PowerModeState, WriteError> {
+        self.shared
+            .device(&route)
+            .run(HidppOperation::ReadPowerMode, |c| async move {
+                openlogi_hid::get_power_mode_on(&c).await
+            })
+            .await
+    }
+
+    async fn set_power_mode(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        mode: PowerMode,
+    ) -> Result<(), WriteError> {
+        self.shared
+            .device(&route)
+            .run(HidppOperation::WritePowerMode, |c| async move {
+                openlogi_hid::set_power_mode_on(&c, mode).await
             })
             .await
     }

--- a/crates/openlogi-cli/src/cmd/diag.rs
+++ b/crates/openlogi-cli/src/cmd/diag.rs
@@ -15,6 +15,7 @@ pub mod controls;
 pub mod dpi;
 pub mod features;
 pub mod lighting;
+pub mod power_mode;
 pub mod smartshift;
 pub mod wheel;
 
@@ -30,6 +31,8 @@ pub enum DiagCmd {
     Dpi(dpi::DpiArgs),
     /// Read SmartShift mode → toggle → read back → toggle back → report.
     Smartshift(smartshift::SmartshiftArgs),
+    /// Read the 0x8090 power mode → toggle → read back → restore → report.
+    PowerMode(power_mode::PowerModeArgs),
     /// Set a wired RGB keyboard to a solid colour (e.g. `ff0000` for red).
     Lighting(lighting::LightingArgs),
     /// Read or set the HID++ 0x2121 wheel reporting resolution.
@@ -44,6 +47,7 @@ impl DiagCmd {
             Self::Battery(args) => battery::run(args).await,
             Self::Dpi(args) => dpi::run(args).await,
             Self::Smartshift(args) => smartshift::run(args).await,
+            Self::PowerMode(args) => power_mode::run(args).await,
             Self::Lighting(args) => lighting::run(args).await,
             Self::Wheel(args) => wheel::run(args).await,
         }

--- a/crates/openlogi-cli/src/cmd/diag/power_mode.rs
+++ b/crates/openlogi-cli/src/cmd/diag/power_mode.rs
@@ -1,0 +1,95 @@
+//! `openlogi diag power-mode` — 0x8090 performance/endurance round-trip.
+
+use anyhow::{Context, Result};
+use clap::{Args, ValueEnum};
+use openlogi_hid::PowerMode;
+
+use crate::cmd::diag::select_device;
+
+/// CLI spelling of [`PowerMode`], so clap owns the value parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PowerModeArg {
+    /// Full report-rate range, higher battery drain.
+    Performance,
+    /// Slowest report rate only, months of battery life.
+    Endurance,
+}
+
+impl From<PowerModeArg> for PowerMode {
+    fn from(arg: PowerModeArg) -> Self {
+        match arg {
+            PowerModeArg::Performance => Self::Performance,
+            PowerModeArg::Endurance => Self::Endurance,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct PowerModeArgs {
+    /// Set the mode and leave it (skip the toggle round-trip). The device
+    /// persists the mode across power cycles.
+    #[arg(long, value_enum, value_name = "MODE")]
+    pub set: Option<PowerModeArg>,
+
+    /// Run against the device whose name contains this string
+    /// (case-insensitive) instead of auto-selecting. Useful when several
+    /// devices are paired (e.g. a mouse and a keyboard over Bluetooth).
+    #[arg(long, value_name = "NAME")]
+    pub device: Option<String>,
+}
+
+pub async fn run(args: PowerModeArgs) -> Result<()> {
+    // 0x8090 = ModeStatus — auto-skip devices that do not expose it.
+    let (route, name) = select_device(args.device.as_deref(), &[0x8090]).await?;
+    println!("device: {name} ({route})");
+
+    let before = openlogi_hid::get_power_mode(&route)
+        .await
+        .context("read power mode")?;
+    println!(
+        "  current: mode={:?} software_switch={} hardware_switch={}",
+        before.mode, before.software_switch, before.hardware_switch
+    );
+
+    if let Some(target) = args.set {
+        let target = PowerMode::from(target);
+        openlogi_hid::set_power_mode(&route, target)
+            .await
+            .context("set power mode")?;
+        let after = openlogi_hid::get_power_mode(&route)
+            .await
+            .context("read power mode after set")?;
+        println!("  read-back: mode={:?}", after.mode);
+        if after.mode != target {
+            anyhow::bail!(
+                "power-mode write not applied: requested {target:?}, device reports {:?}",
+                after.mode
+            );
+        }
+        println!("✓ power mode set to {target:?}");
+        return Ok(());
+    }
+
+    let flipped = before.mode.flipped();
+    openlogi_hid::set_power_mode(&route, flipped)
+        .await
+        .context("toggle power mode")?;
+    let after = openlogi_hid::get_power_mode(&route)
+        .await
+        .context("read power mode after toggle")?;
+    println!("  toggled to: {:?}", after.mode);
+    if after.mode != flipped {
+        anyhow::bail!(
+            "power-mode toggle had no effect: still {:?} after write",
+            after.mode
+        );
+    }
+
+    println!("  restoring mode: {:?}", before.mode);
+    openlogi_hid::set_power_mode(&route, before.mode)
+        .await
+        .context("restore power mode")?;
+
+    println!("✓ power-mode round-trip OK");
+    Ok(())
+}

--- a/crates/openlogi-cli/src/cmd/diag/power_mode.rs
+++ b/crates/openlogi-cli/src/cmd/diag/power_mode.rs
@@ -74,22 +74,44 @@ pub async fn run(args: PowerModeArgs) -> Result<()> {
     openlogi_hid::set_power_mode(&route, flipped)
         .await
         .context("toggle power mode")?;
-    let after = openlogi_hid::get_power_mode(&route)
+
+    // From here on the device may hold the flipped mode, and unlike the other
+    // diags' targets this setting persists across power cycles — so the
+    // restore write runs on every path, including a failed or unexpected
+    // confirming read.
+    let verified = verify_toggle(&route, flipped).await;
+
+    println!("  restoring mode: {:?}", before.mode);
+    let restored = openlogi_hid::set_power_mode(&route, before.mode)
+        .await
+        .context("restore power mode");
+
+    match (verified, restored) {
+        (Ok(()), Ok(())) => {
+            println!("✓ power-mode round-trip OK");
+            Ok(())
+        }
+        // The toggle itself misbehaved but the device is back in its original
+        // mode — report the diagnostic failure.
+        (Err(verify), Ok(())) => Err(verify),
+        (Ok(()), Err(restore)) => Err(restore),
+        // Both failed: the stranded device is the more urgent fact; carry the
+        // verification failure along instead of dropping it.
+        (Err(verify), Err(restore)) => Err(restore.context(format!("after: {verify:#}"))),
+    }
+}
+
+/// Read the mode back after the toggle write and check it took.
+async fn verify_toggle(route: &openlogi_hid::DeviceRoute, expected: PowerMode) -> Result<()> {
+    let after = openlogi_hid::get_power_mode(route)
         .await
         .context("read power mode after toggle")?;
     println!("  toggled to: {:?}", after.mode);
-    if after.mode != flipped {
+    if after.mode != expected {
         anyhow::bail!(
             "power-mode toggle had no effect: still {:?} after write",
             after.mode
         );
     }
-
-    println!("  restoring mode: {:?}", before.mode);
-    openlogi_hid::set_power_mode(&route, before.mode)
-        .await
-        .context("restore power mode")?;
-
-    println!("✓ power-mode round-trip OK");
     Ok(())
 }

--- a/crates/openlogi-cli/src/cmd/diag/power_mode.rs
+++ b/crates/openlogi-cli/src/cmd/diag/power_mode.rs
@@ -82,9 +82,7 @@ pub async fn run(args: PowerModeArgs) -> Result<()> {
     let verified = verify_toggle(&route, flipped).await;
 
     println!("  restoring mode: {:?}", before.mode);
-    let restored = openlogi_hid::set_power_mode(&route, before.mode)
-        .await
-        .context("restore power mode");
+    let restored = restore_and_verify(&route, before.mode).await;
 
     match (verified, restored) {
         (Ok(()), Ok(())) => {
@@ -99,6 +97,25 @@ pub async fn run(args: PowerModeArgs) -> Result<()> {
         // verification failure along instead of dropping it.
         (Err(verify), Err(restore)) => Err(restore.context(format!("after: {verify:#}"))),
     }
+}
+
+/// Write `mode` back and read it out again. An acknowledged restore that did
+/// not apply must fail the diagnostic instead of printing a green round-trip,
+/// exactly like the forward toggle.
+async fn restore_and_verify(route: &openlogi_hid::DeviceRoute, mode: PowerMode) -> Result<()> {
+    openlogi_hid::set_power_mode(route, mode)
+        .await
+        .context("restore power mode")?;
+    let after = openlogi_hid::get_power_mode(route)
+        .await
+        .context("read power mode after restore")?;
+    if after.mode != mode {
+        anyhow::bail!(
+            "power-mode restore not applied: device reports {:?}",
+            after.mode
+        );
+    }
+    Ok(())
 }
 
 /// Read the mode back after the toggle write and check it took.

--- a/crates/openlogi-cli/src/lib.rs
+++ b/crates/openlogi-cli/src/lib.rs
@@ -50,6 +50,7 @@ mod tests {
     use cmd::backlight::BacklightAction;
     use cmd::diag::DiagCmd;
     use cmd::diag::lighting::Method;
+    use cmd::diag::power_mode::PowerModeArg;
     use cmd::diag::wheel::ResolutionArg;
 
     /// Clap's own structural validation (arg ID collisions, invalid
@@ -122,6 +123,23 @@ mod tests {
         // silently becoming "no change" downstream.
         let result = Cli::try_parse_from(["openlogi", "diag", "smartshift", "--sensitivity", "0"]);
         result.expect_err("a zero --sensitivity must fail to parse");
+    }
+
+    #[test]
+    fn power_mode_set_value_is_parsed_and_bad_values_rejected() {
+        let cli = Cli::try_parse_from(["openlogi", "diag", "power-mode", "--set", "performance"])
+            .expect("valid power-mode invocation parses");
+        match cli.cmd.expect("subcommand present") {
+            Command::Diag(DiagCmd::PowerMode(args)) => {
+                assert_eq!(args.set, Some(PowerModeArg::Performance));
+                assert!(args.device.is_none());
+            }
+            other => panic!("expected Diag(PowerMode), got {other:?}"),
+        }
+
+        // An unknown mode must fail to parse rather than silently defaulting.
+        Cli::try_parse_from(["openlogi", "diag", "power-mode", "--set", "fast"])
+            .expect_err("an unknown power mode must be rejected");
     }
 
     #[test]

--- a/crates/openlogi-core/src/hid.rs
+++ b/crates/openlogi-core/src/hid.rs
@@ -11,6 +11,7 @@
 pub mod dpi;
 pub mod error;
 pub mod light;
+pub mod mode_status;
 pub mod pairing;
 pub mod route;
 pub mod smartshift;
@@ -18,6 +19,7 @@ pub mod smartshift;
 pub use dpi::{Dpi, DpiCapabilities, DpiInfo};
 pub use error::{HidppFeatureErrorKind, HidppOperation, WriteError};
 pub use light::{LightCommand, commands_for_light_settings};
+pub use mode_status::{PowerMode, PowerModeState};
 pub use pairing::{Click, PairingError, PasskeyMethod, ReceiverSelector};
 pub use route::{
     DIRECT_DEVICE_INDEX, DeviceRoute, LOGITECH_VENDOR_ID, RECEIVERS, ReceiverBrand,

--- a/crates/openlogi-core/src/hid/error.rs
+++ b/crates/openlogi-core/src/hid/error.rs
@@ -133,6 +133,12 @@ pub enum HidppOperation {
     Light,
     /// Play one haptic waveform. Appended last — variant order is wire format.
     PlayHaptic,
+    /// Read the `0x8090` power-mode status and capabilities. Appended last —
+    /// variant order is wire format.
+    ReadPowerMode,
+    /// Write the `0x8090` power mode. Appended last — variant order is wire
+    /// format.
+    WritePowerMode,
 }
 
 /// HID++ feature error kind in a serializable wire-safe form.

--- a/crates/openlogi-core/src/hid/mode_status.rs
+++ b/crates/openlogi-core/src/hid/mode_status.rs
@@ -1,0 +1,65 @@
+//! HID++ `ModeStatus` (feature `0x8090`) — the performance / endurance power
+//! mode on G-series mice (G305 and friends).
+//!
+//! The protocol-level `0x8090` wrapper lives in `openlogi-hidpp`; this module
+//! keeps OpenLogi's IPC-facing mode and capability types. Nothing here is
+//! persisted to `config.toml`: the device owns the setting and keeps it across
+//! power cycles, so the GUI only ever reads and writes the device.
+
+use serde::{Deserialize, Serialize};
+
+/// The power mode of a mouse with HID++ `0x8090 ModeStatus`.
+///
+/// Crosses the agent↔GUI IPC — serde encodes the variant *index*
+/// (Endurance = 0, Performance = 1), so variant order is wire format and
+/// changes require a `PROTOCOL_VERSION` bump (guarded by
+/// `openlogi-ipc/tests/wire_format.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PowerMode {
+    /// Low-power mode: only the slowest report rate, months of battery life.
+    Endurance,
+    /// Performance mode: the full report-rate range at higher battery drain.
+    Performance,
+}
+
+impl PowerMode {
+    /// The opposite mode — used by the CLI diag round-trip toggle.
+    #[must_use]
+    pub fn flipped(self) -> Self {
+        match self {
+            Self::Endurance => Self::Performance,
+            Self::Performance => Self::Endurance,
+        }
+    }
+}
+
+/// Snapshot returned from OpenLogi's power-mode read helpers.
+///
+/// Crosses the agent↔GUI IPC (`read_power_mode`), so field order is wire
+/// format — changes require a `PROTOCOL_VERSION` bump (guarded by
+/// `openlogi-ipc/tests/wire_format.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PowerModeState {
+    /// Current mode.
+    pub mode: PowerMode,
+    /// Software can change the mode (`getDevConfig` bit 1). Gates the GUI
+    /// toggle: a device without it only reports the mode.
+    pub software_switch: bool,
+    /// A hardware switch can change the mode (`getDevConfig` bit 0).
+    pub hardware_switch: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flipped_is_an_involution() {
+        assert_eq!(PowerMode::Endurance.flipped(), PowerMode::Performance);
+        assert_eq!(PowerMode::Performance.flipped(), PowerMode::Endurance);
+        assert_eq!(
+            PowerMode::Endurance.flipped().flipped(),
+            PowerMode::Endurance
+        );
+    }
+}

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -22,6 +22,7 @@ use crate::features::lighting::device::LightingPanel;
 use crate::features::lighting::standalone::LightPanel;
 use crate::features::mouse::view::MouseModelView;
 use crate::features::pointer::dpi::DpiPanel;
+use crate::features::pointer::power_mode::PowerModePanel;
 use crate::features::pointer::smartshift::SmartShiftPanel;
 use crate::features::profiles::{AppCatalogPicker, ProfileIconCache};
 use crate::services::assets::AssetResolver;
@@ -167,6 +168,7 @@ pub struct AppView {
     keyboard_model: Entity<FunctionRowView>,
     dpi_panel: Entity<DpiPanel>,
     smartshift_panel: Entity<SmartShiftPanel>,
+    power_mode_panel: Entity<PowerModePanel>,
     lighting_panel: Entity<LightingPanel>,
     camera_preview: Entity<CameraPreview>,
     camera_controls: Entity<CameraControlsPanel>,
@@ -191,6 +193,57 @@ pub struct AppView {
 impl Focusable for AppView {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
+    }
+}
+
+/// Whether a state event should re-render the root view. Child entities own
+/// their panels and subscribe directly; this decision covers only what the
+/// root itself draws.
+fn root_event_is_relevant(view: &AppView, event: &StateEvent, cx: &gpui::App) -> bool {
+    let active_key = AppState::try_read(cx)
+        .and_then(AppState::current_record)
+        .map(DeviceRecord::device_key);
+    let on_home = matches!(view.route, Route::Home);
+    match event {
+        StateEvent::AgentChanged | StateEvent::InventoryChanged | StateEvent::DeviceSelected(_) => {
+            true
+        }
+        StateEvent::ForegroundChanged => !on_home,
+        StateEvent::BindingsChanged(key) => {
+            !on_home
+                && matches!(
+                    view.active_tab,
+                    DetailTab::Buttons | DetailTab::ActionsRing | DetailTab::Device
+                )
+                && active_key.as_ref() == Some(key)
+        }
+        StateEvent::DpiChanged(key) => {
+            !on_home && view.active_tab == DetailTab::Device && active_key.as_ref() == Some(key)
+        }
+        StateEvent::LightingChanged(key) => {
+            on_home || (view.active_tab == DetailTab::Light && active_key.as_ref() == Some(key))
+        }
+        StateEvent::DeviceConfigChanged(key) => {
+            on_home
+                || (matches!(view.active_tab, DetailTab::Pointer | DetailTab::Device)
+                    && active_key.as_ref() == Some(key))
+        }
+        StateEvent::CameraChanged => on_home || view.active_tab == DetailTab::Light,
+        // Child entities own these surfaces and subscribe directly. A
+        // language switch already refreshes every window, and the root
+        // caches no localized text.
+        StateEvent::SmartShiftChanged(_)
+        | StateEvent::PowerModeChanged(_)
+        | StateEvent::CameraPermissionChanged
+        | StateEvent::DiagnosticsChanged
+        | StateEvent::LanguageChanged => false,
+        // App-wide settings render in their own window. The root only
+        // cares when a persistence/reload failure opens or closes its
+        // fail-closed configuration-error screen.
+        StateEvent::SettingsChanged => {
+            view.config_issue_visible
+                || AppState::try_read(cx).is_some_and(|state| state.config_issue().is_some())
+        }
     }
 }
 
@@ -229,6 +282,7 @@ impl AppView {
         let keyboard_model = cx.new(FunctionRowView::new);
         let dpi_panel = cx.new(DpiPanel::new);
         let smartshift_panel = cx.new(SmartShiftPanel::new);
+        let power_mode_panel = cx.new(PowerModePanel::new);
         let lighting_panel = cx.new(LightingPanel::new);
         let camera_preview = cx.new(CameraPreview::new);
         let camera_controls = cx.new(CameraControlsPanel::new);
@@ -237,55 +291,7 @@ impl AppView {
         let app_catalog = cx.new(|cx| AppCatalogPicker::new(profile_icons.clone(), window, cx));
         let app_catalog_obs = cx.observe(&app_catalog, |_, _, cx| cx.notify());
         let state_obs = cx.subscribe(&state, |view, _, event: &StateEvent, cx| {
-            let active_key = AppState::try_read(cx)
-                .and_then(AppState::current_record)
-                .map(DeviceRecord::device_key);
-            let on_home = matches!(view.route, Route::Home);
-            let relevant = match event {
-                StateEvent::AgentChanged
-                | StateEvent::InventoryChanged
-                | StateEvent::DeviceSelected(_) => true,
-                StateEvent::ForegroundChanged => !on_home,
-                StateEvent::BindingsChanged(key) => {
-                    !on_home
-                        && matches!(
-                            view.active_tab,
-                            DetailTab::Buttons | DetailTab::ActionsRing | DetailTab::Device
-                        )
-                        && active_key.as_ref() == Some(key)
-                }
-                StateEvent::DpiChanged(key) => {
-                    !on_home
-                        && view.active_tab == DetailTab::Device
-                        && active_key.as_ref() == Some(key)
-                }
-                StateEvent::LightingChanged(key) => {
-                    on_home
-                        || (view.active_tab == DetailTab::Light && active_key.as_ref() == Some(key))
-                }
-                StateEvent::DeviceConfigChanged(key) => {
-                    on_home
-                        || (matches!(view.active_tab, DetailTab::Pointer | DetailTab::Device)
-                            && active_key.as_ref() == Some(key))
-                }
-                StateEvent::CameraChanged => on_home || view.active_tab == DetailTab::Light,
-                // Child entities own these surfaces and subscribe directly. A
-                // language switch already refreshes every window, and the root
-                // caches no localized text.
-                StateEvent::SmartShiftChanged(_)
-                | StateEvent::CameraPermissionChanged
-                | StateEvent::DiagnosticsChanged
-                | StateEvent::LanguageChanged => false,
-                // App-wide settings render in their own window. The root only
-                // cares when a persistence/reload failure opens or closes its
-                // fail-closed configuration-error screen.
-                StateEvent::SettingsChanged => {
-                    view.config_issue_visible
-                        || AppState::try_read(cx)
-                            .is_some_and(|state| state.config_issue().is_some())
-                }
-            };
-            if relevant {
+            if root_event_is_relevant(view, event, cx) {
                 cx.notify();
             }
         });
@@ -297,6 +303,7 @@ impl AppView {
             keyboard_model,
             dpi_panel,
             smartshift_panel,
+            power_mode_panel,
             lighting_panel,
             camera_preview,
             camera_controls,
@@ -603,6 +610,7 @@ impl Render for AppView {
                         keyboard_model: &self.keyboard_model,
                         dpi_panel: &self.dpi_panel,
                         smartshift_panel: &self.smartshift_panel,
+                        power_mode_panel: &self.power_mode_panel,
                         lighting_panel: &self.lighting_panel,
                         camera_preview: &self.camera_preview,
                         camera_controls: &self.camera_controls,

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -31,6 +31,7 @@ use crate::features::lighting::standalone::LightPanel;
 use crate::features::lighting::visual as light_visual;
 use crate::features::mouse::view::MouseModelView;
 use crate::features::pointer::dpi::DpiPanel;
+use crate::features::pointer::power_mode::PowerModePanel;
 use crate::features::pointer::smartshift::SmartShiftPanel;
 use crate::features::profiles::{
     AppCatalogPicker, ProfileIconCache, action_ring_profile_scope_bar, button_profile_scope_bar,
@@ -94,6 +95,7 @@ pub(super) struct DetailPanels<'a> {
     pub keyboard_model: &'a gpui::Entity<FunctionRowView>,
     pub dpi_panel: &'a gpui::Entity<DpiPanel>,
     pub smartshift_panel: &'a gpui::Entity<SmartShiftPanel>,
+    pub power_mode_panel: &'a gpui::Entity<PowerModePanel>,
     pub lighting_panel: &'a gpui::Entity<LightingPanel>,
     pub camera_preview: &'a gpui::Entity<CameraPreview>,
     pub camera_controls: &'a gpui::Entity<CameraControlsPanel>,
@@ -123,9 +125,13 @@ pub(super) fn detail_content(
             action_ring_tab(panels.action_ring, profile_icons, app_catalog, cx).into_any_element()
         }
         DetailTab::Keys => keys_tab(panels.keyboard_model).into_any_element(),
-        DetailTab::Pointer => {
-            pointer_tab(panels.dpi_panel, panels.smartshift_panel, cx).into_any_element()
-        }
+        DetailTab::Pointer => pointer_tab(
+            panels.dpi_panel,
+            panels.smartshift_panel,
+            panels.power_mode_panel,
+            cx,
+        )
+        .into_any_element(),
         DetailTab::Lighting => lighting_tab(panels.lighting_panel).into_any_element(),
         DetailTab::Camera => {
             camera_tab(panels.camera_preview, panels.camera_controls).into_any_element()
@@ -308,6 +314,7 @@ fn action_ring_tab(
 fn pointer_tab(
     dpi_panel: &gpui::Entity<DpiPanel>,
     smartshift_panel: &gpui::Entity<SmartShiftPanel>,
+    power_mode_panel: &gpui::Entity<PowerModePanel>,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
     let pal = theme::palette(cx);
@@ -331,6 +338,14 @@ fn pointer_tab(
                     tr!("pointer.smartshift"),
                     Icon::empty().path("action-icons/refresh-cw.svg"),
                     smartshift_panel.clone().into_any_element(),
+                )
+                .fill(),
+            ))
+            .child(pointer_grid_card(
+                PanelCard::new(
+                    tr!("pointer.power_mode"),
+                    Icon::empty().path("action-icons/bolt.svg"),
+                    power_mode_panel.clone().into_any_element(),
                 )
                 .fill(),
             ))

--- a/crates/openlogi-desktop/src/features/pointer/mod.rs
+++ b/crates/openlogi-desktop/src/features/pointer/mod.rs
@@ -1,4 +1,5 @@
 //! Pointer sensitivity and wheel controls.
 
 pub mod dpi;
+pub mod power_mode;
 pub mod smartshift;

--- a/crates/openlogi-desktop/src/features/pointer/power_mode.rs
+++ b/crates/openlogi-desktop/src/features/pointer/power_mode.rs
@@ -94,16 +94,8 @@ fn ready_body(state: PowerModeState, pal: Palette) -> gpui::Div {
             h_flex()
                 .justify_between()
                 .items_center()
-                .child(
-                    v_flex()
-                        .child(section_label(tr!("pointer.performance_mode"), pal))
-                        .child(
-                            div()
-                                .text_caption()
-                                .text_color(pal.text_muted)
-                                .child(tr!("pointer.power_mode_description")),
-                        ),
-                )
+                .gap_3()
+                .child(section_label(tr!("pointer.performance_mode"), pal))
                 .child(
                     Toggle::new("power-mode-performance")
                         .selected(performance)
@@ -117,6 +109,12 @@ fn ready_body(state: PowerModeState, pal: Palette) -> gpui::Div {
                             AppState::update_power_mode(cx, mode);
                         }),
                 ),
+        )
+        .child(
+            div()
+                .text_caption()
+                .text_color(pal.text_muted)
+                .child(tr!("pointer.power_mode_description")),
         )
         .when(!state.software_switch, |body| {
             body.child(

--- a/crates/openlogi-desktop/src/features/pointer/power_mode.rs
+++ b/crates/openlogi-desktop/src/features/pointer/power_mode.rs
@@ -1,0 +1,138 @@
+//! Performance / endurance power-mode toggle for the pointer-detail column.
+//!
+//! Drives HID++ `0x8090 ModeStatus` (G305 and friends): endurance holds the
+//! slowest report rate for months of battery life, performance unlocks the
+//! full report-rate range. The device persists the mode itself, so there is
+//! no config commit — reads come from the swr-backed device query, writes go
+//! straight to the agent with a confirming re-read. The toggle greys out when
+//! `getDevConfig` reports no software switch.
+
+use gpui::prelude::FluentBuilder as _;
+use gpui::{
+    AnyElement, App, Context, IntoElement, ParentElement, Render, Styled, Subscription, Window, div,
+};
+use gpui_component::{Disableable as _, Selectable as _, h_flex, v_flex};
+use openlogi_core::hid::{PowerMode, PowerModeState};
+
+use crate::state::{AppState, DeviceKey, PowerModeLoad, StateEvent};
+use crate::ui::components::Toggle;
+use crate::ui::section::section_label;
+use crate::ui::status::{retry_line, status_line};
+use crate::ui::theme::{self, Palette, Typography as _};
+
+pub struct PowerModePanel {
+    _state_obs: Subscription,
+}
+
+impl PowerModePanel {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        let state_obs = cx.subscribe(&AppState::global(cx), |_, _, event: &StateEvent, cx| {
+            let relevant = match event {
+                StateEvent::InventoryChanged | StateEvent::DeviceSelected(_) => true,
+                StateEvent::PowerModeChanged(key) => AppState::try_read(cx)
+                    .and_then(AppState::current_record)
+                    .is_some_and(|record| record.device_key() == *key),
+                _ => false,
+            };
+            if relevant {
+                cx.notify();
+            }
+        });
+        Self {
+            _state_obs: state_obs,
+        }
+    }
+}
+
+impl Render for PowerModePanel {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let pal = theme::palette(cx);
+
+        let (key, status) = AppState::try_read(cx)
+            .and_then(|state| {
+                let key = state.current_record()?.device_key();
+                Some((Some(key.clone()), state.power_mode_status_for(&key)))
+            })
+            .unwrap_or((None, PowerModeLoad::Unknown));
+        let reachable = AppState::try_read(cx)
+            .and_then(AppState::current_record)
+            .is_some_and(|r| r.route.is_some());
+
+        let content: AnyElement = match status {
+            PowerModeLoad::Ready(state) => ready_body(*state, pal).into_any_element(),
+            PowerModeLoad::Loading | PowerModeLoad::Unknown if !reachable => {
+                status_line(tr!("pointer.device_offline_power_mode_is_unavailable"), pal)
+                    .into_any_element()
+            }
+            PowerModeLoad::Loading | PowerModeLoad::Unknown => {
+                status_line(tr!("pointer.reading_power_mode"), pal).into_any_element()
+            }
+            PowerModeLoad::Failed(_) => retry_line(
+                "power-mode-retry",
+                tr!("pointer.couldnt_read_power_mode_click_to_retry"),
+                pal,
+                retry_power_mode_closure(key),
+            )
+            .into_any_element(),
+            PowerModeLoad::Unsupported(_) => {
+                status_line(tr!("pointer.this_device_does_not_support_power_mode"), pal)
+                    .into_any_element()
+            }
+        };
+
+        v_flex().gap_3().w_full().child(content)
+    }
+}
+
+/// The interactive body shown once the device's power mode resolves.
+fn ready_body(state: PowerModeState, pal: Palette) -> gpui::Div {
+    let performance = matches!(state.mode, PowerMode::Performance);
+    v_flex()
+        .gap_2()
+        .w_full()
+        .child(
+            h_flex()
+                .justify_between()
+                .items_center()
+                .child(
+                    v_flex()
+                        .child(section_label(tr!("pointer.performance_mode"), pal))
+                        .child(
+                            div()
+                                .text_caption()
+                                .text_color(pal.text_muted)
+                                .child(tr!("pointer.power_mode_description")),
+                        ),
+                )
+                .child(
+                    Toggle::new("power-mode-performance")
+                        .selected(performance)
+                        .disabled(!state.software_switch)
+                        .on_change(|performance, _window, cx| {
+                            let mode = if *performance {
+                                PowerMode::Performance
+                            } else {
+                                PowerMode::Endurance
+                            };
+                            AppState::update_power_mode(cx, mode);
+                        }),
+                ),
+        )
+        .when(!state.software_switch, |body| {
+            body.child(
+                div()
+                    .text_caption()
+                    .text_color(pal.text_muted)
+                    .child(tr!("pointer.power_mode_hardware_switch_only")),
+            )
+        })
+}
+
+/// A retry action bound to `key`, or a no-op when there is no active device.
+fn retry_power_mode_closure(key: Option<DeviceKey>) -> impl Fn(&mut App) + 'static {
+    move |cx| {
+        if let Some(key) = &key {
+            AppState::retry_power_mode_read(cx, key.clone());
+        }
+    }
+}

--- a/crates/openlogi-desktop/src/features/pointer/power_mode.rs
+++ b/crates/openlogi-desktop/src/features/pointer/power_mode.rs
@@ -116,6 +116,18 @@ fn ready_body(state: PowerModeState, pal: Palette) -> gpui::Div {
                 .text_color(pal.text_muted)
                 .child(tr!("pointer.power_mode_description")),
         )
+        // The faster rate shrinks per-report deltas 8x, and macOS's pointer
+        // acceleration gives small deltas less gain — the cursor feels slower
+        // at an unchanged DPI. Verified on a G305: DPI reads identically in
+        // both modes. Say so, or every macOS tester files a DPI bug.
+        .when(cfg!(target_os = "macos"), |body| {
+            body.child(
+                div()
+                    .text_caption()
+                    .text_color(pal.text_muted)
+                    .child(tr!("pointer.power_mode_macos_pointer_note")),
+            )
+        })
         .when(!state.software_switch, |body| {
             body.child(
                 div()

--- a/crates/openlogi-desktop/src/services/device_reads.rs
+++ b/crates/openlogi-desktop/src/services/device_reads.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::{Context, Subscription};
-use openlogi_core::hid::{DeviceRoute, DpiInfo, SmartShiftStatus, WriteError};
+use openlogi_core::hid::{DeviceRoute, DpiInfo, PowerModeState, SmartShiftStatus, WriteError};
 use swr_core::{
     MaybeSend, MaybeSync, QueryOptions, QueryState, Retry, RetryPolicy, Runtime, SwrClient,
 };
@@ -13,11 +13,14 @@ use swr_gpui::Query;
 use tokio::sync::mpsc;
 
 use super::ipc::Command;
-use crate::state::{AppState, DeviceKey, DpiStatus, Load, SmartShiftLoad, StateEvent};
+use crate::state::{
+    AppState, DeviceKey, DpiStatus, Load, PowerModeLoad, SmartShiftLoad, StateEvent,
+};
 
 const ROOT: &str = "device-read";
 const DPI: &str = "dpi";
 const SMARTSHIFT: &str = "smartshift";
+const POWER_MODE: &str = "power-mode";
 
 /// Preserve the old budget: one initial attempt and two retries.
 const READ_RETRY_POLICY: RetryPolicy = RetryPolicy {
@@ -49,6 +52,7 @@ pub(crate) struct DeviceReads {
     next_generation: u64,
     dpi: BTreeMap<DeviceKey, DeviceRead<DpiInfo>>,
     smartshift: BTreeMap<DeviceKey, DeviceRead<SmartShiftStatus>>,
+    power_mode: BTreeMap<DeviceKey, DeviceRead<PowerModeState>>,
 }
 
 impl DeviceReads {
@@ -274,6 +278,7 @@ impl DeviceReads {
     pub(crate) fn remove(&mut self, key: &DeviceKey) {
         self.remove_dpi(key);
         self.remove_smartshift(key);
+        self.remove_power_mode(key);
     }
 
     pub(crate) fn remove_dpi(&mut self, key: &DeviceKey) {
@@ -296,6 +301,7 @@ impl DeviceReads {
             .dpi
             .keys()
             .chain(self.smartshift.keys())
+            .chain(self.power_mode.keys())
             .filter(|key| !present(key.as_str()))
             .cloned()
             .collect();
@@ -364,6 +370,155 @@ impl DeviceReads {
         read.load = load;
         true
     }
+
+    /// Start an initial power-mode query unless this route is already watched.
+    pub(crate) fn ensure_power_mode(
+        &mut self,
+        key: DeviceKey,
+        route: DeviceRoute,
+        commands: mpsc::UnboundedSender<Command>,
+        cx: &mut Context<AppState>,
+    ) {
+        if self
+            .power_mode
+            .get(&key)
+            .is_some_and(|read| read.route == route)
+        {
+            return;
+        }
+        self.subscribe_power_mode(key, route, false, commands, cx);
+    }
+
+    /// Replace the active power-mode query with a write-confirming re-read.
+    pub(crate) fn confirm_power_mode(
+        &mut self,
+        key: DeviceKey,
+        route: DeviceRoute,
+        commands: mpsc::UnboundedSender<Command>,
+        cx: &mut Context<AppState>,
+    ) {
+        self.subscribe_power_mode(key, route, true, commands, cx);
+    }
+
+    fn subscribe_power_mode(
+        &mut self,
+        key: DeviceKey,
+        route: DeviceRoute,
+        preserve_data: bool,
+        commands: mpsc::UnboundedSender<Command>,
+        cx: &mut Context<AppState>,
+    ) {
+        let Some((client, runtime)) = self.cache() else {
+            return;
+        };
+        let previous = self.power_mode.remove(&key);
+        let had_previous = previous.is_some();
+        drop(previous);
+        if preserve_data {
+            // A confirming read keeps the optimistic write visible as stale
+            // data while invalidation starts the replacement query.
+            client.invalidate(query_key(POWER_MODE, &key));
+        } else if had_previous {
+            self.clear::<PowerModeState>(POWER_MODE, &key);
+        }
+        let generation = self.take_generation();
+        let fetch_route = route.clone();
+        let fetcher = Retry::new(
+            runtime,
+            move |_| {
+                let commands = commands.clone();
+                let route = fetch_route.clone();
+                read_ipc(move |reply| Command::ReadPowerMode(route, reply), commands)
+            },
+            READ_RETRY_POLICY,
+        )
+        .retry_if(|error| !power_mode_error_is_permanent(error));
+        let handle = client.subscribe(
+            query_key(POWER_MODE, &key),
+            fetcher,
+            QueryOptions::immutable(),
+        );
+        let query = Query::new(&client, handle, cx);
+        let load = project_load(query.read(cx), power_mode_error_is_permanent);
+        let observed_key = key.clone();
+        let observer = cx.observe(query.state(), move |state, query_state, cx| {
+            let load = project_load(query_state.read(cx), power_mode_error_is_permanent);
+            if state
+                .device_reads_mut()
+                .update_power_mode(&observed_key, generation, load)
+            {
+                cx.emit(StateEvent::PowerModeChanged(observed_key.clone()));
+            }
+        });
+        self.power_mode.insert(
+            key,
+            DeviceRead {
+                route,
+                generation,
+                load,
+                query,
+                _observer: observer,
+            },
+        );
+    }
+
+    #[must_use]
+    pub(crate) fn power_mode_status(&self, key: &DeviceKey) -> PowerModeLoad {
+        self.power_mode
+            .get(key)
+            .map_or(Load::Unknown, |read| read.load.clone())
+    }
+
+    #[must_use]
+    pub(crate) fn power_mode_load(&self, key: &DeviceKey) -> Option<&PowerModeLoad> {
+        self.power_mode.get(key).map(|read| &read.load)
+    }
+
+    /// Retry an exhausted initial power-mode query.
+    pub(crate) fn retry_power_mode(&mut self, key: &DeviceKey) {
+        let Some(read) = self.power_mode.get_mut(key) else {
+            return;
+        };
+        if !matches!(read.load, Load::Ready(_)) {
+            read.load = Load::Loading;
+        }
+        read.query.revalidate();
+    }
+
+    /// Publish a power-mode write optimistically into swr and the view model.
+    pub(crate) fn set_power_mode_ready(&mut self, key: &DeviceKey, state: PowerModeState) {
+        let value = Arc::new(state);
+        if let Some(client) = &self.client {
+            client.set::<_, Cached<PowerModeState>, WriteError>(
+                query_key(POWER_MODE, key),
+                Some(value.clone()),
+            );
+        }
+        if let Some(read) = self.power_mode.get_mut(key) {
+            read.load = Load::Ready(value);
+        }
+    }
+
+    pub(crate) fn remove_power_mode(&mut self, key: &DeviceKey) {
+        if let Some(read) = self.power_mode.remove(key) {
+            drop(read);
+            self.clear::<PowerModeState>(POWER_MODE, key);
+        }
+    }
+
+    fn update_power_mode(&mut self, key: &DeviceKey, generation: u64, load: PowerModeLoad) -> bool {
+        let Some(read) = self
+            .power_mode
+            .get_mut(key)
+            .filter(|read| read.generation == generation)
+        else {
+            return false;
+        };
+        // A confirmation commonly resolves to the optimistic value already in
+        // `load`; still publish so subscribers re-render from device truth.
+        read.load = load;
+        true
+    }
 }
 
 fn query_key(kind: &'static str, key: &DeviceKey) -> (&'static str, &'static str, String) {
@@ -415,6 +570,10 @@ fn dpi_error_is_permanent(error: &WriteError) -> bool {
 }
 
 fn smartshift_error_is_permanent(error: &WriteError) -> bool {
+    matches!(error, WriteError::FeatureUnsupported { .. })
+}
+
+fn power_mode_error_is_permanent(error: &WriteError) -> bool {
     matches!(error, WriteError::FeatureUnsupported { .. })
 }
 

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -29,7 +29,8 @@ use std::time::{Duration, Instant};
 
 use openlogi_core::config::Lighting;
 use openlogi_core::hid::{
-    DeviceRoute, Dpi, DpiInfo, LightCommand, ReceiverSelector, SmartShiftStatus, WriteError,
+    DeviceRoute, Dpi, DpiInfo, LightCommand, PowerMode, PowerModeState, ReceiverSelector,
+    SmartShiftStatus, WriteError,
 };
 use openlogi_ipc::{
     AgentClient, AgentSnapshot, ClientKind, ConfigReloadError, Generation, OBSERVE_HOLD,
@@ -112,6 +113,11 @@ pub enum Command {
     ReadSmartShift(
         DeviceRoute,
         oneshot::Sender<Result<SmartShiftStatus, WriteError>>,
+    ),
+    SetPowerMode(DeviceRoute, PowerMode),
+    ReadPowerMode(
+        DeviceRoute,
+        oneshot::Sender<Result<PowerModeState, WriteError>>,
     ),
     ReloadConfig,
     /// Ask the agent to fire the macOS Accessibility prompt. The agent owns the
@@ -554,6 +560,12 @@ async fn handle(
         Command::ReadSmartShift(route, reply) => {
             let _ = reply.send(rpc_result(client.read_smartshift(ctx, route).await)?);
         }
+        Command::SetPowerMode(route, mode) => {
+            log_apply(client.set_power_mode(ctx, route, mode).await)?;
+        }
+        Command::ReadPowerMode(route, reply) => {
+            let _ = reply.send(rpc_result(client.read_power_mode(ctx, route).await)?);
+        }
         Command::ReloadConfig => {
             // A transport failure is not the agent rejecting the config, but it
             // is still a reload that did not happen — and the file on disk has
@@ -660,7 +672,7 @@ fn rpc_result<T>(r: Result<T, tarpc::client::RpcError>) -> Result<T, ()> {
 /// fire-and-forget so they have nothing to reply to.
 #[expect(
     clippy::match_same_arms,
-    reason = "the two read arms send the same disconnect error to differently-typed reply channels, so they can't be merged"
+    reason = "the read arms send the same disconnect error to differently-typed reply channels, so they can't be merged"
 )]
 fn reply_disconnected(update_tx: &mpsc::UnboundedSender<GuiUpdate>, cmd: Command) {
     // Transient, not a permanent feature error: the agent is just restarting,
@@ -670,6 +682,9 @@ fn reply_disconnected(update_tx: &mpsc::UnboundedSender<GuiUpdate>, cmd: Command
             let _ = reply.send(Err(WriteError::AgentUnavailable));
         }
         Command::ReadSmartShift(_, reply) => {
+            let _ = reply.send(Err(WriteError::AgentUnavailable));
+        }
+        Command::ReadPowerMode(_, reply) => {
             let _ = reply.send(Err(WriteError::AgentUnavailable));
         }
         Command::SetLight(_, command, key, request_id) => {

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -24,7 +24,7 @@ pub(crate) use device_key::DeviceKey;
 pub use devices::DeviceRecord;
 pub use light::LightCommandStatus;
 pub(crate) use load::Load;
-pub use load::{DpiStatus, SmartShiftLoad};
+pub use load::{DpiStatus, PowerModeLoad, SmartShiftLoad};
 
 /// Result of confirming a SmartShift write by reading the value back.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +69,7 @@ mod light;
 mod lighting;
 mod load;
 mod pointer;
+mod power_mode;
 mod scroll;
 mod settings;
 mod smartshift;
@@ -103,6 +104,8 @@ pub(crate) enum StateEvent {
     DpiChanged(DeviceKey),
     /// SmartShift data or write status changed.
     SmartShiftChanged(DeviceKey),
+    /// Power-mode (`0x8090`) data changed.
+    PowerModeChanged(DeviceKey),
     /// Device or standalone-light settings changed.
     LightingChanged(DeviceKey),
     /// Camera settings or activity changed.
@@ -214,6 +217,7 @@ impl AppState {
         Self::update(cx, |state, cx| {
             state.load_current_dpi(cx);
             state.load_current_smartshift(cx);
+            state.load_current_power_mode(cx);
             state.confirm_current_smartshift(cx);
         });
     }

--- a/crates/openlogi-desktop/src/state/load.rs
+++ b/crates/openlogi-desktop/src/state/load.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use openlogi_core::hid::{DpiInfo, SmartShiftStatus};
+use openlogi_core::hid::{DpiInfo, PowerModeState, SmartShiftStatus};
 
 /// State projected from an swr-backed device query: unqueried, in flight,
 /// resolved, transiently failed, or permanently unsupported.
@@ -30,3 +30,8 @@ pub type DpiStatus = Load<Arc<DpiInfo>>;
 /// stores wheel mode / threshold / torque in its own non-volatile memory, so the
 /// GUI only ever reads and writes the device.
 pub type SmartShiftLoad = Load<Arc<SmartShiftStatus>>;
+
+/// Per-device power-mode (`0x8090`) load state. See [`Load`]. The value is
+/// never persisted host-side: the device keeps the mode across power cycles
+/// itself, so the GUI only ever reads and writes the device.
+pub type PowerModeLoad = Load<Arc<PowerModeState>>;

--- a/crates/openlogi-desktop/src/state/power_mode.rs
+++ b/crates/openlogi-desktop/src/state/power_mode.rs
@@ -1,0 +1,89 @@
+//! Power-mode (HID++ `0x8090`) reads and optimistic writes.
+//!
+//! Deliberately simpler than the SmartShift sibling: there is no config
+//! persistence (the device keeps the mode across power cycles itself) and no
+//! write-status banner. A write is sent, cached optimistically, and followed
+//! by a confirming re-read that replaces the cache with whatever the device
+//! really holds — a failed write becomes visible when the toggle flips back.
+
+use gpui::{App, Context};
+use openlogi_core::hid::{PowerMode, PowerModeState};
+use tracing::debug;
+
+use super::AppState;
+use super::StateEvent;
+use super::device_key::DeviceKey;
+use super::load::PowerModeLoad;
+
+impl AppState {
+    /// Start any pending power-mode read for the selected device.
+    pub(super) fn load_current_power_mode(&mut self, cx: &mut Context<Self>) {
+        let Some((key, route)) = self
+            .current_record()
+            .and_then(|record| Some((record.device_key(), record.route.clone()?)))
+        else {
+            return;
+        };
+        self.pointer
+            .reads
+            .ensure_power_mode(key, route, self.ipc_sender(), cx);
+    }
+
+    /// Re-arm a failed power-mode read from the panel's retry affordance.
+    pub(crate) fn retry_power_mode_read(cx: &mut App, key: DeviceKey) {
+        Self::update(cx, |state, cx| {
+            state.pointer.reads.retry_power_mode(&key);
+            cx.emit(StateEvent::PowerModeChanged(key));
+        });
+    }
+
+    /// The active device's resolved power mode, if the read succeeded.
+    #[must_use]
+    pub fn current_power_mode_ready(&self) -> Option<PowerModeState> {
+        self.current_record()
+            .and_then(|record| self.pointer.reads.power_mode_load(&record.device_key()))
+            .and_then(|load| match load {
+                PowerModeLoad::Ready(state) => Some(**state),
+                PowerModeLoad::Unknown
+                | PowerModeLoad::Loading
+                | PowerModeLoad::Failed(_)
+                | PowerModeLoad::Unsupported(_) => None,
+            })
+    }
+
+    /// The load state backing the panel for `key`.
+    pub(crate) fn power_mode_status_for(&self, key: &DeviceKey) -> PowerModeLoad {
+        self.pointer.reads.power_mode_status(key)
+    }
+
+    /// Write `mode` to the active device, cache it optimistically, and queue a
+    /// confirming re-read that replaces the optimistic value with whatever the
+    /// device reports. No-op when no device is selected, it is offline, or its
+    /// power mode never resolved.
+    pub(crate) fn update_power_mode(cx: &mut App, mode: PowerMode) {
+        Self::update(cx, |state, cx| {
+            let Some((key, route)) = state
+                .current_record()
+                .and_then(|record| Some((record.device_key(), record.route.clone()?)))
+            else {
+                debug!("no reachable device — power-mode change ignored");
+                return;
+            };
+            let Some(current) = state.current_power_mode_ready() else {
+                debug!("power mode unresolved — change ignored");
+                return;
+            };
+            state.send_ipc(crate::services::ipc::Command::SetPowerMode(
+                route.clone(),
+                mode,
+            ));
+            let expected = PowerModeState { mode, ..current };
+            state.pointer.reads.set_power_mode_ready(&key, expected);
+            state
+                .pointer
+                .reads
+                .confirm_power_mode(key.clone(), route, state.ipc_sender(), cx);
+            cx.emit(StateEvent::PowerModeChanged(key));
+        });
+    }
+}

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -42,6 +42,8 @@ pub use device_io::{DeviceIoGate, DeviceIoSignal, device_io_channel};
 pub use inventory::hotplug::watch_hotplug;
 pub use inventory::standalone::enumerate_standalone;
 pub use inventory::{Enumerator, InventoryError, enumerate};
+pub use openlogi_core::hid::mode_status;
+pub use openlogi_core::hid::mode_status::{PowerMode, PowerModeState};
 pub use openlogi_core::hid::smartshift;
 pub use openlogi_core::hid::smartshift::{
     SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, SmartShiftThreshold, TunableTorque,
@@ -67,12 +69,13 @@ pub use write::{
     ReprogControlEntry, ScrollReportingTarget, ScrollResolution, ScrollWheelMode, WriteError,
     apply_litra, commands_for_light_settings, dump_features, dump_firmware_entities,
     dump_reprog_controls, encode_litra_command, ensure_haptics_armed_on, find_litra, get_backlight,
-    get_dpi, get_dpi_info, get_dpi_info_on, get_scroll_wheel_mode, get_scroll_wheel_mode_on,
-    get_smartshift_status, get_smartshift_status_on, litra_model_for_route, matches_litra,
-    play_haptic, play_haptic_on, read_battery_raw, set_backlight_enabled, set_dpi, set_dpi_on,
-    set_fn_lock, set_fn_lock_on, set_keyboard_color, set_keyboard_color_on,
-    set_keyboard_color_with, set_keyboard_color_with_on, set_scroll_inversion,
-    set_scroll_inversion_on, set_scroll_resolution, set_scroll_resolution_on,
-    set_scroll_wheel_mode, set_scroll_wheel_mode_on, set_smartshift, set_smartshift_on,
-    set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,
+    get_dpi, get_dpi_info, get_dpi_info_on, get_power_mode, get_power_mode_on,
+    get_scroll_wheel_mode, get_scroll_wheel_mode_on, get_smartshift_status,
+    get_smartshift_status_on, litra_model_for_route, matches_litra, play_haptic, play_haptic_on,
+    read_battery_raw, set_backlight_enabled, set_dpi, set_dpi_on, set_fn_lock, set_fn_lock_on,
+    set_keyboard_color, set_keyboard_color_on, set_keyboard_color_with, set_keyboard_color_with_on,
+    set_power_mode, set_power_mode_on, set_scroll_inversion, set_scroll_inversion_on,
+    set_scroll_resolution, set_scroll_resolution_on, set_scroll_wheel_mode,
+    set_scroll_wheel_mode_on, set_smartshift, set_smartshift_on, set_smartshift_sensitivity,
+    toggle_smartshift, toggle_smartshift_on,
 };

--- a/crates/openlogi-device/src/write.rs
+++ b/crates/openlogi-device/src/write.rs
@@ -24,6 +24,7 @@ mod haptic;
 mod hires_wheel;
 mod lighting;
 mod litra;
+mod power_mode;
 mod smartshift;
 
 pub use backlight::{get_backlight, set_backlight_enabled};
@@ -53,6 +54,7 @@ pub use litra::{
     apply as apply_litra, encode_command as encode_litra_command, find_litra,
     litra_model_for_route, matches_litra,
 };
+pub use power_mode::{get_power_mode, get_power_mode_on, set_power_mode, set_power_mode_on};
 pub use smartshift::{
     get_smartshift_status, get_smartshift_status_on, set_smartshift, set_smartshift_on,
     set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,

--- a/crates/openlogi-device/src/write/power_mode.rs
+++ b/crates/openlogi-device/src/write/power_mode.rs
@@ -1,0 +1,115 @@
+//! HID++ `0x8090 ModeStatus` — the performance / endurance power mode on
+//! G-series mice (G305 and friends).
+//!
+//! The device persists the mode across power cycles in its own memory, so
+//! there is no host-side persistence: callers read the device and write the
+//! device, nothing else.
+
+use std::sync::Arc;
+
+use hidpp::{
+    channel::HidppChannel,
+    device::Device,
+    feature::{
+        CreatableFeature,
+        mode_status::{ModeStatus0, ModeStatusCapabilities, ModeStatusFeature},
+    },
+};
+use tracing::debug;
+
+use crate::SharedChannel;
+use crate::backend::HidBackend;
+use crate::channel::route::DeviceRoute;
+use openlogi_core::hid::mode_status::{PowerMode, PowerModeState};
+
+use super::{HidppOperation, WriteError, classify_hidpp_error, open_feature, with_route};
+
+/// Read the current power mode plus the switch capabilities of the device
+/// `route` reaches.
+///
+/// `FeatureUnsupported` when the device does not expose HID++ `0x8090`.
+pub async fn get_power_mode(
+    backend: &dyn HidBackend,
+    route: &DeviceRoute,
+) -> Result<PowerModeState, WriteError> {
+    let index = route.device_index();
+    with_route(backend, route, move |channel| async move {
+        get_power_mode_on_channel(&channel, index).await
+    })
+    .await
+}
+
+pub(super) async fn get_power_mode_on_channel(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+) -> Result<PowerModeState, WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let feature = open_feature::<ModeStatusFeature>(&mut device).await?;
+    let status = feature.get_mode_status().await.map_err(|e| {
+        classify_hidpp_error(e, HidppOperation::ReadPowerMode, ModeStatusFeature::ID)
+    })?;
+    let capabilities = feature.get_device_config().await.map_err(|e| {
+        classify_hidpp_error(e, HidppOperation::ReadPowerMode, ModeStatusFeature::ID)
+    })?;
+    Ok(PowerModeState {
+        mode: if status.status0.contains(ModeStatus0::PERFORMANCE) {
+            PowerMode::Performance
+        } else {
+            PowerMode::Endurance
+        },
+        software_switch: capabilities.contains(ModeStatusCapabilities::SOFTWARE_SWITCH),
+        hardware_switch: capabilities.contains(ModeStatusCapabilities::HARDWARE_SWITCH),
+    })
+}
+
+/// Write a new power mode to the device `route` reaches. The device persists
+/// the mode across power cycles itself, so nothing is stored host-side.
+///
+/// Only `changed_mask0` is written: a G305 answers HID++ `InvalidArgument` to
+/// any set that touches `changed_mask1`.
+///
+/// `FeatureUnsupported` when the device does not expose HID++ `0x8090`.
+pub async fn set_power_mode(
+    backend: &dyn HidBackend,
+    route: &DeviceRoute,
+    mode: PowerMode,
+) -> Result<(), WriteError> {
+    let index = route.device_index();
+    with_route(backend, route, move |channel| async move {
+        set_power_mode_on_channel(&channel, index, mode).await
+    })
+    .await
+}
+
+pub(super) async fn set_power_mode_on_channel(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+    mode: PowerMode,
+) -> Result<(), WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let feature = open_feature::<ModeStatusFeature>(&mut device).await?;
+    feature
+        .set_performance_mode(matches!(mode, PowerMode::Performance))
+        .await
+        .map_err(|e| {
+            classify_hidpp_error(e, HidppOperation::WritePowerMode, ModeStatusFeature::ID)
+        })?;
+    debug!(index, ?mode, "wrote power mode");
+    Ok(())
+}
+
+/// Read the power mode and switch capabilities on an already-open
+/// [`SharedChannel`].
+pub async fn get_power_mode_on(shared: &SharedChannel) -> Result<PowerModeState, WriteError> {
+    get_power_mode_on_channel(shared.channel(), shared.device_index()).await
+}
+
+/// Write a new power mode on an already-open [`SharedChannel`] — the fast
+/// path that skips enumeration and channel setup.
+pub async fn set_power_mode_on(shared: &SharedChannel, mode: PowerMode) -> Result<(), WriteError> {
+    set_power_mode_on_channel(shared.channel(), shared.device_index(), mode).await
+}

--- a/crates/openlogi-device/src/write/tests.rs
+++ b/crates/openlogi-device/src/write/tests.rs
@@ -14,7 +14,8 @@ use crate::write::smartshift::{
 };
 use crate::write::{HidppFeatureErrorKind, HidppOperation};
 use crate::{
-    SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, SmartShiftThreshold, TunableTorque,
+    PowerMode, SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, SmartShiftThreshold,
+    TunableTorque,
 };
 use hidpp::feature::device_information::DeviceEntityType;
 
@@ -461,12 +462,14 @@ fn scripted_response(request: &[u8]) -> Option<Vec<u8>> {
                 0x2201 => 0x05,
                 0x2111 => 0x06,
                 0x8080 => 0x07,
+                0x8090 => 0x08,
                 _ => 0x00,
             };
             false
         }
-        // AdjustableDpi sensor count/current/list.
-        (0x05, 0x00) => {
+        // AdjustableDpi sensor count / ModeStatus getModeStatus: one sensor
+        // and a set performance bit share the same reply byte.
+        (0x05 | 0x08, 0x00) => {
             payload[0] = 1;
             false
         }
@@ -481,6 +484,13 @@ fn scripted_response(request: &[u8]) -> Option<Vec<u8>> {
         // Enhanced SmartShift status.
         (0x06, 0x01) => {
             payload[..3].copy_from_slice(&[u8::from(WheelMode::Ratchet), 10, 33]);
+            false
+        }
+        // ModeStatus setModeStatus ack (the request arrives as a long report).
+        (0x08, 0x01) => false,
+        // ModeStatus getDevConfig — software switch only (the G305 value).
+        (0x08, 0x02) => {
+            payload[1] = 0x02;
             false
         }
         // Raw per-key frame commit expects no reply.
@@ -758,4 +768,49 @@ async fn a_channel_failure_aborts_the_dump_instead_of_blaming_the_firmware() {
         !written.iter().any(|report| is_fw_info_for(report, 2)),
         "the dump stops at the failure rather than timing out per entity"
     );
+}
+
+#[tokio::test]
+async fn power_mode_reads_use_the_supplied_channel() -> Result<(), WriteError> {
+    let (raw, _handle) = ScriptedRawHidChannel::with_responder(scripted_response);
+    let channel = scripted_channel(raw).await;
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    let state = get_power_mode_on(&shared).await?;
+    assert_eq!(state.mode, PowerMode::Performance);
+    assert!(state.software_switch);
+    assert!(!state.hardware_switch);
+    Ok(())
+}
+
+#[tokio::test]
+async fn power_mode_writes_touch_only_changed_mask0() -> Result<(), WriteError> {
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(scripted_response);
+    let channel = scripted_channel(raw).await;
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    set_power_mode_on(&shared, PowerMode::Performance).await?;
+
+    let written = handle.written_reports();
+    let set = written
+        .iter()
+        .find(|report| report.len() >= 8 && report[2] == 0x08 && report[3] >> 4 == 1)
+        .expect("a setModeStatus report was written");
+    // status0 = performance, status1 untouched, changed_mask0 = performance,
+    // changed_mask1 untouched — the G305 answers HID++ InvalidArgument to any
+    // set that touches changed_mask1.
+    assert_eq!(&set[4..8], &[0x01, 0x00, 0x01, 0x00]);
+    Ok(())
 }

--- a/crates/openlogi-device/src/write/tests.rs
+++ b/crates/openlogi-device/src/write/tests.rs
@@ -488,9 +488,10 @@ fn scripted_response(request: &[u8]) -> Option<Vec<u8>> {
         }
         // ModeStatus setModeStatus ack (the request arrives as a long report).
         (0x08, 0x01) => false,
-        // ModeStatus getDevConfig — software switch only (the G305 value).
+        // ModeStatus getDevConfig — software switch only. A real G305
+        // answers 0x02 in the reply's first byte.
         (0x08, 0x02) => {
-            payload[1] = 0x02;
+            payload[0] = 0x02;
             false
         }
         // Raw per-key frame commit expects no reply.

--- a/crates/openlogi-hid/src/host.rs
+++ b/crates/openlogi-hid/src/host.rs
@@ -16,6 +16,7 @@ use openlogi_core::hid::{LightCommand, PairingError, WriteError};
 
 use crate::probe_cache::FileProbeCacheStore;
 use crate::transport::native_backend;
+use openlogi_core::hid::mode_status::{PowerMode, PowerModeState};
 use openlogi_core::hid::smartshift::{SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus};
 use openlogi_device::ChannelPool;
 use openlogi_device::backend::{HidBackend, HotplugStream};
@@ -90,6 +91,16 @@ pub async fn set_smartshift_sensitivity(
     value: SmartShiftAutoDisengage,
 ) -> Result<SmartShiftStatus, WriteError> {
     device::set_smartshift_sensitivity(&*native_backend(), route, value).await
+}
+
+/// Read the power mode and switch capabilities of the device `route` reaches.
+pub async fn get_power_mode(route: &DeviceRoute) -> Result<PowerModeState, WriteError> {
+    device::get_power_mode(&*native_backend(), route).await
+}
+
+/// Write a new power mode to the device `route` reaches.
+pub async fn set_power_mode(route: &DeviceRoute, mode: PowerMode) -> Result<(), WriteError> {
+    device::set_power_mode(&*native_backend(), route, mode).await
 }
 
 /// Read the scroll-wheel resolution and inversion of the device `route` reaches.

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -30,10 +30,11 @@ pub use hidpp::feature::FeatureType;
 pub use hidpp::feature::device_information::DeviceEntityType;
 pub use host::{
     apply_litra, channel_pool, dump_features, dump_firmware_entities, dump_reprog_controls,
-    enumerate, enumerate_standalone, get_backlight, get_dpi, get_dpi_info, get_scroll_wheel_mode,
-    get_smartshift_status, list_pairing_receivers, play_haptic, read_battery_raw,
-    set_backlight_enabled, set_dpi, set_fn_lock, set_keyboard_color, set_keyboard_color_with,
-    set_scroll_inversion, set_scroll_resolution, set_scroll_wheel_mode, set_smartshift,
-    set_smartshift_sensitivity, toggle_smartshift, watch_hotplug,
+    enumerate, enumerate_standalone, get_backlight, get_dpi, get_dpi_info, get_power_mode,
+    get_scroll_wheel_mode, get_smartshift_status, list_pairing_receivers, play_haptic,
+    read_battery_raw, set_backlight_enabled, set_dpi, set_fn_lock, set_keyboard_color,
+    set_keyboard_color_with, set_power_mode, set_scroll_inversion, set_scroll_resolution,
+    set_scroll_wheel_mode, set_smartshift, set_smartshift_sensitivity, toggle_smartshift,
+    watch_hotplug,
 };
 pub use probe_cache::FileProbeCacheStore;

--- a/crates/openlogi-hidpp/src/feature/mode_status.rs
+++ b/crates/openlogi-hidpp/src/feature/mode_status.rs
@@ -2,7 +2,10 @@
 
 use openlogi_hidpp_derive::Feature;
 
-use crate::{feature::FeatureEndpoint, protocol::v20::Hidpp20Error};
+use crate::{
+    feature::{DecodeEvent, EventSource, FeatureEndpoint},
+    protocol::v20::Hidpp20Error,
+};
 
 bitflags::bitflags! {
     /// The first mode-status byte.
@@ -52,11 +55,14 @@ pub struct ModeStatusChange {
 }
 
 /// Implements the `ModeStatus` / `0x8090` feature.
-#[derive(Clone, Feature)]
+#[derive(Feature)]
 #[creatable(id = 0x8090, version = 1)]
 pub struct ModeStatusFeature {
     /// The endpoint this feature talks to.
     endpoint: FeatureEndpoint,
+
+    /// Publishes decoded events to listeners.
+    events: EventSource<ModeStatusEvent>,
 }
 
 impl ModeStatusFeature {
@@ -103,5 +109,103 @@ impl ModeStatusFeature {
         Ok(ModeStatusCapabilities::from_bits_retain(
             u16::from_be_bytes([payload[0], payload[1]]),
         ))
+    }
+}
+
+impl DecodeEvent for ModeStatusEvent {
+    fn decode(sub_id: u8, payload: &[u8; 16]) -> Option<Self> {
+        // The mode-status broadcast is the only event and carries sub-id 0.
+        if sub_id != 0 {
+            return None;
+        }
+
+        // Every field decodes infallibly (`from_bits_retain` keeps unknown
+        // bits): a broadcast flipping a bit this crate does not model yet must
+        // still reach listeners, mirroring `wireless_device_status`.
+        Some(ModeStatusEvent::StatusBroadcast(ModeStatusBroadcast {
+            status: ModeStatus {
+                status0: ModeStatus0::from_bits_retain(payload[0]),
+                status1: payload[1],
+            },
+            changed_mask0: ModeStatus0::from_bits_retain(payload[2]),
+            changed_mask1: payload[3],
+        }))
+    }
+}
+
+impl ModeStatusEvent {
+    /// Decodes one event payload for this feature, or returns `None` for an
+    /// unsupported event function.
+    ///
+    /// Consumers that already own a channel-level listener can use this
+    /// without constructing a second [`ModeStatusFeature`].
+    #[must_use]
+    pub fn decode(function_id: u8, payload: &[u8; 16]) -> Option<Self> {
+        <Self as DecodeEvent>::decode(function_id, payload)
+    }
+}
+
+/// Represents an event emitted by the [`ModeStatusFeature`] feature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub enum ModeStatusEvent {
+    /// Is emitted whenever the mode-status bits change — observed after a
+    /// successful `setModeStatus` and on power-on (alongside the `0x1d4b`
+    /// reconnection broadcast).
+    StatusBroadcast(ModeStatusBroadcast),
+}
+
+/// Represents the data of the [`ModeStatusEvent::StatusBroadcast`] event.
+///
+/// The payload layout mirrors the `setModeStatus` argument order (`status0`,
+/// `status1`, `changed_mask0`, `changed_mask1`). Reverse-engineered from G305
+/// captures rather than read from a spec: `01 00 01` right after a successful
+/// set, `00 00 01` on power-on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct ModeStatusBroadcast {
+    /// The mode-status bytes after the change.
+    pub status: ModeStatus,
+    /// Primary changed-bit mask.
+    pub changed_mask0: ModeStatus0,
+    /// Secondary changed-bit mask.
+    pub changed_mask1: u8,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_the_g305_post_set_broadcast() {
+        // Observed on a G305 right after a successful setModeStatus.
+        let mut payload = [0u8; 16];
+        payload[..3].copy_from_slice(&[0x01, 0x00, 0x01]);
+
+        let event = ModeStatusEvent::decode(0, &payload).expect("event 0 decodes");
+        let ModeStatusEvent::StatusBroadcast(broadcast) = event;
+        assert!(broadcast.status.status0.contains(ModeStatus0::PERFORMANCE));
+        assert_eq!(broadcast.status.status1, 0);
+        assert_eq!(broadcast.changed_mask0, ModeStatus0::PERFORMANCE);
+        assert_eq!(broadcast.changed_mask1, 0);
+    }
+
+    #[test]
+    fn decodes_the_power_on_broadcast_with_the_bit_cleared() {
+        // Observed on a G305 power-on: the performance bit reported cleared.
+        let mut payload = [0u8; 16];
+        payload[..3].copy_from_slice(&[0x00, 0x00, 0x01]);
+
+        let event = ModeStatusEvent::decode(0, &payload).expect("event 0 decodes");
+        let ModeStatusEvent::StatusBroadcast(broadcast) = event;
+        assert!(!broadcast.status.status0.contains(ModeStatus0::PERFORMANCE));
+        assert_eq!(broadcast.changed_mask0, ModeStatus0::PERFORMANCE);
+    }
+
+    #[test]
+    fn other_functions_do_not_decode() {
+        assert_eq!(ModeStatusEvent::decode(1, &[0; 16]), None);
     }
 }

--- a/crates/openlogi-hidpp/src/feature/mode_status.rs
+++ b/crates/openlogi-hidpp/src/feature/mode_status.rs
@@ -104,10 +104,17 @@ impl ModeStatusFeature {
     }
 
     /// Retrieves device capabilities for mode switching.
+    ///
+    /// The capability bits live in the reply's first byte: a G305 answers
+    /// `0x02` there (software switch only, matching its software-togglable
+    /// mode), which a big-endian two-byte read would shift into the high byte
+    /// and report as no capabilities at all. Decoded little-endian so byte 0
+    /// carries bits 0-7 as observed on hardware while a second byte, if a
+    /// future device uses one, still surfaces.
     pub async fn get_device_config(&self) -> Result<ModeStatusCapabilities, Hidpp20Error> {
         let payload = self.endpoint.call(2, [0; 3]).await?.extend_payload();
         Ok(ModeStatusCapabilities::from_bits_retain(
-            u16::from_be_bytes([payload[0], payload[1]]),
+            u16::from_le_bytes([payload[0], payload[1]]),
         ))
     }
 }

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -17,8 +17,8 @@ use openlogi_core::binding::{ActionRingIcon, ActionRingSlot};
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
 use openlogi_core::hid::{
-    DeviceRoute, Dpi, DpiInfo, LightCommand, PairingError, PasskeyMethod, ReceiverSelector,
-    SmartShiftStatus, WriteError,
+    DeviceRoute, Dpi, DpiInfo, LightCommand, PairingError, PasskeyMethod, PowerMode,
+    PowerModeState, ReceiverSelector, SmartShiftStatus, WriteError,
 };
 use serde::{Deserialize, Serialize};
 pub use succession::Identity;
@@ -61,7 +61,9 @@ pub use succession::Identity;
 /// v28: `Action::HoldShortcut` appended for lifecycle-held keyboard output.
 /// v29: `Agent::declare_client` + [`ClientKind`] appended — typed demand for
 ///      the macOS dormancy gate.
-pub const PROTOCOL_VERSION: u32 = 29;
+/// v30: `read_power_mode` / `set_power_mode` appended (HID++ `0x8090`
+///      performance/endurance).
+pub const PROTOCOL_VERSION: u32 = 30;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -560,4 +562,8 @@ pub trait Agent {
     /// arms only on [`ClientKind::Gui`]. The takeover probe never declares —
     /// it speaks only [`Agent::protocol_version`] — and so never arms.
     async fn declare_client(kind: ClientKind);
+    /// Read the `0x8090` power mode + switch capabilities from `route`.
+    async fn read_power_mode(route: DeviceRoute) -> Result<PowerModeState, WriteError>;
+    /// Apply a power mode to `route` now.
+    async fn set_power_mode(route: DeviceRoute, mode: PowerMode) -> Result<(), WriteError>;
 }

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -40,8 +40,9 @@ use openlogi_core::device::{
 };
 use openlogi_core::hid::{
     Click, DeviceRoute, Dpi, DpiCapabilities, DpiInfo, HidppFeatureErrorKind, HidppOperation,
-    LightCommand, PasskeyMethod, ReceiverSelector, SmartShiftAutoDisengage, SmartShiftMode,
-    SmartShiftStatus, SmartShiftThreshold, TunableTorque, WriteError,
+    LightCommand, PasskeyMethod, PowerMode, PowerModeState, ReceiverSelector,
+    SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, SmartShiftThreshold, TunableTorque,
+    WriteError,
 };
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, ActionRingPresentation, AgentRequest,
@@ -97,11 +98,27 @@ fn representative_smartshift_status() -> SmartShiftStatus {
     }
 }
 
+/// The Bolt route every request golden uses.
+fn bolt_f00dcafe() -> DeviceRoute {
+    DeviceRoute::Bolt {
+        receiver_uid: "F00DCAFE".into(),
+        slot: 1,
+    }
+}
+
+fn representative_power_mode_state() -> PowerModeState {
+    PowerModeState {
+        mode: PowerMode::Performance,
+        software_switch: true,
+        hardware_switch: false,
+    }
+}
+
 /// Any golden regeneration must come with a version bump — this is the test
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 29);
+    assert_eq!(PROTOCOL_VERSION, 30);
 }
 
 #[test]
@@ -143,6 +160,19 @@ fn request_variant_order() {
     assert_wire(&AgentRequest::NextPairing {}, "0d");
     assert_wire(&AgentRequest::Snapshot {}, "0e");
     assert_wire(&AgentRequest::PollEventMonitor {}, "0f");
+    assert_wire(
+        &AgentRequest::ReadPowerMode {
+            route: bolt_f00dcafe(),
+        },
+        "1a0008463030444341464501",
+    );
+    assert_wire(
+        &AgentRequest::SetPowerMode {
+            route: bolt_f00dcafe(),
+            mode: PowerMode::Performance,
+        },
+        "1b000846303044434146450101",
+    );
     assert_wire(
         &AgentRequest::SetLight {
             route: DeviceRoute::RawHid {
@@ -514,6 +544,10 @@ fn device_settings_payloads() {
     // is exactly the kind of thing a refactor would "fix".
     let smartshift: Result<SmartShiftStatus, WriteError> = Ok(representative_smartshift_status());
     assert_wire(&smartshift, "0001103c");
+
+    // PowerMode encodes its variant *index* (Endurance=0, Performance=1).
+    let power_mode: Result<PowerModeState, WriteError> = Ok(representative_power_mode_state());
+    assert_wire(&power_mode, "00010100");
 
     // `Rgb` serializes as the same hex string the field used to hold raw, so
     // the pinned bytes are identical to the pre-newtype encoding.

--- a/crates/openlogi-ui/locales/be.toml
+++ b/crates/openlogi-ui/locales/be.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Вылучае дробныя рухі 
 wheel_resolution_unsupported = "Гэта прылада не падтрымлівае кіраванне раздзяляльнасцю кола."
 wheel_resolution_other_connection = "Гэта прылада падтрымлівае раздзяляльнасць кола на іншым падключэнні, але не на гэтым."
 smartshift = "SmartShift"
+power_mode = "Рэжым сілкавання"
+performance_mode = "Рэжым прадукцыйнасці"
+power_mode_description = "Прадукцыйнасць адкрывае ўвесь дыяпазон частот апытання; эканомія падаўжае працу ад батарэі."
+power_mode_hardware_switch_only = "Рэжым сілкавання гэтай прылады задаецца яе апаратным пераключальнікам."
+device_offline_power_mode_is_unavailable = "Прылада не ў сетцы. Рэжым сілкавання недаступны."
+reading_power_mode = "Чытанне рэжыму сілкавання…"
+couldnt_read_power_mode_click_to_retry = "Не ўдалося прачытаць рэжым сілкавання. Націсніце, каб паўтарыць."
+this_device_does_not_support_power_mode = "Гэтая прылада не падтрымлівае пераключэнне рэжыму сілкавання."
 
 [actions]
 bind_control = "Прывязаць %{name}"

--- a/crates/openlogi-ui/locales/be.toml
+++ b/crates/openlogi-ui/locales/be.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Прылада не ў сетцы. �
 reading_power_mode = "Чытанне рэжыму сілкавання…"
 couldnt_read_power_mode_click_to_retry = "Не ўдалося прачытаць рэжым сілкавання. Націсніце, каб паўтарыць."
 this_device_does_not_support_power_mode = "Гэтая прылада не падтрымлівае пераключэнне рэжыму сілкавання."
+power_mode_macos_pointer_note = "Вышэйшая частата апытання ў рэжыме прадукцыйнасці можа рабіць паказальнік macOS павольнейшым на адчуванне. Гэта крывая паскарэння сістэмы, а не змена DPI."
 
 [actions]
 bind_control = "Прывязаць %{name}"

--- a/crates/openlogi-ui/locales/da.toml
+++ b/crates/openlogi-ui/locales/da.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Enheden er offline. Strømtilstand e
 reading_power_mode = "Læser strømtilstand…"
 couldnt_read_power_mode_click_to_retry = "Kunne ikke læse strømtilstanden. Klik for at prøve igen."
 this_device_does_not_support_power_mode = "Denne enhed understøtter ikke skift af strømtilstand."
+power_mode_macos_pointer_note = "Ydelsestilstandens højere rapporteringshastighed kan få macOS-markøren til at føles langsommere. Det er systemets accelerationskurve, ikke en DPI-ændring."
 
 [actions]
 bind_control = "Tildel %{name}"

--- a/crates/openlogi-ui/locales/da.toml
+++ b/crates/openlogi-ui/locales/da.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Registrerer finere bevægelser mellem r
 wheel_resolution_unsupported = "Denne enhed understøtter ikke styring af hjulopløsning."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Strømtilstand"
+performance_mode = "Ydelsestilstand"
+power_mode_description = "Ydelse låser alle rapporteringshastigheder op; udholdenhed forlænger batterilevetiden."
+power_mode_hardware_switch_only = "Enhedens strømtilstand indstilles med dens hardwarekontakt."
+device_offline_power_mode_is_unavailable = "Enheden er offline. Strømtilstand er ikke tilgængelig."
+reading_power_mode = "Læser strømtilstand…"
+couldnt_read_power_mode_click_to_retry = "Kunne ikke læse strømtilstanden. Klik for at prøve igen."
+this_device_does_not_support_power_mode = "Denne enhed understøtter ikke skift af strømtilstand."
 
 [actions]
 bind_control = "Tildel %{name}"

--- a/crates/openlogi-ui/locales/de.toml
+++ b/crates/openlogi-ui/locales/de.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Erkennt feinere Bewegungen zwischen den
 wheel_resolution_unsupported = "Dieses Gerät unterstützt keine Steuerung der Mausradauflösung."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Energiemodus"
+performance_mode = "Leistungsmodus"
+power_mode_description = "Leistung schaltet alle Abtastraten frei; Ausdauer verlängert die Akkulaufzeit."
+power_mode_hardware_switch_only = "Der Energiemodus dieses Geräts wird über seinen Hardware-Schalter eingestellt."
+device_offline_power_mode_is_unavailable = "Gerät offline. Der Energiemodus ist nicht verfügbar."
+reading_power_mode = "Energiemodus wird gelesen…"
+couldnt_read_power_mode_click_to_retry = "Energiemodus konnte nicht gelesen werden. Zum Wiederholen klicken."
+this_device_does_not_support_power_mode = "Dieses Gerät unterstützt keinen Energiemodus-Wechsel."
 
 [actions]
 bind_control = "%{name} zuweisen"

--- a/crates/openlogi-ui/locales/de.toml
+++ b/crates/openlogi-ui/locales/de.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Gerät offline. Der Energiemodus ist
 reading_power_mode = "Energiemodus wird gelesen…"
 couldnt_read_power_mode_click_to_retry = "Energiemodus konnte nicht gelesen werden. Zum Wiederholen klicken."
 this_device_does_not_support_power_mode = "Dieses Gerät unterstützt keinen Energiemodus-Wechsel."
+power_mode_macos_pointer_note = "Die höhere Abtastrate im Leistungsmodus kann den macOS-Zeiger langsamer wirken lassen. Das ist die Beschleunigungskurve des Systems, keine DPI-Änderung."
 
 [actions]
 bind_control = "%{name} zuweisen"

--- a/crates/openlogi-ui/locales/el.toml
+++ b/crates/openlogi-ui/locales/el.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Συσκευή εκτός σύνδε
 reading_power_mode = "Ανάγνωση λειτουργίας τροφοδοσίας…"
 couldnt_read_power_mode_click_to_retry = "Αδυναμία ανάγνωσης της λειτουργίας τροφοδοσίας. Κάντε κλικ για επανάληψη."
 this_device_does_not_support_power_mode = "Αυτή η συσκευή δεν υποστηρίζει εναλλαγή λειτουργίας τροφοδοσίας."
+power_mode_macos_pointer_note = "Η υψηλότερη συχνότητα αναφοράς της λειτουργίας επιδόσεων μπορεί να κάνει τον δείκτη του macOS να μοιάζει πιο αργός. Είναι η καμπύλη επιτάχυνσης του συστήματος, όχι αλλαγή DPI."
 
 [actions]
 bind_control = "Αντιστοίχιση %{name}"

--- a/crates/openlogi-ui/locales/el.toml
+++ b/crates/openlogi-ui/locales/el.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Ανιχνεύει λεπτότερη �
 wheel_resolution_unsupported = "Αυτή η συσκευή δεν υποστηρίζει έλεγχο ανάλυσης τροχού."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Λειτουργία τροφοδοσίας"
+performance_mode = "Λειτουργία επιδόσεων"
+power_mode_description = "Οι επιδόσεις ξεκλειδώνουν όλες τις συχνότητες αναφοράς· η αντοχή παρατείνει την μπαταρία."
+power_mode_hardware_switch_only = "Η λειτουργία τροφοδοσίας αυτής της συσκευής ορίζεται από τον διακόπτη της."
+device_offline_power_mode_is_unavailable = "Συσκευή εκτός σύνδεσης. Η λειτουργία τροφοδοσίας δεν είναι διαθέσιμη."
+reading_power_mode = "Ανάγνωση λειτουργίας τροφοδοσίας…"
+couldnt_read_power_mode_click_to_retry = "Αδυναμία ανάγνωσης της λειτουργίας τροφοδοσίας. Κάντε κλικ για επανάληψη."
+this_device_does_not_support_power_mode = "Αυτή η συσκευή δεν υποστηρίζει εναλλαγή λειτουργίας τροφοδοσίας."
 
 [actions]
 bind_control = "Αντιστοίχιση %{name}"

--- a/crates/openlogi-ui/locales/en.toml
+++ b/crates/openlogi-ui/locales/en.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Device offline. Power mode is unavai
 reading_power_mode = "Reading power mode…"
 couldnt_read_power_mode_click_to_retry = "Couldn't read the power mode. Click to retry."
 this_device_does_not_support_power_mode = "This device does not support power-mode switching."
+power_mode_macos_pointer_note = "The faster performance report rate can make the macOS pointer feel slower. That is the system's acceleration curve, not a DPI change."
 
 [actions]
 bind_control = "Bind %{name}"

--- a/crates/openlogi-ui/locales/en.toml
+++ b/crates/openlogi-ui/locales/en.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Detects finer movement between ratchet 
 wheel_resolution_unsupported = "This device does not support wheel resolution control."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Power mode"
+performance_mode = "Performance mode"
+power_mode_description = "Performance unlocks the full report-rate range; endurance extends battery life."
+power_mode_hardware_switch_only = "This device's power mode is set with its hardware switch."
+device_offline_power_mode_is_unavailable = "Device offline. Power mode is unavailable."
+reading_power_mode = "Reading power mode…"
+couldnt_read_power_mode_click_to_retry = "Couldn't read the power mode. Click to retry."
+this_device_does_not_support_power_mode = "This device does not support power-mode switching."
 
 [actions]
 bind_control = "Bind %{name}"

--- a/crates/openlogi-ui/locales/es.toml
+++ b/crates/openlogi-ui/locales/es.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Dispositivo sin conexión. El modo d
 reading_power_mode = "Leyendo el modo de energía…"
 couldnt_read_power_mode_click_to_retry = "No se pudo leer el modo de energía. Haz clic para reintentar."
 this_device_does_not_support_power_mode = "Este dispositivo no admite el cambio de modo de energía."
+power_mode_macos_pointer_note = "La mayor frecuencia de sondeo del modo rendimiento puede hacer que el puntero de macOS parezca más lento. Es la curva de aceleración del sistema, no un cambio de DPI."
 
 [actions]
 bind_control = "Asignar %{name}"

--- a/crates/openlogi-ui/locales/es.toml
+++ b/crates/openlogi-ui/locales/es.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Detecta movimientos más finos entre lo
 wheel_resolution_unsupported = "Este dispositivo no admite el control de resolución de la rueda."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Modo de energía"
+performance_mode = "Modo rendimiento"
+power_mode_description = "Rendimiento desbloquea todas las frecuencias de sondeo; resistencia prolonga la batería."
+power_mode_hardware_switch_only = "El modo de energía de este dispositivo se ajusta con su interruptor físico."
+device_offline_power_mode_is_unavailable = "Dispositivo sin conexión. El modo de energía no está disponible."
+reading_power_mode = "Leyendo el modo de energía…"
+couldnt_read_power_mode_click_to_retry = "No se pudo leer el modo de energía. Haz clic para reintentar."
+this_device_does_not_support_power_mode = "Este dispositivo no admite el cambio de modo de energía."
 
 [actions]
 bind_control = "Asignar %{name}"

--- a/crates/openlogi-ui/locales/fi.toml
+++ b/crates/openlogi-ui/locales/fi.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Tunnistaa hienovaraisemman liikkeen pyk
 wheel_resolution_unsupported = "Tämä laite ei tue vierityspyörän tarkkuuden hallintaa."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Virtatila"
+performance_mode = "Suorituskykytila"
+power_mode_description = "Suorituskyky avaa kaikki raportointitaajuudet; kestotila pidentää akunkestoa."
+power_mode_hardware_switch_only = "Tämän laitteen virtatila asetetaan laitteen omalla kytkimellä."
+device_offline_power_mode_is_unavailable = "Laite offline-tilassa. Virtatila ei ole käytettävissä."
+reading_power_mode = "Luetaan virtatilaa…"
+couldnt_read_power_mode_click_to_retry = "Virtatilan lukeminen epäonnistui. Yritä uudelleen napsauttamalla."
+this_device_does_not_support_power_mode = "Tämä laite ei tue virtatilan vaihtoa."
 
 [actions]
 bind_control = "Määritä %{name}"

--- a/crates/openlogi-ui/locales/fi.toml
+++ b/crates/openlogi-ui/locales/fi.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Laite offline-tilassa. Virtatila ei 
 reading_power_mode = "Luetaan virtatilaa…"
 couldnt_read_power_mode_click_to_retry = "Virtatilan lukeminen epäonnistui. Yritä uudelleen napsauttamalla."
 this_device_does_not_support_power_mode = "Tämä laite ei tue virtatilan vaihtoa."
+power_mode_macos_pointer_note = "Suorituskykytilan suurempi raportointitaajuus voi saada macOS-osoittimen tuntumaan hitaammalta. Kyse on järjestelmän kiihtyvyyskäyrästä, ei DPI-muutoksesta."
 
 [actions]
 bind_control = "Määritä %{name}"

--- a/crates/openlogi-ui/locales/fr.toml
+++ b/crates/openlogi-ui/locales/fr.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Appareil hors ligne. Mode d'alimenta
 reading_power_mode = "Lecture du mode d'alimentation…"
 couldnt_read_power_mode_click_to_retry = "Impossible de lire le mode d'alimentation. Cliquez pour réessayer."
 this_device_does_not_support_power_mode = "Cet appareil ne prend pas en charge le changement de mode d'alimentation."
+power_mode_macos_pointer_note = "La fréquence de rapport plus élevée du mode performance peut faire paraître le pointeur macOS plus lent. C'est la courbe d'accélération du système, pas un changement de DPI."
 
 [actions]
 bind_control = "Attribuer %{name}"

--- a/crates/openlogi-ui/locales/fr.toml
+++ b/crates/openlogi-ui/locales/fr.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Détecte les mouvements plus fins entre
 wheel_resolution_unsupported = "Cet appareil ne prend pas en charge le réglage de la résolution de la molette."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Mode d'alimentation"
+performance_mode = "Mode performance"
+power_mode_description = "Performance débloque toutes les fréquences de rapport ; endurance prolonge l'autonomie."
+power_mode_hardware_switch_only = "Le mode d'alimentation de cet appareil se règle avec son commutateur matériel."
+device_offline_power_mode_is_unavailable = "Appareil hors ligne. Mode d'alimentation indisponible."
+reading_power_mode = "Lecture du mode d'alimentation…"
+couldnt_read_power_mode_click_to_retry = "Impossible de lire le mode d'alimentation. Cliquez pour réessayer."
+this_device_does_not_support_power_mode = "Cet appareil ne prend pas en charge le changement de mode d'alimentation."
 
 [actions]
 bind_control = "Attribuer %{name}"

--- a/crates/openlogi-ui/locales/it.toml
+++ b/crates/openlogi-ui/locales/it.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Rileva movimenti più fini tra gli scat
 wheel_resolution_unsupported = "Questo dispositivo non supporta il controllo della risoluzione della rotellina."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Modalità di alimentazione"
+performance_mode = "Modalità prestazioni"
+power_mode_description = "Prestazioni sblocca tutte le frequenze di polling; risparmio prolunga la batteria."
+power_mode_hardware_switch_only = "La modalità di alimentazione di questo dispositivo si imposta con il suo interruttore fisico."
+device_offline_power_mode_is_unavailable = "Dispositivo offline. Modalità di alimentazione non disponibile."
+reading_power_mode = "Lettura della modalità di alimentazione…"
+couldnt_read_power_mode_click_to_retry = "Impossibile leggere la modalità di alimentazione. Fai clic per riprovare."
+this_device_does_not_support_power_mode = "Questo dispositivo non supporta il cambio della modalità di alimentazione."
 
 [actions]
 bind_control = "Associa %{name}"

--- a/crates/openlogi-ui/locales/it.toml
+++ b/crates/openlogi-ui/locales/it.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Dispositivo offline. Modalità di al
 reading_power_mode = "Lettura della modalità di alimentazione…"
 couldnt_read_power_mode_click_to_retry = "Impossibile leggere la modalità di alimentazione. Fai clic per riprovare."
 this_device_does_not_support_power_mode = "Questo dispositivo non supporta il cambio della modalità di alimentazione."
+power_mode_macos_pointer_note = "La frequenza di polling più alta della modalità prestazioni può far sembrare più lento il puntatore di macOS. È la curva di accelerazione del sistema, non un cambio di DPI."
 
 [actions]
 bind_control = "Associa %{name}"

--- a/crates/openlogi-ui/locales/ja.toml
+++ b/crates/openlogi-ui/locales/ja.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "デバイスはオフラインです
 reading_power_mode = "電源モードを読み取っています…"
 couldnt_read_power_mode_click_to_retry = "電源モードを読み取れませんでした。クリックして再試行してください。"
 this_device_does_not_support_power_mode = "このデバイスは電源モードの切り替えに対応していません。"
+power_mode_macos_pointer_note = "パフォーマンスモードの高いレポートレートでは、macOSのポインターが遅く感じられることがあります。これはシステムの加速カーブによるもので、DPIの変更ではありません。"
 
 [actions]
 bind_control = "%{name} を割り当て"

--- a/crates/openlogi-ui/locales/ja.toml
+++ b/crates/openlogi-ui/locales/ja.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "ラチェットの段間にある細か
 wheel_resolution_unsupported = "このデバイスはホイール解像度の制御に対応していません。"
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "電源モード"
+performance_mode = "パフォーマンスモード"
+power_mode_description = "パフォーマンスは全レポートレートを利用可能にし、エンデュランスはバッテリー駆動時間を延ばします。"
+power_mode_hardware_switch_only = "このデバイスの電源モードは本体のハードウェアスイッチで設定します。"
+device_offline_power_mode_is_unavailable = "デバイスはオフラインです。電源モードは利用できません。"
+reading_power_mode = "電源モードを読み取っています…"
+couldnt_read_power_mode_click_to_retry = "電源モードを読み取れませんでした。クリックして再試行してください。"
+this_device_does_not_support_power_mode = "このデバイスは電源モードの切り替えに対応していません。"
 
 [actions]
 bind_control = "%{name} を割り当て"

--- a/crates/openlogi-ui/locales/ko.toml
+++ b/crates/openlogi-ui/locales/ko.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "래칫 단계 사이의 미세한 움�
 wheel_resolution_unsupported = "이 기기는 휠 해상도 제어를 지원하지 않습니다."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "전원 모드"
+performance_mode = "성능 모드"
+power_mode_description = "성능 모드는 모든 보고 속도를 사용할 수 있게 하고, 지구력 모드는 배터리 사용 시간을 늘립니다."
+power_mode_hardware_switch_only = "이 장치의 전원 모드는 하드웨어 스위치로 설정합니다."
+device_offline_power_mode_is_unavailable = "장치가 오프라인입니다. 전원 모드를 사용할 수 없습니다."
+reading_power_mode = "전원 모드를 읽는 중…"
+couldnt_read_power_mode_click_to_retry = "전원 모드를 읽지 못했습니다. 클릭하여 다시 시도하세요."
+this_device_does_not_support_power_mode = "이 장치는 전원 모드 전환을 지원하지 않습니다."
 
 [actions]
 bind_control = "%{name} 지정"

--- a/crates/openlogi-ui/locales/ko.toml
+++ b/crates/openlogi-ui/locales/ko.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "장치가 오프라인입니다. 전
 reading_power_mode = "전원 모드를 읽는 중…"
 couldnt_read_power_mode_click_to_retry = "전원 모드를 읽지 못했습니다. 클릭하여 다시 시도하세요."
 this_device_does_not_support_power_mode = "이 장치는 전원 모드 전환을 지원하지 않습니다."
+power_mode_macos_pointer_note = "성능 모드의 높은 보고 속도에서는 macOS 포인터가 느리게 느껴질 수 있습니다. 이는 시스템 가속 곡선 때문이며 DPI 변경이 아닙니다."
 
 [actions]
 bind_control = "%{name} 지정"

--- a/crates/openlogi-ui/locales/nb.toml
+++ b/crates/openlogi-ui/locales/nb.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Oppdager finere bevegelse mellom hakken
 wheel_resolution_unsupported = "Denne enheten støtter ikke styring av hjuloppløsning."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Strømmodus"
+performance_mode = "Ytelsesmodus"
+power_mode_description = "Ytelse låser opp alle rapporteringsrater; utholdenhet forlenger batteritiden."
+power_mode_hardware_switch_only = "Strømmodusen på denne enheten stilles med maskinvarebryteren."
+device_offline_power_mode_is_unavailable = "Enheten er frakoblet. Strømmodus er utilgjengelig."
+reading_power_mode = "Leser strømmodus…"
+couldnt_read_power_mode_click_to_retry = "Kunne ikke lese strømmodusen. Klikk for å prøve igjen."
+this_device_does_not_support_power_mode = "Denne enheten støtter ikke bytte av strømmodus."
 
 [actions]
 bind_control = "Tilordne %{name}"

--- a/crates/openlogi-ui/locales/nb.toml
+++ b/crates/openlogi-ui/locales/nb.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Enheten er frakoblet. Strømmodus er
 reading_power_mode = "Leser strømmodus…"
 couldnt_read_power_mode_click_to_retry = "Kunne ikke lese strømmodusen. Klikk for å prøve igjen."
 this_device_does_not_support_power_mode = "Denne enheten støtter ikke bytte av strømmodus."
+power_mode_macos_pointer_note = "Den høyere rapporteringsraten i ytelsesmodus kan få macOS-pekeren til å føles tregere. Det er systemets akselerasjonskurve, ikke en DPI-endring."
 
 [actions]
 bind_control = "Tilordne %{name}"

--- a/crates/openlogi-ui/locales/nl.toml
+++ b/crates/openlogi-ui/locales/nl.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Apparaat offline. Energiemodus is ni
 reading_power_mode = "Energiemodus wordt gelezen…"
 couldnt_read_power_mode_click_to_retry = "Kan de energiemodus niet lezen. Klik om opnieuw te proberen."
 this_device_does_not_support_power_mode = "Dit apparaat ondersteunt geen energiemoduswissel."
+power_mode_macos_pointer_note = "De hogere rapportagesnelheid van de prestatiemodus kan de macOS-aanwijzer trager doen aanvoelen. Dat is de versnellingscurve van het systeem, geen DPI-wijziging."
 
 [actions]
 bind_control = "%{name} toewijzen"

--- a/crates/openlogi-ui/locales/nl.toml
+++ b/crates/openlogi-ui/locales/nl.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Detecteert fijnere bewegingen tussen ra
 wheel_resolution_unsupported = "Dit apparaat ondersteunt geen regeling van de wielresolutie."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Energiemodus"
+performance_mode = "Prestatiemodus"
+power_mode_description = "Prestatie ontgrendelt alle rapportagesnelheden; uithouding verlengt de batterijduur."
+power_mode_hardware_switch_only = "De energiemodus van dit apparaat wordt met de hardwareschakelaar ingesteld."
+device_offline_power_mode_is_unavailable = "Apparaat offline. Energiemodus is niet beschikbaar."
+reading_power_mode = "Energiemodus wordt gelezen…"
+couldnt_read_power_mode_click_to_retry = "Kan de energiemodus niet lezen. Klik om opnieuw te proberen."
+this_device_does_not_support_power_mode = "Dit apparaat ondersteunt geen energiemoduswissel."
 
 [actions]
 bind_control = "%{name} toewijzen"

--- a/crates/openlogi-ui/locales/pl.toml
+++ b/crates/openlogi-ui/locales/pl.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Wykrywa drobniejsze ruchy między skoka
 wheel_resolution_unsupported = "To urządzenie nie obsługuje sterowania rozdzielczością kółka."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Tryb zasilania"
+performance_mode = "Tryb wydajności"
+power_mode_description = "Wydajność odblokowuje pełny zakres częstotliwości raportowania; oszczędzanie wydłuża czas pracy baterii."
+power_mode_hardware_switch_only = "Tryb zasilania tego urządzenia ustawia się jego przełącznikiem sprzętowym."
+device_offline_power_mode_is_unavailable = "Urządzenie offline. Tryb zasilania jest niedostępny."
+reading_power_mode = "Odczytywanie trybu zasilania…"
+couldnt_read_power_mode_click_to_retry = "Nie udało się odczytać trybu zasilania. Kliknij, aby spróbować ponownie."
+this_device_does_not_support_power_mode = "To urządzenie nie obsługuje przełączania trybu zasilania."
 
 [actions]
 bind_control = "Przypisz %{name}"

--- a/crates/openlogi-ui/locales/pl.toml
+++ b/crates/openlogi-ui/locales/pl.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Urządzenie offline. Tryb zasilania 
 reading_power_mode = "Odczytywanie trybu zasilania…"
 couldnt_read_power_mode_click_to_retry = "Nie udało się odczytać trybu zasilania. Kliknij, aby spróbować ponownie."
 this_device_does_not_support_power_mode = "To urządzenie nie obsługuje przełączania trybu zasilania."
+power_mode_macos_pointer_note = "Wyższa częstotliwość raportowania trybu wydajności może sprawiać, że wskaźnik macOS wydaje się wolniejszy. To krzywa przyspieszenia systemu, a nie zmiana DPI."
 
 [actions]
 bind_control = "Przypisz %{name}"

--- a/crates/openlogi-ui/locales/pt-BR.toml
+++ b/crates/openlogi-ui/locales/pt-BR.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Dispositivo offline. O modo de energ
 reading_power_mode = "Lendo o modo de energia…"
 couldnt_read_power_mode_click_to_retry = "Não foi possível ler o modo de energia. Clique para tentar novamente."
 this_device_does_not_support_power_mode = "Este dispositivo não suporta troca de modo de energia."
+power_mode_macos_pointer_note = "A taxa de resposta mais alta do modo desempenho pode fazer o ponteiro do macOS parecer mais lento. É a curva de aceleração do sistema, não uma mudança de DPI."
 
 [actions]
 bind_control = "Atribuir %{name}"

--- a/crates/openlogi-ui/locales/pt-BR.toml
+++ b/crates/openlogi-ui/locales/pt-BR.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Detecta movimentos mais sutis entre as 
 wheel_resolution_unsupported = "Este dispositivo não oferece controle de resolução da roda."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Modo de energia"
+performance_mode = "Modo desempenho"
+power_mode_description = "Desempenho libera todas as taxas de resposta; resistência prolonga a bateria."
+power_mode_hardware_switch_only = "O modo de energia deste dispositivo é definido pelo interruptor físico."
+device_offline_power_mode_is_unavailable = "Dispositivo offline. O modo de energia está indisponível."
+reading_power_mode = "Lendo o modo de energia…"
+couldnt_read_power_mode_click_to_retry = "Não foi possível ler o modo de energia. Clique para tentar novamente."
+this_device_does_not_support_power_mode = "Este dispositivo não suporta troca de modo de energia."
 
 [actions]
 bind_control = "Atribuir %{name}"

--- a/crates/openlogi-ui/locales/pt-PT.toml
+++ b/crates/openlogi-ui/locales/pt-PT.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Deteta movimentos mais finos entre os p
 wheel_resolution_unsupported = "Este dispositivo não suporta o controlo da resolução da roda."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Modo de energia"
+performance_mode = "Modo de desempenho"
+power_mode_description = "O desempenho desbloqueia todas as taxas de resposta; a resistência prolonga a bateria."
+power_mode_hardware_switch_only = "O modo de energia deste dispositivo define-se com o interruptor físico."
+device_offline_power_mode_is_unavailable = "Dispositivo offline. O modo de energia está indisponível."
+reading_power_mode = "A ler o modo de energia…"
+couldnt_read_power_mode_click_to_retry = "Não foi possível ler o modo de energia. Clique para tentar novamente."
+this_device_does_not_support_power_mode = "Este dispositivo não suporta a mudança de modo de energia."
 
 [actions]
 bind_control = "Atribuir %{name}"

--- a/crates/openlogi-ui/locales/pt-PT.toml
+++ b/crates/openlogi-ui/locales/pt-PT.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Dispositivo offline. O modo de energ
 reading_power_mode = "A ler o modo de energia…"
 couldnt_read_power_mode_click_to_retry = "Não foi possível ler o modo de energia. Clique para tentar novamente."
 this_device_does_not_support_power_mode = "Este dispositivo não suporta a mudança de modo de energia."
+power_mode_macos_pointer_note = "A taxa de resposta mais alta do modo de desempenho pode fazer o ponteiro do macOS parecer mais lento. É a curva de aceleração do sistema, não uma alteração de DPI."
 
 [actions]
 bind_control = "Atribuir %{name}"

--- a/crates/openlogi-ui/locales/ru.toml
+++ b/crates/openlogi-ui/locales/ru.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Обнаруживает более м�
 wheel_resolution_unsupported = "Это устройство не поддерживает управление разрешением колеса."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Режим питания"
+performance_mode = "Режим производительности"
+power_mode_description = "Производительность открывает весь диапазон частот опроса; экономия продлевает работу от батареи."
+power_mode_hardware_switch_only = "Режим питания этого устройства задаётся его аппаратным переключателем."
+device_offline_power_mode_is_unavailable = "Устройство не в сети. Режим питания недоступен."
+reading_power_mode = "Чтение режима питания…"
+couldnt_read_power_mode_click_to_retry = "Не удалось прочитать режим питания. Нажмите, чтобы повторить."
+this_device_does_not_support_power_mode = "Это устройство не поддерживает переключение режима питания."
 
 [actions]
 bind_control = "Назначить %{name}"

--- a/crates/openlogi-ui/locales/ru.toml
+++ b/crates/openlogi-ui/locales/ru.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Устройство не в сет�
 reading_power_mode = "Чтение режима питания…"
 couldnt_read_power_mode_click_to_retry = "Не удалось прочитать режим питания. Нажмите, чтобы повторить."
 this_device_does_not_support_power_mode = "Это устройство не поддерживает переключение режима питания."
+power_mode_macos_pointer_note = "Более высокая частота опроса в режиме производительности может делать указатель macOS субъективно медленнее. Это кривая ускорения системы, а не изменение DPI."
 
 [actions]
 bind_control = "Назначить %{name}"

--- a/crates/openlogi-ui/locales/sv.toml
+++ b/crates/openlogi-ui/locales/sv.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Enheten är frånkopplad. Strömläg
 reading_power_mode = "Läser strömläge…"
 couldnt_read_power_mode_click_to_retry = "Kunde inte läsa strömläget. Klicka för att försöka igen."
 this_device_does_not_support_power_mode = "Den här enheten stöder inte byte av strömläge."
+power_mode_macos_pointer_note = "Prestandalägets högre rapportfrekvens kan få macOS-pekaren att kännas långsammare. Det är systemets accelerationskurva, inte en DPI-ändring."
 
 [actions]
 bind_control = "Bind %{name}"

--- a/crates/openlogi-ui/locales/sv.toml
+++ b/crates/openlogi-ui/locales/sv.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Upptäcker finare rörelser mellan spä
 wheel_resolution_unsupported = "Den här enheten stöder inte styrning av hjulupplösning."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Strömläge"
+performance_mode = "Prestandaläge"
+power_mode_description = "Prestanda låser upp alla rapportfrekvenser; uthållighet förlänger batteritiden."
+power_mode_hardware_switch_only = "Enhetens strömläge ställs in med dess hårdvarubrytare."
+device_offline_power_mode_is_unavailable = "Enheten är frånkopplad. Strömläget är inte tillgängligt."
+reading_power_mode = "Läser strömläge…"
+couldnt_read_power_mode_click_to_retry = "Kunde inte läsa strömläget. Klicka för att försöka igen."
+this_device_does_not_support_power_mode = "Den här enheten stöder inte byte av strömläge."
 
 [actions]
 bind_control = "Bind %{name}"

--- a/crates/openlogi-ui/locales/tr.toml
+++ b/crates/openlogi-ui/locales/tr.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Kademeler arasındaki daha ince hareket
 wheel_resolution_unsupported = "Bu cihaz tekerlek çözünürlüğü denetimini desteklemiyor."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Güç modu"
+performance_mode = "Performans modu"
+power_mode_description = "Performans tüm rapor hızlarını açar; dayanıklılık pil ömrünü uzatır."
+power_mode_hardware_switch_only = "Bu cihazın güç modu donanım anahtarıyla ayarlanır."
+device_offline_power_mode_is_unavailable = "Cihaz çevrimdışı. Güç modu kullanılamıyor."
+reading_power_mode = "Güç modu okunuyor…"
+couldnt_read_power_mode_click_to_retry = "Güç modu okunamadı. Yeniden denemek için tıklayın."
+this_device_does_not_support_power_mode = "Bu cihaz güç modu değiştirmeyi desteklemiyor."
 
 [actions]
 bind_control = "%{name} ata"

--- a/crates/openlogi-ui/locales/tr.toml
+++ b/crates/openlogi-ui/locales/tr.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Cihaz çevrimdışı. Güç modu kul
 reading_power_mode = "Güç modu okunuyor…"
 couldnt_read_power_mode_click_to_retry = "Güç modu okunamadı. Yeniden denemek için tıklayın."
 this_device_does_not_support_power_mode = "Bu cihaz güç modu değiştirmeyi desteklemiyor."
+power_mode_macos_pointer_note = "Performans modunun daha yüksek rapor hızı macOS imlecinin daha yavaş hissettirmesine yol açabilir. Bu, DPI değişikliği değil, sistemin ivme eğrisidir."
 
 [actions]
 bind_control = "%{name} ata"

--- a/crates/openlogi-ui/locales/uk.toml
+++ b/crates/openlogi-ui/locales/uk.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "Розпізнає дрібніші р�
 wheel_resolution_unsupported = "Цей пристрій не підтримує керування роздільністю коліщатка."
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "Режим живлення"
+performance_mode = "Режим продуктивності"
+power_mode_description = "Продуктивність відкриває весь діапазон частот опитування; економія подовжує роботу від батареї."
+power_mode_hardware_switch_only = "Режим живлення цього пристрою задається його апаратним перемикачем."
+device_offline_power_mode_is_unavailable = "Пристрій не в мережі. Режим живлення недоступний."
+reading_power_mode = "Читання режиму живлення…"
+couldnt_read_power_mode_click_to_retry = "Не вдалося прочитати режим живлення. Натисніть, щоб повторити."
+this_device_does_not_support_power_mode = "Цей пристрій не підтримує перемикання режиму живлення."
 
 [actions]
 bind_control = "Прив'язати %{name}"

--- a/crates/openlogi-ui/locales/uk.toml
+++ b/crates/openlogi-ui/locales/uk.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "Пристрій не в мереж�
 reading_power_mode = "Читання режиму живлення…"
 couldnt_read_power_mode_click_to_retry = "Не вдалося прочитати режим живлення. Натисніть, щоб повторити."
 this_device_does_not_support_power_mode = "Цей пристрій не підтримує перемикання режиму живлення."
+power_mode_macos_pointer_note = "Вища частота опитування в режимі продуктивності може робити вказівник macOS повільнішим на відчуття. Це крива прискорення системи, а не зміна DPI."
 
 [actions]
 bind_control = "Прив'язати %{name}"

--- a/crates/openlogi-ui/locales/zh-CN.toml
+++ b/crates/openlogi-ui/locales/zh-CN.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "设备离线。电源模式不可用
 reading_power_mode = "正在读取电源模式…"
 couldnt_read_power_mode_click_to_retry = "无法读取电源模式。点击重试。"
 this_device_does_not_support_power_mode = "此设备不支持切换电源模式。"
+power_mode_macos_pointer_note = "性能模式更高的回报率可能让 macOS 指针感觉变慢。这是系统加速曲线所致，并非 DPI 变化。"
 
 [actions]
 bind_control = "绑定 %{name}"

--- a/crates/openlogi-ui/locales/zh-CN.toml
+++ b/crates/openlogi-ui/locales/zh-CN.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "检测棘轮刻度之间更细微的移
 wheel_resolution_unsupported = "此设备不支持滚轮分辨率控制。"
 wheel_resolution_other_connection = "此设备通过其他连接时支持滚轮分辨率控制，但当前连接不支持。"
 smartshift = "SmartShift"
+power_mode = "电源模式"
+performance_mode = "性能模式"
+power_mode_description = "性能模式解锁全部回报率；续航模式延长电池续航。"
+power_mode_hardware_switch_only = "此设备的电源模式由其硬件开关设置。"
+device_offline_power_mode_is_unavailable = "设备离线。电源模式不可用。"
+reading_power_mode = "正在读取电源模式…"
+couldnt_read_power_mode_click_to_retry = "无法读取电源模式。点击重试。"
+this_device_does_not_support_power_mode = "此设备不支持切换电源模式。"
 
 [actions]
 bind_control = "绑定 %{name}"

--- a/crates/openlogi-ui/locales/zh-HK.toml
+++ b/crates/openlogi-ui/locales/zh-HK.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "裝置離線。電源模式不可用
 reading_power_mode = "正在讀取電源模式…"
 couldnt_read_power_mode_click_to_retry = "無法讀取電源模式。按一下重試。"
 this_device_does_not_support_power_mode = "此裝置不支援切換電源模式。"
+power_mode_macos_pointer_note = "效能模式較高的回報率可能令 macOS 指標感覺變慢。這是系統加速曲線所致，並非 DPI 變化。"
 
 [actions]
 bind_control = "綁定 %{name}"

--- a/crates/openlogi-ui/locales/zh-HK.toml
+++ b/crates/openlogi-ui/locales/zh-HK.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "偵測棘輪段落之間更細微的移
 wheel_resolution_unsupported = "此裝置不支援滾輪解析度控制。"
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "電源模式"
+performance_mode = "效能模式"
+power_mode_description = "效能模式解鎖全部回報率；續航模式延長電池壽命。"
+power_mode_hardware_switch_only = "此裝置的電源模式由其硬件開關設定。"
+device_offline_power_mode_is_unavailable = "裝置離線。電源模式不可用。"
+reading_power_mode = "正在讀取電源模式…"
+couldnt_read_power_mode_click_to_retry = "無法讀取電源模式。按一下重試。"
+this_device_does_not_support_power_mode = "此裝置不支援切換電源模式。"
 
 [actions]
 bind_control = "綁定 %{name}"

--- a/crates/openlogi-ui/locales/zh-TW.toml
+++ b/crates/openlogi-ui/locales/zh-TW.toml
@@ -232,6 +232,14 @@ high_resolution_scrolling_description = "偵測棘輪段落之間更細微的移
 wheel_resolution_unsupported = "此裝置不支援滾輪解析度控制。"
 wheel_resolution_other_connection = "This device supports wheel resolution on its other connection, but not this one."
 smartshift = "SmartShift"
+power_mode = "電源模式"
+performance_mode = "效能模式"
+power_mode_description = "效能模式解鎖全部回報率；續航模式延長電池續航力。"
+power_mode_hardware_switch_only = "此裝置的電源模式由其硬體開關設定。"
+device_offline_power_mode_is_unavailable = "裝置離線。電源模式無法使用。"
+reading_power_mode = "正在讀取電源模式…"
+couldnt_read_power_mode_click_to_retry = "無法讀取電源模式。按一下以重試。"
+this_device_does_not_support_power_mode = "此裝置不支援切換電源模式。"
 
 [actions]
 bind_control = "設定 %{name}"

--- a/crates/openlogi-ui/locales/zh-TW.toml
+++ b/crates/openlogi-ui/locales/zh-TW.toml
@@ -240,6 +240,7 @@ device_offline_power_mode_is_unavailable = "裝置離線。電源模式無法使
 reading_power_mode = "正在讀取電源模式…"
 couldnt_read_power_mode_click_to_retry = "無法讀取電源模式。按一下以重試。"
 this_device_does_not_support_power_mode = "此裝置不支援切換電源模式。"
+power_mode_macos_pointer_note = "效能模式較高的回報率可能讓 macOS 指標感覺變慢。這是系統加速曲線所致，並非 DPI 變化。"
 
 [actions]
 bind_control = "設定 %{name}"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,6 +10,7 @@ openlogi diag features        # dump every HID++ feature the active device repor
 openlogi diag controls        # dump reprogrammable controls and capability flags
 openlogi diag dpi             # read → write → read-back → restore DPI (smoke test)
 openlogi diag smartshift      # toggle SmartShift and restore (smoke test)
+openlogi diag power-mode      # toggle performance/endurance and restore (smoke test)
 openlogi diag lighting ff0000 # solid colour for a wired RGB keyboard (any RRGGBB hex)
 ```
 


### PR DESCRIPTION
## Summary

Wires the existing `ModeStatusFeature` (HID++ `0x8090`, performance/endurance power mode) end to end, per the plan in #1193: the driver decodes the mode-change event, the agent serves read/write RPCs, the GUI gets a Performance-mode toggle on the Pointer tab, and the CLI gets a `diag power-mode` round-trip. All protocol behavior follows the G305 measurements in the issue: `status0` bit 0, `changed_mask0`-only writes (a set touching `changed_mask1` answers `InvalidArgument`), `getDevConfig` gating, and the `01 00 01` / `00 00 01` event-0 broadcasts.

## Changes

- **hidpp**: `ModeStatusFeature` gains an `EventSource<ModeStatusEvent>` plus a public `ModeStatusEvent::decode` shim (same shape as `unified_battery`); payload layout is marked reverse-engineered from G305 captures.
- **core**: new `hid::mode_status` module with the IPC-facing `PowerMode` / `PowerModeState`; `HidppOperation` gains `ReadPowerMode` / `WritePowerMode` (appended, wire-safe).
- **device / hid**: `write/power_mode.rs` with `get_power_mode(_on)` / `set_power_mode(_on)` (writes only `changed_mask0`), host-facade wrappers, and scripted-channel tests asserting the exact set bytes `01 00 01 00`.
- **ipc**: `read_power_mode` / `set_power_mode` appended to the trait, `PROTOCOL_VERSION` 29 -> 30, wire-format goldens extended (request variants `0x1a`/`0x1b`, result encoding pinned).
- **agent**: both RPCs served over the shared per-device channel runner; the mock agent seeds the Bolt mouse with a G305-shaped state (endurance, software switch only) so the GUI dev loop exercises the panel.
- **gui**: a "Power mode" card on the Pointer tab with a Performance toggle, gated in-place like SmartShift (`Load::Unsupported` degradation, no `Capabilities` churn). The toggle disables when `getDevConfig` reports no software switch. Writes are optimistic with a confirming re-read; the resolved value is never persisted because the device keeps the mode across power cycles itself (verified in the issue) - deliberately no `config.toml` surface. Reads re-arm on selection/inventory changes, so every reconnect re-reads the mode as the issue recommends.
- **i18n**: 8 new `[pointer]` keys across all 23 catalogs (best-effort translations; happy to take corrections).
- **cli**: `openlogi diag power-mode` - read -> toggle -> read-back -> restore, `--set performance|endurance` to leave a mode applied, `--device` filter; device auto-selection keys on feature `0x8090`.
- **docs**: one `diag power-mode` line in USAGE.md.

The last commit fixes a pre-existing `get_device_config` byte-order bug the hardware run exposed (details under Testing).

Deliberate scope cuts (can follow up if wanted): no agent-side event consumption yet (the driver decode + shim make that a small follow-up in `inventory/events.rs`), no bindable button action, no report-rate UI interplay (OpenLogi does not wire `0x8060` today).

## Screenshot

The card on a real G305 (Pointer tab, macOS), served by the agent over the new RPCs - endurance active, toggle live, with the macOS pointer-speed note:

![Power mode card on a G305](https://raw.githubusercontent.com/007hacky007/OpenLogi/pr-assets/power-mode-card-g305.png)

## Testing

- `cargo test -p openlogi-hidpp` (event decode: post-set `01 00 01`, power-on `00 00 01`, non-zero function rejected)
- `cargo test -p openlogi-device` (scripted-channel read + exact write bytes)
- `cargo test -p openlogi-ipc --test wire_format` (new goldens + pinned v30)
- `cargo test -p openlogi-ui locale` and `cargo test -p openlogi-desktop i18n` (23-catalog parity)
- Full local gate: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` (RUSTFLAGS="-D warnings"), `cargo test --workspace`, non-GUI rustdoc, `typos --config .config/typos.toml .`
- Not run: `cargo-deny`, MSRV matrix, Linux/Windows clippy (no toolchains on this host)
- Desktop app runtime-verified twice: against `openlogi-agent-mock`, and against the real agent + G305 over the receiver - the screenshot above is live hardware, read through the new `read_power_mode` RPC
- **Real-hardware verification (G305, WPID 0x4074, Lightspeed receiver)**: `openlogi diag power-mode` round-trip passes - reads Endurance, toggles to Performance, reads it back, restores Endurance. It also caught a latent driver bug on the first run: `get_device_config` decoded the capability bytes big-endian, shifting the G305's `0x02` (software switch) into the high byte and reporting no capabilities at all - which would have greyed out the GUI toggle on the exact device this feature targets. Fixed to read the byte the device answers (little-endian; the scripted fixture now mirrors the real reply) and re-verified: the diag reports `software_switch=true hardware_switch=false`, matching the issue's capture.

Field observation worth documenting: with macOS pointer acceleration enabled, switching to performance (report rate 8 ms -> 1 ms) makes the cursor *feel* slower at the same DPI - per-report deltas are 8x smaller and the OS acceleration curve gives small deltas less gain. Verified the sensor DPI itself is untouched by the mode switch (read 4400 in both modes on the G305). Not an OpenLogi bug, but it is the first thing a tester notices, so the card now carries a macOS-only caption explaining it (new `pointer.power_mode_macos_pointer_note` key in all catalogs).

Fixes #1193
