### PR TITLE
fix(hook): normalize Windows cursor position to DIP scale

### DIFF
--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -50,8 +50,10 @@ objc2-foundation = { workspace = true, features = [
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_System_Threading",
     "Win32_UI_Accessibility",
+    "Win32_UI_HiDpi",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -39,7 +39,11 @@ pub use openlogi_core::scroll::ScrollDelta;
 /// sources (IOKit, evdev) hand it back as a `u32`.
 pub const LOGITECH_VENDOR_ID: u32 = openlogi_core::hid::LOGITECH_VENDOR_ID as u32;
 
-/// Cursor position in the operating system's global screen coordinate space.
+/// Cursor position in the operating system's global screen coordinate space,
+/// scaled so it lines up with GPUI's own logical (DIP) display bounds — the
+/// Windows backend divides physical `GetCursorPos` pixels by the cursor's
+/// monitor DPI scale to match; macOS `CGEvent` points and Linux root-window
+/// coordinates are already resolution-independent.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CursorPosition {
     /// Horizontal screen coordinate.

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -10,9 +10,11 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
 use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, LPARAM, LRESULT, POINT, WPARAM};
+use windows_sys::Win32::Graphics::Gdi::{MONITOR_DEFAULTTONEAREST, MonitorFromPoint};
 use windows_sys::Win32::System::Threading::{
     GetCurrentThreadId, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
 };
+use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
     GetAsyncKeyState, VIRTUAL_KEY, VK_CONTROL, VK_ESCAPE, VK_F1, VK_LWIN, VK_MENU, VK_RWIN,
     VK_SHIFT,
@@ -21,10 +23,10 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, DispatchMessageW, GetCursorPos, GetForegroundWindow, GetMessageW,
     GetWindowThreadProcessId, HC_ACTION, KBDLLHOOKSTRUCT, LLKHF_INJECTED, LLMHF_INJECTED, MSG,
     MSLLHOOKSTRUCT, PM_NOREMOVE, PeekMessageW, PostThreadMessageW, SetWindowsHookExW,
-    TranslateMessage, UnhookWindowsHookEx, WH_KEYBOARD_LL, WH_MOUSE_LL, WM_KEYDOWN, WM_KEYUP,
-    WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE,
-    WM_MOUSEWHEEL, WM_QUIT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_USER,
-    WM_XBUTTONDOWN, WM_XBUTTONUP, XBUTTON1, XBUTTON2,
+    TranslateMessage, USER_DEFAULT_SCREEN_DPI, UnhookWindowsHookEx, WH_KEYBOARD_LL, WH_MOUSE_LL,
+    WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP,
+    WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_QUIT, WM_RBUTTONDOWN, WM_RBUTTONUP,
+    WM_SYSKEYDOWN, WM_SYSKEYUP, WM_USER, WM_XBUTTONDOWN, WM_XBUTTONUP, XBUTTON1, XBUTTON2,
 };
 
 use crate::windows_worker::{WorkerEvent, WorkerPhase, WorkerStatus};
@@ -183,9 +185,34 @@ impl HookBackend for Backend {
         if unsafe { GetCursorPos(&raw mut point) } == 0 {
             return None;
         }
+        // `GetCursorPos` reports physical pixels, but every consumer of
+        // `CursorPosition` (currently the overlay, matching cursor against
+        // GPUI's own display bounds) works in DIPs — GPUI's Windows backend
+        // divides every display and window bounds by the monitor's DPI scale.
+        // Left un-normalized, the ring drifts away from the cursor by exactly
+        // the scale factor on any monitor above 100% scaling.
+        // SAFETY: `MonitorFromPoint` takes `point` by value and never fails —
+        // `MONITOR_DEFAULTTONEAREST` guarantees a valid `HMONITOR` even when
+        // `point` sits outside every monitor.
+        let monitor = unsafe { MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST) };
+        let mut dpi_x = 0u32;
+        let mut dpi_y = 0u32;
+        // SAFETY: `monitor` is a valid `HMONITOR` from `MonitorFromPoint` above;
+        // `dpi_x`/`dpi_y` are valid writable `u32`s for the duration of the call.
+        // The HRESULT is checked below rather than trusted, since MSDN leaves
+        // the out-params unspecified (not necessarily untouched) on failure.
+        let hr =
+            unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &raw mut dpi_x, &raw mut dpi_y) };
+        let (dpi_x, dpi_y) = if hr >= 0 && dpi_x > 0 && dpi_y > 0 {
+            (dpi_x, dpi_y)
+        } else {
+            (USER_DEFAULT_SCREEN_DPI, USER_DEFAULT_SCREEN_DPI)
+        };
+        let scale_x = f64::from(dpi_x) / f64::from(USER_DEFAULT_SCREEN_DPI);
+        let scale_y = f64::from(dpi_y) / f64::from(USER_DEFAULT_SCREEN_DPI);
         Some(CursorPosition {
-            x: f64::from(point.x),
-            y: f64::from(point.y),
+            x: f64::from(point.x) / scale_x,
+            y: f64::from(point.y) / scale_y,
         })
     }
 }


### PR DESCRIPTION
## Summary
Actions Ring overlay drifted away from the cursor on Windows displays scaled above 100% (e.g. 150%), while it stayed centered at 100%.

## Changes
- `openlogi-hook`: `cursor_position()` on Windows resolves the cursor's monitor via `MonitorFromPoint` and divides the raw `GetCursorPos` physical-pixel result by that monitor's `GetDpiForMonitor` scale factor, returning DIP coordinates that match GPUI's own (already logical) display bounds — the same resolution-independent space macOS/Linux already report.

## Testing
- `cargo check -p openlogi-hook`
- `cargo clippy -p openlogi-hook --all-targets -- -D warnings`
- `cargo test -p openlogi-hook` (20 passed)
- `cargo fmt --all -- --check`
- Hardware-verified: built `openlogi-desktop`/`openlogi-agent`/`openlogi-overlay` in release and confirmed the Actions Ring stays centered on the cursor at 150% Windows display scaling.