### PR TITLE
fix(gui): render camera depots that ship no hotspot metadata

### DIFF
--- a/crates/openlogi-desktop/src/services/assets.rs
+++ b/crates/openlogi-desktop/src/services/assets.rs
@@ -226,12 +226,21 @@ impl AssetResolver {
                 continue;
             };
             // Hotspot metadata in whichever schema this depot cached:
-            // `core_metadata.json` (newer) or `metadata.json` (older). Camera
-            // depots ship none of these — their `image_metadata` is a per-PID
-            // `metadata_<pid>.json` carrying marker-less settings slots, and no
-            // hotspot consumer reads it — so a missing file must not fail the
-            // depot: the render below is what decides whether this root hits.
+            // `core_metadata.json` (newer) or `metadata.json` (older).
+            //
+            // Two different situations look the same on disk, and only the
+            // registry tells them apart. A depot that *publishes* hotspot
+            // metadata but has none in this root is a stale or half-synced
+            // cache: skip the root so the next one (or the synthetic fallback)
+            // serves the device, rather than a render with no hotspots. A depot
+            // that publishes none at all — cameras, whose `image_metadata` is a
+            // per-PID `metadata_<pid>.json` of marker-less settings slots that
+            // no hotspot consumer reads — legitimately resolves from its render
+            // alone.
             let meta_name = METADATA_FILES.iter().find(|n| dir.join(n).exists());
+            if meta_name.is_none() && entry.preferred_file(&METADATA_FILES).is_some() {
+                continue;
+            }
 
             // Pick the colour variant matching this device's HID++
             // extended_model_id byte. Logi calibrates the assignment

--- a/crates/openlogi-desktop/src/services/assets.rs
+++ b/crates/openlogi-desktop/src/services/assets.rs
@@ -226,11 +226,12 @@ impl AssetResolver {
                 continue;
             };
             // Hotspot metadata in whichever schema this depot cached:
-            // `core_metadata.json` (newer) or `metadata.json` (older).
-            let Some(&meta_name) = METADATA_FILES.iter().find(|n| dir.join(n).exists()) else {
-                continue;
-            };
-            let meta_path = dir.join(meta_name);
+            // `core_metadata.json` (newer) or `metadata.json` (older). Camera
+            // depots ship none of these — their `image_metadata` is a per-PID
+            // `metadata_<pid>.json` carrying marker-less settings slots, and no
+            // hotspot consumer reads it — so a missing file must not fail the
+            // depot: the render below is what decides whether this root hits.
+            let meta_name = METADATA_FILES.iter().find(|n| dir.join(n).exists());
 
             // Pick the colour variant matching this device's HID++
             // extended_model_id byte. Logi calibrates the assignment
@@ -286,12 +287,14 @@ impl AssetResolver {
                 continue;
             };
 
