### PR TITLE
fix(core): stop seeding Back/Forward with a divertable default

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -320,6 +320,38 @@ mod tests {
     }
 
     #[test]
+    fn thumb_button_bound_to_a_browser_action_is_diverted() {
+        // BrowserBack used to be the default action for Back, so choosing it
+        // in the GUI matched the default and the button was never diverted.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b023",
+            ButtonId::Back,
+            Binding::Single(Action::BrowserBack),
+        );
+
+        let plan = plan_for_device(&cfg, "2b023", route(), None, 0, true);
+        assert!(
+            plan.target
+                .spec
+                .divert_buttons
+                .iter()
+                .any(|&(_, button)| button == ButtonId::Back),
+            "a thumb button bound to a browser action must be diverted: {:?}",
+            plan.target.spec.divert_buttons
+        );
+        assert!(
+            !plan
+                .target
+                .spec
+                .divert_buttons
+                .iter()
+                .any(|&(_, button)| button == ButtonId::Forward),
+            "the untouched forward button must keep its native button 5"
+        );
+    }
+
+    #[test]
     fn haptic_panel_gestures_when_promoted() {
         // The MX Master 4 haptic panel is a HID++ gesture source: promoting it
         // into gesture mode must arm the raw-XY gesture divert, exactly like

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -48,8 +48,11 @@ pub fn default_binding(button: ButtonId) -> Action {
             reason = "see the left tilt above — same control pair, mirrored direction"
         )]
         ButtonId::WheelTiltRight => Action::HorizontalScrollRight,
-        ButtonId::Back => Action::BrowserBack,
-        ButtonId::Forward => Action::BrowserForward,
+        // Seeding this as BrowserBack made it unreachable: picking BrowserBack
+        // in the GUI matched the default, so capture_plan never diverted the
+        // button and the action never fired.
+        ButtonId::Back => Action::MouseBack,
+        ButtonId::Forward => Action::MouseForward,
         ButtonId::DpiToggle => Action::CycleDpiPresets,
         #[expect(
             clippy::match_same_arms,

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1596,7 +1596,7 @@ fn set_gesture_mode_off_without_click_falls_back_to_the_default() {
 
     assert_eq!(
         cfg.bindings_for("2b042").get(&ButtonId::Back),
-        Some(&Binding::Single(Action::BrowserBack))
+        Some(&Binding::Single(Action::MouseBack))
     );
 }
 


### PR DESCRIPTION
## Summary

- Reseed `ButtonId::Back`/`ButtonId::Forward`'s default binding from `BrowserBack`/`BrowserForward` to `MouseBack`/`MouseForward`.

## Changes

- `openlogi-core`: `default_binding` now seeds Back/Forward with `MouseBack`/`MouseForward` instead of `BrowserBack`/`BrowserForward`.
- `openlogi-core`: update a config test's expected fallback value to match the new default.
- `openlogi-agent-core`: add a regression test asserting a thumb button bound to `BrowserBack` is diverted, while an untouched Forward stays native.

## Why

`capture_plan` only diverts a button into OpenLogi's dispatch pipeline when its configured binding differs from `default_binding`. Back/Forward's default was `BrowserBack`/`BrowserForward` — so picking that same action in the GUI (the obviously correct choice for "navigate back/forward") matched the default and the button was never diverted. The raw native button-4/5 click went straight to the OS instead.

Chrome/Firefox interpret a native button-4/5 click as back/forward themselves, so this was invisible there. Safari has no native mouse-button navigation binding, so the click did nothing — the action was configured correctly in the GUI but structurally unreachable, regardless of the separate Safari-dispatch-timing work in #1082.

Confirmed on real hardware: with this change alone (on top of current `master`, which already carries the Safari `AXPress` navigation code from #363), a Logitech MX Master 3 with `Back = "BrowserBack"` / `Forward = "BrowserForward"` correctly navigates back/forward in Safari and Chrome.

## Testing

```
cargo fmt --all -- --check
cargo clippy -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-cli \
  -p openlogi-device -p openlogi-hid -p openlogi-hook -p openlogi-inject -p openlogi-ipc \
  -p openlogi-permissions -p openlogi -p xtask --all-targets -- -D warnings
cargo test -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-cli \
  -p openlogi-device -p openlogi-hid -p openlogi-hook -p openlogi-inject -p openlogi-ipc \
  -p openlogi-permissions -p openlogi -p xtask
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
```

- GUI crates (`openlogi-desktop`, `openlogi-ui`, `openlogi-overlay`) not built/tested locally — no full Xcode/Metal toolchain available on this machine.
- Hardware-verified: real-device test on macOS with a Logitech MX Master 3 (Bluetooth-direct), confirmed Back/Forward now navigate in Safari.

Related: #736, #1118, #23, #354, #1018 (stale, proposed the same default reseed among a larger, now-conflicting diff), #1082 (fixes separate Safari-dispatch timing/focus issues once a button is diverted).

Fixes #736
Fixes #1118
Fixes #23
Fixes #354