### PR TITLE
feat(gui): add a Reset to defaults button to the F-key binding panel

### DIFF
--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -25,11 +25,12 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use gpui::{
-    AnyElement, App, AppContext as _, Bounds, Context, Entity, FontWeight, Hsla,
+    AnyElement, App, AppContext as _, Bounds, ClickEvent, Context, Entity, FontWeight, Hsla,
     InteractiveElement, IntoElement, ParentElement, PathBuilder, Render, RenderOnce, Role,
     SharedString, StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla,
     point, prelude::FluentBuilder as _, px, rgb, svg,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{Selectable as _, h_flex, input::InputState, v_flex};
 use openlogi_core::binding::{Action, WorkflowStep};
 use openlogi_core::config::{KeyModifiers, KeyTrigger};
@@ -833,9 +834,48 @@ impl FunctionRowView {
             .w(px(PANEL_W))
             .max_h(px(500.))
             .child(title_header(&key_name, &pal))
+            .when(current.is_some(), |panel| {
+                panel.child(reset_row(trigger.clone(), view, &pal))
+            })
             .child(divider(pal))
             .child(editor_scroll_list("key-panel-scroll", rows))
     }
+}
+
+/// "Reset to defaults" — shown only while `trigger` carries a non-default
+/// binding, so there is nothing else to reset to. Clearing goes through
+/// [`AppState::commit_keyboard_binding`] with `None`, the same call an
+/// F-key's binding removal already used before this button existed to
+/// trigger it — see that method's doc comment. Mirrors the camera controls
+/// panel's reset affordance (`crates/openlogi-desktop/src/features/camera/controls.rs`),
+/// reusing its `tr!("camera.reset_to_defaults")` key rather than adding a new one.
+fn reset_row(trigger: KeyTrigger, view: &Entity<FunctionRowView>, pal: &Palette) -> gpui::Div {
+    let view = view.clone();
+    h_flex().w_full().justify_end().px_2().pb_1().child(
+        BaseButton::new("fkey-reset")
+            .accessibility_label(tr!("camera.reset_to_defaults"))
+            .px_2p5()
+            .py_0p5()
+            .rounded_md()
+            .border_1()
+            .border_color(pal.border)
+            .bg(pal.control)
+            .hover(|s| s.bg(pal.control_hover))
+            .focus_visible(|s| s.bg(pal.control_hover))
+            .text_caption()
+            .text_color(pal.text_muted)
+            .child(tr!("camera.reset_to_defaults"))
+            .on_click(move |_: &ClickEvent, _window, cx| {
+                AppState::update(cx, |state, cx| {
+                    let key = state.current_record().map(DeviceRecord::device_key);
+                    state.commit_keyboard_binding(trigger.clone(), None);
+                    if let Some(key) = key {
+                        cx.emit(StateEvent::BindingsChanged(key));
+                    }
+                });
+                view.update(cx, |_, vcx| vcx.notify());
+            }),
+    )
 }
 
 /// The panel's title — shows which key is selected, e.g. "F1".


### PR DESCRIPTION
## Summary

Fixes #1237

Once an F-key's binding was changed in the Keys panel, there was no way to clear it back to unbound — no reset button, and no "unbind" entry in the action catalog to pick instead.

## Changes

`crates/openlogi-desktop/src/features/keyboard/function_row.rs`:

- `AppState::commit_keyboard_binding(trigger, None)` already clears an F-key binding — it's how removing one worked internally, just nothing in the panel ever called it with `None`.
- Added a "Reset to defaults" row to the F-key config panel, shown only while the selected key has a non-default binding (so there's never a reset button with nothing to reset). Placed under the key's title, above the action list.
- Mirrors the camera controls panel's own reset affordance (`crates/openlogi-desktop/src/features/camera/controls.rs`) in both structure and styling, and reuses its `camera.reset_to_defaults` translation key rather than adding a new key that would need touching every locale file.

## Testing

Linux, x86_64, Rust 1.98.0:

```
cargo fmt --all -- --check
cargo clippy -p openlogi-desktop --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test -p openlogi-desktop   # 193 passed
```

All green.

**Not runtime-tested in the running app** — no way to launch/click through the GUI in this environment. The button reuses an existing, already-tested affordance pattern (camera controls' reset) and an existing, already-wired backend call (`commit_keyboard_binding(.., None)`), so I'm reasonably confident, but worth a visual check before merge: select a bound F-key, confirm the reset row appears only then, click it, confirm the key returns to unbound and the row disappears.

**Not run:** `tests (macos)`, `cargo-deny`, macOS clippy — no macOS SDK on this host.
