### PR TITLE
fix: add Debian runtime dependencies

### DIFF
--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -111,6 +111,11 @@ archlinux:
   packager: "AprilNEA <dev@aprilnea.me>"
 
 overrides:
+  deb:
+    depends:
+      - libxkbcommon0
+      - libxkbcommon-x11-0
+      - libxcb1
   archlinux:
     depends:
       - dbus


### PR DESCRIPTION
The Debian package currently does not declare the runtime dependencies required by the graphical binaries.

On Ubuntu 26.04, installing the `.deb` without `libxkbcommon-x11-0` causes `openlogi-desktop` to fail to start because `libxkbcommon-x11.so.0` is missing.

This PR adds the required Debian runtime dependencies to the nfpm configuration:

* `libxkbcommon0`
* `libxkbcommon-x11-0`
* `libxcb1`

## Testing

* Rebuilt the `.deb` package locally.
* Verified that the generated package now contains the expected `Depends` metadata.
* Installed the generated `.deb` on Ubuntu 26.04.
* Verified that `openlogi-desktop` starts successfully.
