### PR TITLE
fix(cli): let macOS prompt for Input Monitoring before diag opens a device

### DIFF
--- a/crates/openlogi-cli/src/cmd/diag.rs
+++ b/crates/openlogi-cli/src/cmd/diag.rs
@@ -38,6 +38,9 @@ pub enum DiagCmd {
 
 impl DiagCmd {
     pub async fn run(self) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        request_input_monitoring().await?;
+
         match self {
             Self::Features(args) => features::run(args).await,
             Self::Controls(args) => controls::run(args).await,
@@ -48,6 +51,39 @@ impl DiagCmd {
             Self::Wheel(args) => wheel::run(args).await,
         }
     }
+}
+
+/// Raise the macOS Input Monitoring consent dialog before any `diag`
+/// subcommand opens a device directly, mirroring the agent's own gate
+/// (`openlogi_agent::lifecycle::request_input_monitoring`).
+///
+/// Without this, `IOHIDDeviceOpen` is silently denied and this binary's own
+/// Input Monitoring row never appears in System Settings at all for a user
+/// to grant — `has_access()` only ever answers `false`, forever, for a
+/// process that never once called the prompting API. Confirmed live on
+/// `diag controls` (#1213): a device already granted to the packaged
+/// `OpenLogi Agent` helper still failed to open here, because Input
+/// Monitoring is granted per exact signed binary — a grant to the agent
+/// does nothing for this separate one.
+#[cfg(target_os = "macos")]
+async fn request_input_monitoring() -> Result<()> {
+    if openlogi_hid::permissions::has_access() {
+        return Ok(());
+    }
+    tokio::task::spawn_blocking(openlogi_hid::permissions::request_access)
+        .await
+        .map_err(|e| anyhow!("Input Monitoring permission request task failed: {e}"))?;
+    // A grant (or an existing denial) is never visible to this same
+    // process — macOS only updates a process's cached answer on its next
+    // launch, the same reason the agent relaunches itself after a fresh
+    // grant. A one-shot CLI command has no equivalent to relaunch into, so
+    // there is nothing to continue with here regardless of what the user
+    // just chose.
+    Err(anyhow!(
+        "Input Monitoring is not granted to `openlogi` — check System Settings → \
+         Privacy & Security → Input Monitoring (a fresh grant needs this command \
+         run again to take effect) and try again"
+    ))
 }
 
 /// One online, paired device discovered during enumeration, already resolved to


### PR DESCRIPTION
## Summary

On macOS, `openlogi diag <controls|features|battery|dpi|smartshift|lighting|wheel>` fails with "Input Monitoring is NOT granted" no matter what's granted in System Settings — including to the packaged `OpenLogi Agent` helper.

## Root cause

Found while chasing #1213: `openlogi-agent` requests the Input Monitoring consent dialog (`IOHIDRequestAccess`, the *prompting* API) before its first HID++ open (`lifecycle.rs::request_input_monitoring`). The `openlogi` CLI never did — its `diag` subcommands open devices directly (they don't go through the agent at all), but only ever called `IOHIDCheckAccess` (the non-prompting *query* API, via `has_access()`).

A process that never calls the prompting API gets **no row in System Settings at all** — there's nothing for a user to grant. `has_access()` answers `false` forever, regardless of what's granted to the agent, the GUI, or anything else — Input Monitoring on macOS is scoped per exact signed binary, so a grant to `OpenLogi Agent.app`'s helper does nothing for this separate CLI binary.

## Changes

`crates/openlogi-cli/src/cmd/diag.rs`: `DiagCmd::run()` now requests Input Monitoring up front on macOS, mirroring the agent's own gate exactly (same `has_access()` → `spawn_blocking(request_access)` → re-check pattern). Unlike the agent, which relaunches itself after a fresh grant, a one-shot CLI command has no equivalent process to relaunch into — a grant is never visible to the *same* process either way (macOS only updates the cached answer on next launch) — so this reports the failure and asks the user to run the command again rather than trying to continue.

## Testing

Linux, x86_64, Rust 1.98.0:

```
cargo fmt --all -- --check
cargo clippy -p openlogi-cli --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
```

Clean. **The new code itself is `#[cfg(target_os = "macos")]` and does not compile on this host at all** — I can't `cargo check`/test it here. I mirrored `openlogi-agent/src/lifecycle.rs`'s already-proven-on-macOS-CI call shape (`spawn_blocking(openlogi_hid::permissions::request_access)`, `has_access()`) as closely as possible rather than writing new logic, but this needs macOS CI or a real machine to actually confirm it compiles and behaves — flagging that plainly rather than claiming it's verified.
