### PR TITLE
ci(nix): only run Nix CI on flake and packaging changes

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,9 +1,10 @@
 name: Nix CI
 
 # Evaluate every advertised Flake output, then build and test the package on
-# both supported Linux architectures. Dependency graph and packaging changes
-# run immediately on PRs; the weekly build catches source-only integration
-# drift without adding a full Nix rebuild to every Rust change.
+# both supported Linux architectures. Flake and packaging/linux changes run
+# immediately on PRs. The weekly build catches Cargo/source integration drift
+# (for example a new native dependency that package.nix does not wrap) without
+# a full Nix rebuild on every crate Cargo.toml bump.
 #
 # flake.lock pins nixpkgs exactly; update-flake-lock.yml advances it in a tested
 # PR instead of allowing an unreviewed upstream channel to drift under builds.
@@ -14,12 +15,6 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/**/Cargo.toml"
-      - "crates/**/build.rs"
-      - "design/icon/**"
-      - "docs/config.example.toml"
       - "flake.nix"
       - "flake.lock"
       - "packaging/linux/package.nix"


### PR DESCRIPTION
## Summary

Stop running the two-arch Nix build on ordinary feature PRs. Nix CI now triggers on PRs only when the flake or `packaging/linux` actually changes. The Monday job still catches Cargo/source drift.

## Why

Nix CI was matching `Cargo.toml`, `Cargo.lock`, `crates/**/Cargo.toml`, `build.rs`, icons, and the example config. That is most feature PRs. Each run is a full `nix build` on x86_64 and aarch64 (typically 17–20 minutes each, ~40 billed minutes per push). The workflow already has 658 runs. Linux cargo CI already compiles those same Cargo.toml changes.

## Residual risk

A PR that adds a new native/system dependency without touching `packaging/linux` stays green until the Monday cron (or a manual `workflow_dispatch`). That is the tradeoff for not rebuilding Nix on every crate bump.

## Test plan

- [ ] Confirm this PR itself still runs Nix CI (it touches `.github/workflows/nix.yml`)
- [ ] Confirm a HID/GUI-only PR no longer queues Nix CI after this merges