-            let metadata = match Metadata::load_from(&meta_path) {
-                Ok(m) => m,
-                Err(e) => {
+            let metadata = if let Some(&meta_name) = meta_name {
+                Metadata::load_from(&dir.join(meta_name)).unwrap_or_else(|e| {
                     warn!(depot, root = %root.display(), file = meta_name, error = ?e, "device metadata unparseable — rendering image without hotspots");
                     Metadata::default()
-                }
+                })
+            } else {
+                debug!(depot, root = %root.display(), "depot ships no hotspot metadata — rendering image without hotspots");
+                Metadata::default()
             };
             let (png_width, png_height) = match read_png_dimensions(&image_path) {
                 Ok(dims) => dims,

--- a/crates/openlogi-desktop/src/services/assets/tests.rs
+++ b/crates/openlogi-desktop/src/services/assets/tests.rs
@@ -93,6 +93,19 @@ fn bare_model() -> DeviceModelInfo {
     }
 }
 
+/// Registry `files` entries for `names`; the hashes and sizes are irrelevant to
+/// resolution, which only asks which names the depot publishes.
+fn registry_files(names: &[&str]) -> Vec<openlogi_assets::FileEntry> {
+    names
+        .iter()
+        .map(|name| openlogi_assets::FileEntry {
+            name: (*name).to_string(),
+            sha256: String::new(),
+            bytes: 0,
+        })
+        .collect()
+}
+
 /// A 24-byte PNG: signature + an `IHDR` chunk header carrying only the
 /// width/height — all `read_png_dimensions` actually reads.
 fn png_header(width: u32, height: u32) -> Vec<u8> {
@@ -183,7 +196,7 @@ fn resolves_camera_depot_without_hotspot_metadata() {
         display_name: "C922".to_string(),
         kind: "CAMERA".to_string(),
         asset_path: format!("v1/devices/{depot}/"),
-        files: Vec::new(),
+        files: registry_files(&["front.png", "manifest.json", "metadata_085c.json"]),
     };
     let mut model = bare_model();
     model.model_ids = [0x085c, 0, 0];
@@ -202,6 +215,41 @@ fn resolves_camera_depot_without_hotspot_metadata() {
     assert_eq!((asset.png_width, asset.png_height), (300, 150));
     assert_eq!(asset.kind, Some(DeviceKind::Camera));
     assert_eq!(asset.metadata.assignments().count(), 0);
+}
+
+/// A depot that *publishes* hotspot metadata (every mouse and keyboard) but has
+/// none in this root is a stale or half-synced cache, not a metadata-free
+/// device. It must keep missing so the next root or the synthetic fallback
+/// serves the device instead of a render with no hotspots.
+#[test]
+fn metadata_publishing_depot_without_cached_metadata_still_misses() {
+    let root = tempfile::tempdir().expect("create temp dir");
+    let depot = "mx_master_4";
+    let dir = root.path().join(depot);
+    std::fs::create_dir_all(&dir).expect("create depot dir");
+    std::fs::write(dir.join("front_core.png"), png_header(100, 200)).expect("write render");
+    std::fs::write(dir.join("side_core.png"), png_header(100, 200)).expect("write render");
+
+    let resolver = AssetResolver {
+        read_roots: vec![root.path().to_path_buf()],
+        write_root: root.path().to_path_buf(),
+        has_bundle: false,
+        index: None,
+    };
+    let entry = DeviceEntry {
+        model_id: "2b042".to_string(),
+        model_ids: Vec::new(),
+        display_name: "MX Master 4".to_string(),
+        kind: "MOUSE".to_string(),
+        asset_path: format!("v1/devices/{depot}/"),
+        files: registry_files(&[
+            "core_metadata.json",
+            "front_core.png",
+            "manifest.json",
+            "side_core.png",
+        ]),
+    };
+    assert!(resolver.load_files(depot, &entry, &bare_model()).is_none());
 }
 
 /// An unsynced depot directory — no render at all — must still miss, so the

--- a/crates/openlogi-desktop/src/services/assets/tests.rs
+++ b/crates/openlogi-desktop/src/services/assets/tests.rs
@@ -151,6 +151,86 @@ fn resolves_old_schema_depot_on_disk() {
     assert_eq!(asset.metadata.assignments().count(), 1);
 }
 
+/// A camera depot (the C922 / StreamCam family) ships `front.png` and a
+/// manifest but none of the hotspot metadata files — its `image_metadata` is a
+/// per-PID `metadata_<pid>.json` nobody reads. The render alone must resolve,
+/// or every webcam falls back to the gallery glyph.
+#[test]
+fn resolves_camera_depot_without_hotspot_metadata() {
+    let root = tempfile::tempdir().expect("create temp dir");
+    let depot = "c922";
+    let dir = root.path().join(depot);
+    std::fs::create_dir_all(&dir).expect("create depot dir");
+    std::fs::write(
+        dir.join("manifest.json"),
+        r#"{"devices":[{"modelId":"085c","resources":[
+            {"key":"device_camera_image","src":"front.png"},
+            {"key":"image_metadata","src":"metadata_085c.json"}]}],
+          "resources":[]}"#,
+    )
+    .expect("write manifest.json");
+    std::fs::write(dir.join("front.png"), png_header(300, 150)).expect("write front.png");
+
+    let resolver = AssetResolver {
+        read_roots: vec![root.path().to_path_buf()],
+        write_root: root.path().to_path_buf(),
+        has_bundle: false,
+        index: None,
+    };
+    let entry = DeviceEntry {
+        model_id: "085c".to_string(),
+        model_ids: vec!["0883".to_string(), "0894".to_string(), "085c".to_string()],
+        display_name: "C922".to_string(),
+        kind: "CAMERA".to_string(),
+        asset_path: format!("v1/devices/{depot}/"),
+        files: Vec::new(),
+    };
+    let mut model = bare_model();
+    model.model_ids = [0x085c, 0, 0];
+
+    let asset = resolver
+        .load_files(depot, &entry, &model)
+        .expect("render-only camera depot should resolve");
+    assert_eq!(
+        asset.image_path.file_name().expect("image has a file name"),
+        "front.png"
+    );
+    assert_eq!(
+        asset.hero_image_path.as_deref(),
+        Some(asset.image_path.as_path())
+    );
+    assert_eq!((asset.png_width, asset.png_height), (300, 150));
+    assert_eq!(asset.kind, Some(DeviceKind::Camera));
+    assert_eq!(asset.metadata.assignments().count(), 0);
+}
+
+/// An unsynced depot directory — no render at all — must still miss, so the
+/// metadata relaxation above doesn't turn an empty cache into a broken image.
+#[test]
+fn depot_without_any_render_still_misses() {
+    let root = tempfile::tempdir().expect("create temp dir");
+    let depot = "c922";
+    let dir = root.path().join(depot);
+    std::fs::create_dir_all(&dir).expect("create depot dir");
+    std::fs::write(dir.join("manifest.json"), b"{}").expect("write manifest.json");
+
+    let resolver = AssetResolver {
+        read_roots: vec![root.path().to_path_buf()],
+        write_root: root.path().to_path_buf(),
+        has_bundle: false,
+        index: None,
+    };
+    let entry = DeviceEntry {
+        model_id: "085c".to_string(),
+        model_ids: Vec::new(),
+        display_name: "C922".to_string(),
+        kind: "CAMERA".to_string(),
+        asset_path: format!("v1/devices/{depot}/"),
+        files: Vec::new(),
+    };
+    assert!(resolver.load_files(depot, &entry, &bare_model()).is_none());
+}
+
 #[test]
 fn resolves_standalone_registry_model_without_synthetic_hidpp_info() {
     let root = tempfile::tempdir().expect("create temp dir");


### PR DESCRIPTION
## Summary

Webcam gallery cards showed the generic eye glyph even though the asset mirror ships a front render for them (C922, StreamCam, Brio, ...). The registry match and the download both worked; the resolver then threw the depot away because it required a hotspot metadata file (`core_metadata.json` / `metadata_full.json` / `metadata.json`). Camera depots ship none of those — their `image_metadata` is a per-PID `metadata_<pid>.json` with marker-less settings slots that no hotspot consumer reads.

The resolver now treats hotspot metadata as optional: a depot resolves whenever a render is on disk, and a missing metadata file yields an empty `Metadata` (no hotspots), which is exactly right for a camera. A depot directory with no render still misses, so an unsynced cache does not turn into a broken image.

## Changes

- `openlogi-desktop`: `AssetResolver::load_files` no longer requires one of `METADATA_FILES` to exist; it loads metadata when present and falls back to `Metadata::default()` with a debug log otherwise. Added `resolves_camera_depot_without_hotspot_metadata` and `depot_without_any_render_still_misses` tests.

## Screenshots

| Before | After |
|---|---|
| <img width="1278" height="1084" alt="Screenshot 2026-09-04 at 15 18 55" src="https://github.com/user-attachments/assets/43c0abd8-5eda-4c57-917a-13e4ebf164db" /> |  <img width="1280" height="1019" alt="Screenshot 2026-09-04 at 15 19 49" src="https://github.com/user-attachments/assets/dc968199-e347-462d-9828-f4f1b47f9e9c" /> |

## Testing

```sh
export RUSTFLAGS="-D warnings"
cargo fmt --all -- --check
cargo clippy -p openlogi-desktop --all-targets -- -D warnings
cargo test -p openlogi-desktop            # 203 passed
cargo clippy --workspace --all-targets -- -D warnings
```

Runtime-verified on macOS with a C922 Pro Stream attached: a dev build logs `asset hit depot="c922" image=front.png` and the gallery card shows the camera render where it previously showed the eye glyph (see screenshots). The other cards remain unchanged

To reproduce on hardware: plug in any Logitech webcam with a depot in the asset index (C922, C920, StreamCam, Brio), open the device gallery, and check the card shows the product photo instead of the eye icon.