### PR TITLE
fix(linux): declare F13-F20 in uinput key capabilities

### DIFF
--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -274,6 +274,8 @@ const KEY_CAPABILITIES: &[KeyCode] = &[
     KeyCode::KEY_F1,  KeyCode::KEY_F2,  KeyCode::KEY_F3,  KeyCode::KEY_F4,
     KeyCode::KEY_F5,  KeyCode::KEY_F6,  KeyCode::KEY_F7,  KeyCode::KEY_F8,
     KeyCode::KEY_F9,  KeyCode::KEY_F10, KeyCode::KEY_F11, KeyCode::KEY_F12,
+    KeyCode::KEY_F13, KeyCode::KEY_F14, KeyCode::KEY_F15, KeyCode::KEY_F16,
+    KeyCode::KEY_F17, KeyCode::KEY_F18, KeyCode::KEY_F19, KeyCode::KEY_F20,
     // System
     KeyCode::KEY_SYSRQ,
     // Multimedia


### PR DESCRIPTION
## Summary

`CustomShortcut` bindings on F13–F20 never reach the compositor on Linux. `hid_usage_to_linux` maps HID usages `0x68..=0x6f` to `KEY_F13`..`KEY_F20` and `validate_keyboard_usage` accepts them, but `KEY_CAPABILITIES` declares only F1–F12. A uinput device cannot emit a key it has not declared, so the kernel drops the event: the binding parses, validates and resolves, then does nothing, with no error on any path.

The mapping is already covered by a test asserting `hid_usage_to_linux(0x6f) == KEY_F20`. Only the capability declaration was missing.

## Changes

- `openlogi-inject`: declare `KEY_F13`–`KEY_F20` in `KEY_CAPABILITIES` (`inject/linux.rs`).

## Testing

- `cargo fmt --check -p openlogi-inject`
- `cargo clippy -p openlogi-inject --all-targets -- -D warnings`
- `cargo test -p openlogi-inject` — 10 passed

Verified on hardware (Ubuntu 24.04, X11, MX Master 4 for Business over Bluetooth) by decoding the injector's capability bitmap from `/proc/bus/input/devices`:

- v0.8.3 packaged build: F1–F12 present, F13–F20 absent. A button bound to `F18` produced no event.
- This build: F13–F20 present.

Refs #431
