### PR TITLE
fix(windows): Use `Win` for `Cmd` CustomShortcut

### DIFF
--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -284,7 +284,7 @@ fn post_custom_shortcut(combo: &KeyCombo) {
 fn combo_modifiers(combo: &KeyCombo) -> Vec<u16> {
     let mut modifiers = Vec::new();
     if combo.has_command() {
-        modifiers.push(VK_CONTROL);
+        modifiers.push(VK_LWIN);
     }
     if combo.has_shift() {
         modifiers.push(VK_SHIFT);


### PR DESCRIPTION
As issue #893 reports, the Cmd or Win CustomShortcuts don't map to the Win-button. This happens because the current Windows configuration instead maps the command-button to the Ctrl-button.

I didn't find any tests that cover Windows-specific keybindings, and didn't see any easy ways to add that. This PR was only manually tested to work on a Windows with the `HaptipPanel` TOML config attached below by running `cargo run -p openlogi-agent --bin openlogi-agent` together with `cargo run -p openlogi-desktop --release`.

```toml
Up = { CustomShortcut = "Win+Up" }
Down = { CustomShortcut = "Win+Down" }
Right = { CustomShortcut = "Win+Right" }
Left = { CustomShortcut = "Win+Left" }
Click = { CustomShortcut = "Win+D" }
```