### PR TITLE
fix(agent): serialize the macOS tray tests that share NSWorkspace's center

### DIFF
--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -502,8 +502,21 @@ mod tests {
     use super::*;
     use openlogi_hid::device_io_channel;
 
+    /// `NSWorkspace::sharedWorkspace()` and its `notificationCenter()` are a
+    /// process-global singleton: a notification posted by one test's
+    /// `install_activity_observer` call is delivered to every other live
+    /// `ActivityTarget`, this test module's included, regardless of which
+    /// test posted it. Rust's default parallel test runner would otherwise
+    /// let these tests corrupt each other's gate state through that shared
+    /// center — this held for a test's whole body serializes them.
+    fn workspace_notifications_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: Mutex<()> = Mutex::new(());
+        LOCK.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
     #[test]
     fn overlapping_suspend_sources_all_clear_before_device_io_resumes() {
+        let _lock = workspace_notifications_lock();
         let (signal, gate) = device_io_channel();
         let target = install_activity_observer(signal);
         target.finish_startup(false);
@@ -558,6 +571,7 @@ mod tests {
 
     #[test]
     fn startup_stays_suspended_when_the_display_is_already_asleep() {
+        let _lock = workspace_notifications_lock();
         let (signal, gate) = device_io_channel();
         let target = install_activity_observer(signal);
         assert!(!gate.allows_io(), "startup must fail closed");


### PR DESCRIPTION
## Summary

Two macOS-only unit tests in `crates/openlogi-agent/src/tray.rs` — `startup_stays_suspended_when_the_display_is_already_asleep` and `overlapping_suspend_sources_all_clear_before_device_io_resumes` — each register an `ActivityTarget` observer on `NSWorkspace::sharedWorkspace().notificationCenter()`, a process-global singleton. A notification either test posts is delivered to every live observer registered on that center, this test module's included, regardless of which test posted it. Run in parallel (Rust's default test runner), one test's posted notifications can flip the other's device-IO gate mid-assertion.

Not a hypothetical: two independent, unrelated PRs (#1191 and #1205) each hit the exact same failing assertion in `startup_stays_suspended_when_the_display_is_already_asleep` on `tests (macos, arm64)`, and both passed cleanly on an unmodified retry. Neither PR touches `tray.rs`. That's the signature of this race, not a real regression in either PR — but it means every PR pays an intermittent, unrelated CI failure until someone happens to hit a lucky interleaving.

## Changes

`crates/openlogi-agent/src/tray.rs`: added a module-private `workspace_notifications_lock()` — a `Mutex<()>` acquired at the top of each affected test and held for its body, so the two tests can no longer run concurrently with each other. Doesn't touch the notification-observer logic under test, only forces the two tests calling into the shared singleton to run one at a time.

## Testing

Can't compile or run this locally — `mod tray` is `#[cfg(target_os = "macos")]`-gated and this machine has no macOS toolchain. Verified the change parses/formats correctly with `cargo fmt -p openlogi-agent -- --check` (clean) and by careful manual review — the added code is plain `std::sync::Mutex`, no macOS-specific API surface, and `Mutex`/`PoisonError` are already imported in this file. Will watch the `tests (macos, arm64)` / `tests (macos, x86_64)` CI jobs on this PR for the real verification.
