### PR TITLE
feat(overlay): free-floating, tighter Actions Ring with fly-out animation

### DIFF
--- a/crates/openlogi-core/src/action_ring.rs
+++ b/crates/openlogi-core/src/action_ring.rs
@@ -1,4 +1,4 @@
-//! The Actions Ring's shared display-duration constant.
+//! The Actions Ring's shared display-duration constant and geometry.
 //!
 //! The ring's runtime session state (`ActionRingManager`: `Mutex`, `Notify`,
 //! `Instant`) is agent-only and stays in `openlogi-agent-core` — it is not a
@@ -15,3 +15,18 @@ use std::time::Duration;
 /// session that has to outlive it is derived from it rather than kept in step
 /// by hand.
 pub const DISPLAY_LIFETIME: Duration = Duration::from_secs(15);
+
+/// The ring's shape, in points. The overlay draws the real ring from these and
+/// the settings app draws its preview from them, so the preview shows the ring
+/// the user will actually get. The radius is the mouse travel to any slot, so
+/// it is as tight as the slots allow: eight slots of [`SLOT_DIAMETER`] on
+/// [`RADIUS`] leave a 16 pt gap between neighbours — enough for the desktop to
+/// read through and for a slot's hover edge to be unambiguous.
+pub mod geometry {
+    /// Diameter of each of the eight slot buttons.
+    pub const SLOT_DIAMETER: f32 = 48.0;
+    /// Distance from the ring's centre (the cursor) to each slot's centre.
+    pub const RADIUS: f32 = 84.0;
+    /// Diameter of the central cancel button.
+    pub const CANCEL_DIAMETER: f32 = 36.0;
+}

--- a/crates/openlogi-core/src/action_ring.rs
+++ b/crates/openlogi-core/src/action_ring.rs
@@ -19,9 +19,11 @@ pub const DISPLAY_LIFETIME: Duration = Duration::from_secs(15);
 /// The ring's shape, in points. The overlay draws the real ring from these and
 /// the settings app draws its preview from them, so the preview shows the ring
 /// the user will actually get. The radius is the mouse travel to any slot, so
-/// it is as tight as the slots allow: eight slots of [`SLOT_DIAMETER`] on
-/// [`RADIUS`] leave a 16 pt gap between neighbours — enough for the desktop to
-/// read through and for a slot's hover edge to be unambiguous.
+/// it is as tight as the slots allow: eight slots of
+/// [`SLOT_DIAMETER`](crate::action_ring::geometry::SLOT_DIAMETER) on
+/// [`RADIUS`](crate::action_ring::geometry::RADIUS) leave a 16 pt gap between
+/// neighbours — enough for the desktop to read through and for a slot's hover
+/// edge to be unambiguous.
 pub mod geometry {
     /// Diameter of each of the eight slot buttons.
     pub const SLOT_DIAMETER: f32 = 48.0;

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -13,6 +13,7 @@ use gpui_component::{
     Icon, IconName, Selectable as _, button::Button, h_flex, input::InputState, tooltip::Tooltip,
     v_flex,
 };
+use openlogi_core::action_ring::geometry;
 use openlogi_core::binding::{
     ActionRingConfig, ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot,
 };
@@ -244,9 +245,13 @@ fn toggle_button(
         })
 }
 
-const PREVIEW_SIZE: f32 = 320.0;
-const PREVIEW_RADIUS: f32 = 106.0;
-const PREVIEW_SLOT_SIZE: f32 = 50.0;
+/// The preview draws the ring at its real size and shape
+/// (`openlogi_core::action_ring::geometry`), so what the user arranges here
+/// is what the overlay shows. The canvas is the ring plus a margin.
+const PREVIEW_SIZE: f32 = 280.0;
+const PREVIEW_RADIUS: f32 = geometry::RADIUS;
+const PREVIEW_SLOT_SIZE: f32 = geometry::SLOT_DIAMETER;
+const PREVIEW_CANCEL_SIZE: f32 = geometry::CANCEL_DIAMETER;
 
 fn ring_preview(
     layout: &ActionRingLayout,
@@ -258,30 +263,21 @@ fn ring_preview(
         .relative()
         .flex_none()
         .size(px(PREVIEW_SIZE))
+        // Free-floating slots around the cancel button, like the real ring:
+        // no backing disc.
         .child(
             div()
                 .absolute()
-                .left(px(24.0))
-                .top(px(24.0))
-                .size(px(PREVIEW_SIZE - 48.0))
-                .rounded_full()
-                .border_1()
-                .border_color(pal.border)
-                .bg(pal.panel),
-        )
-        .child(
-            div()
-                .absolute()
-                .left(px(PREVIEW_SIZE / 2.0 - 24.0))
-                .top(px(PREVIEW_SIZE / 2.0 - 24.0))
-                .size(px(48.0))
+                .left(px(PREVIEW_SIZE / 2.0 - PREVIEW_CANCEL_SIZE / 2.0))
+                .top(px(PREVIEW_SIZE / 2.0 - PREVIEW_CANCEL_SIZE / 2.0))
+                .size(px(PREVIEW_CANCEL_SIZE))
                 .flex()
                 .items_center()
                 .justify_center()
                 .rounded_full()
                 .bg(pal.muted)
                 .text_color(pal.text_muted)
-                .child(svg().path(RING_CANCEL_ICON).size(px(20.0)).flex_none()),
+                .child(svg().path(RING_CANCEL_ICON).size(px(16.0)).flex_none()),
         )
         .children(ActionRingSlot::ALL.into_iter().map(|slot| {
             slot_button(

--- a/crates/openlogi-overlay/src/platform/windows.rs
+++ b/crates/openlogi-overlay/src/platform/windows.rs
@@ -29,7 +29,7 @@ impl RingPlacement {
 
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "360 DIP scaled by a native display DPI fits in screen-sized i32 pixels"
+        reason = "the ring's DIP edge scaled by a native display DPI fits in screen-sized i32 pixels"
     )]
     fn bounds(&self, dpi: u32) -> Bounds<DevicePixels> {
         let edge = DevicePixels((f64::from(WINDOW_SIZE) * f64::from(dpi) / 96.0).round() as i32);
@@ -60,6 +60,25 @@ mod tests {
         }
     }
 
+    /// The ring's edge in device pixels at `dpi`: [`WINDOW_SIZE`] DIP scaled,
+    /// as [`RingPlacement::bounds`] scales it. Expectations are written in
+    /// terms of it so they follow the ring's size rather than pin one.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "test-sized DPI scaling of the ring's DIP edge"
+    )]
+    fn edge(dpi: u32) -> i32 {
+        (f64::from(WINDOW_SIZE) * f64::from(dpi) / 96.0).round() as i32
+    }
+
+    fn half(dpi: u32) -> i32 {
+        edge(dpi) / 2
+    }
+
+    fn device_point(x: i32, y: i32) -> Point<DevicePixels> {
+        point(DevicePixels(x), DevicePixels(y))
+    }
+
     #[test]
     fn native_monitor_identity_survives_logical_overlap() {
         // 100% primary [0,1920), 200% right-hand monitor [1920,4480).
@@ -72,51 +91,72 @@ mod tests {
             "no frame may be shown at the default HWND DPI"
         );
         let bounds = placement.bounds(192);
-        assert_eq!(bounds.origin, point(DevicePixels(1920), DevicePixels(440)));
-        assert_eq!(bounds.size, size(DevicePixels(720), DevicePixels(720)));
+        // Centred on the cursor, then held inside the monitor's left edge.
+        assert_eq!(bounds.origin, device_point(1920, 800 - half(192)));
+        assert_eq!(
+            bounds.size,
+            size(DevicePixels(edge(192)), DevicePixels(edge(192)))
+        );
     }
 
     #[test]
     fn physical_center_is_independent_of_monitor_scale_and_global_origin() {
-        for (cursor, rect, dpi, origin, edge) in [
-            ((3000, 850), (1920, 0, 4480, 1440), 192, (2640, 490), 720),
-            ((900, 600), (0, 0, 1920, 1080), 96, (720, 420), 360),
+        for (cursor, rect, dpi) in [
+            ((3000, 850), (1920, 0, 4480, 1440), 192),
+            ((900, 600), (0, 0, 1920, 1080), 96),
             // 150% left, 125% above, and 175% below-left with nonzero X/Y.
-            ((-1400, 450), (-2560, -200, 0, 1240), 144, (-1670, 180), 540),
-            ((-300, -700), (-640, -1440, 1920, 0), 120, (-525, -925), 450),
-            (
-                (-1200, 1600),
-                (-1920, 1080, 0, 2520),
-                168,
-                (-1515, 1285),
-                630,
-            ),
+            ((-1400, 450), (-2560, -200, 0, 1240), 144),
+            ((-300, -700), (-640, -1440, 1920, 0), 120),
+            ((-1200, 1600), (-1920, 1080, 0, 2520), 168),
         ] {
             let bounds = placement(cursor, rect).bounds(dpi);
             assert_eq!(
                 bounds.origin,
-                point(DevicePixels(origin.0), DevicePixels(origin.1))
+                device_point(cursor.0 - half(dpi), cursor.1 - half(dpi)),
+                "cursor {cursor:?} at {dpi} dpi"
             );
-            assert_eq!(bounds.size, size(DevicePixels(edge), DevicePixels(edge)));
+            assert_eq!(
+                bounds.size,
+                size(DevicePixels(edge(dpi)), DevicePixels(edge(dpi)))
+            );
         }
     }
 
+    /// A cursor, the monitor it is on, that monitor's DPI, and the origin the
+    /// ring must land on there as a function of the DPI.
+    type ClampCase = ((i32, i32), (i32, i32, i32, i32), u32, fn(u32) -> (i32, i32));
+
     #[test]
     fn monitor_seams_and_outer_edges_clamp_on_the_selected_side() {
-        for (cursor, rect, dpi, origin) in [
-            ((1919, 600), (0, 0, 1920, 1080), 96, (1560, 420)),
-            ((1920, 600), (1920, 0, 4480, 1440), 192, (1920, 240)),
-            ((4479, 1439), (1920, 0, 4480, 1440), 192, (3760, 720)),
-            ((-1, 600), (-2560, -200, 0, 1240), 144, (-540, 330)),
-            ((0, 600), (0, 0, 1920, 1080), 96, (0, 420)),
-            ((600, -1), (-640, -1440, 1920, 0), 120, (375, -450)),
-            ((600, 0), (0, 0, 1920, 1080), 96, (420, 0)),
-            ((-640, -1440), (-640, -1440, 1920, 0), 120, (-640, -1440)),
-        ] {
+        let cases: [ClampCase; 8] = [
+            ((1919, 600), (0, 0, 1920, 1080), 96, |dpi| {
+                (1920 - edge(dpi), 600 - half(dpi))
+            }),
+            ((1920, 600), (1920, 0, 4480, 1440), 192, |dpi| {
+                (1920, 600 - half(dpi))
+            }),
+            ((4479, 1439), (1920, 0, 4480, 1440), 192, |dpi| {
+                (4480 - edge(dpi), 1440 - edge(dpi))
+            }),
+            ((-1, 600), (-2560, -200, 0, 1240), 144, |dpi| {
+                (-edge(dpi), 600 - half(dpi))
+            }),
+            ((0, 600), (0, 0, 1920, 1080), 96, |dpi| (0, 600 - half(dpi))),
+            ((600, -1), (-640, -1440, 1920, 0), 120, |dpi| {
+                (600 - half(dpi), -edge(dpi))
+            }),
+            ((600, 0), (0, 0, 1920, 1080), 96, |dpi| (600 - half(dpi), 0)),
+            ((-640, -1440), (-640, -1440, 1920, 0), 120, |_| {
+                (-640, -1440)
+            }),
+        ];
+        for (cursor, rect, dpi, origin) in cases {
             let bounds = placement(cursor, rect).bounds(dpi);
+            let (x, y) = origin(dpi);
             assert_eq!(
                 bounds.origin,
-                point(DevicePixels(origin.0), DevicePixels(origin.1))
+                device_point(x, y),
+                "cursor {cursor:?} at {dpi} dpi"
             );
         }
     }
@@ -124,7 +164,10 @@ mod tests {
     #[test]
     fn undersized_display_keeps_a_valid_clamp_range() {
         let bounds = placement((-100, -50), (-200, -100, 0, 0)).bounds(192);
-        assert_eq!(bounds.origin, point(DevicePixels(-200), DevicePixels(-100)));
-        assert_eq!(bounds.size, size(DevicePixels(720), DevicePixels(720)));
+        assert_eq!(bounds.origin, device_point(-200, -100));
+        assert_eq!(
+            bounds.size,
+            size(DevicePixels(edge(192)), DevicePixels(edge(192)))
+        );
     }
 }

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -3,33 +3,59 @@
 //! Placement is the interesting part — the panel is centred on the cursor and
 //! clamped to the display it came up on, so a ring raised near a screen edge
 //! stays whole instead of being cut off.
+//!
+//! The ring is eight free-floating slots around a cancel button, with the
+//! desktop showing through between them; there is no backing disc. On open the
+//! slots fly out from the cursor to their places on the ring, so the motion
+//! itself says where the ring came from.
 
 #[cfg(any(not(target_os = "windows"), test))]
 use gpui::{Bounds, Pixels, Point, Size, point};
 use gpui::{
-    Context, Hsla, InteractiveElement, IntoElement, ParentElement, Render, SharedString,
-    StatefulInteractiveElement as _, Styled, Window, WindowBackgroundAppearance, WindowKind,
-    WindowOptions, div, prelude::FluentBuilder as _, px, svg,
+    Animation, AnimationExt as _, Context, Hsla, InteractiveElement, IntoElement, ParentElement,
+    Render, SharedString, StatefulInteractiveElement as _, Styled, Window,
+    WindowBackgroundAppearance, WindowKind, WindowOptions, div, prelude::FluentBuilder as _, px,
+    svg,
 };
 use openlogi_core::binding::{Action, ActionRingSlot};
 use openlogi_ipc::ActionRingInvocation;
 use openlogi_ui::action_icons::RING_CANCEL_ICON;
 use openlogi_ui::color;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 use crate::agent::OverlayCommand;
 use crate::session::{ClickAwaySession, ShowingRing};
 
-pub(crate) const WINDOW_SIZE: f32 = 360.0;
-pub(crate) const SLOT_SIZE: f32 = 54.0;
-pub(crate) const RADIUS: f32 = 122.0;
+/// Ring geometry. The radius is the mouse travel to any slot, so it is kept
+/// as tight as the slots allow: eight 48 pt slots on an 84 pt radius leave a
+/// 16 pt gap between neighbours, which is enough for the desktop to read
+/// through and for a slot's hover edge to be unambiguous. The window is the
+/// ring plus room for the hover label under it and the slot shadows.
+pub(crate) const WINDOW_SIZE: f32 = 300.0;
+pub(crate) const SLOT_SIZE: f32 = 48.0;
+pub(crate) const RADIUS: f32 = 84.0;
+const CANCEL_SIZE: f32 = 36.0;
+const SLOT_GLYPH: f32 = 20.0;
+const CANCEL_GLYPH_SIZE: f32 = 16.0;
+
+/// How long the slots take to fly out from the cursor to their places on the
+/// ring. Short enough to read as the ring *appearing* rather than a transition
+/// the user waits on; the cubic ease-out front-loads the motion, so the slots
+/// are most of the way home by the midpoint and the tail only settles them.
+const FLY_OUT: Duration = Duration::from_millis(180);
+
+/// Cubic ease-out: fast off the cursor, settling gently into place.
+fn ease_out_cubic(delta: f32) -> f32 {
+    1.0 - (1.0 - delta).powi(3)
+}
 
 /// The ring's own neutral scale. It floats over whatever is on the desktop, so
 /// unlike the settings app it cannot take its surfaces from the OS appearance —
-/// it commits to a dark panel and rides its own contrast. Only the accent is
+/// it commits to dark slots and rides its own contrast. Only the accent is
 /// shared (`openlogi_ui::color`); these greys are local by nature.
-const PANEL: Hsla = neutral(0.06, 0.82);
+const LABEL_PILL: Hsla = neutral(0.06, 0.82);
 const SLOT_RESTING: Hsla = neutral(0.16, 0.98);
 const CANCEL_RESTING: Hsla = neutral(0.20, 0.98);
 const GLYPH: Hsla = neutral(0.98, 1.0);
@@ -55,6 +81,14 @@ pub(crate) struct RingView {
     invocation: ActionRingInvocation,
     commands: mpsc::UnboundedSender<OverlayCommand>,
     hovered: Option<ActionRingSlot>,
+    /// Whether the fly-out has been started. GPUI draws a new window once,
+    /// synchronously, inside `open_window` — before the platform has put it
+    /// on screen — and an animation started on that draw has its clock running
+    /// while the window is still invisible; by the first frame anyone sees,
+    /// most of the motion is gone. So the first render only parks the slots
+    /// at the cursor and asks for a frame, and the animation is started on the
+    /// frame after, which comes from the frame loop of a presented window.
+    armed: bool,
     /// Publishes click-away identity for exactly this view's lifetime.
     _showing: ShowingRing,
 }
@@ -71,6 +105,7 @@ impl RingView {
             invocation,
             commands,
             hovered: None,
+            armed: false,
             _showing: showing,
         }
     }
@@ -91,62 +126,93 @@ impl RingView {
     fn slot_element(
         &self,
         slot: ActionRingSlot,
+        armed: bool,
         cx: &mut Context<Self>,
     ) -> Option<gpui::AnyElement> {
         let presentation = self.invocation.slots.get(&slot)?;
         let icon_path = presentation.icon.asset_path();
         let selected = self.hovered == Some(slot);
-        let (left, top) = slot.placement(WINDOW_SIZE, RADIUS, SLOT_SIZE);
+        let home = slot.placement(WINDOW_SIZE, RADIUS, SLOT_SIZE);
         let session_id = self.invocation.session_id;
         let activate = self.commands.clone();
-        Some(
-            div()
-                .id(("ring-slot", slot.index()))
-                .absolute()
-                .left(px(left))
-                .top(px(top))
-                .size(px(SLOT_SIZE))
-                .flex()
-                .items_center()
-                .justify_center()
-                .rounded_full()
-                .bg(if selected {
-                    color::accent_at_lightness(SELECTED_FILL_L)
-                } else {
-                    SLOT_RESTING
-                })
-                .when(selected, |slot| {
-                    slot.border_2()
-                        .border_color(color::accent_at_lightness(SELECTED_BORDER_L))
-                })
-                .shadow_md()
-                .text_color(GLYPH)
-                .cursor_pointer()
-                .child(svg().path(icon_path).size(px(22.0)).text_color(GLYPH))
-                .on_hover(cx.listener(move |this, hovered, _, cx| {
-                    if *hovered && this.hovered != Some(slot) {
-                        this.hovered = Some(slot);
-                        let _ = this
-                            .commands
-                            .send(OverlayCommand::Hover { session_id, slot });
-                        cx.notify();
-                    } else if !*hovered && this.hovered == Some(slot) {
-                        this.hovered = None;
-                        cx.notify();
-                    }
-                }))
-                .on_click(move |_, window, cx| {
-                    cx.stop_propagation();
-                    let _ = activate.send(OverlayCommand::Activate { session_id, slot });
-                    window.remove_window();
-                })
-                .into_any_element(),
-        )
+        let element = div()
+            .id(("ring-slot", slot.index()))
+            .absolute()
+            .size(px(SLOT_SIZE))
+            .flex()
+            .items_center()
+            .justify_center()
+            .rounded_full()
+            .bg(if selected {
+                color::accent_at_lightness(SELECTED_FILL_L)
+            } else {
+                SLOT_RESTING
+            })
+            .when(selected, |slot| {
+                slot.border_2()
+                    .border_color(color::accent_at_lightness(SELECTED_BORDER_L))
+            })
+            .shadow_md()
+            .text_color(GLYPH)
+            .cursor_pointer()
+            .child(svg().path(icon_path).size(px(SLOT_GLYPH)).text_color(GLYPH))
+            .on_hover(cx.listener(move |this, hovered, _, cx| {
+                if *hovered && this.hovered != Some(slot) {
+                    this.hovered = Some(slot);
+                    let _ = this
+                        .commands
+                        .send(OverlayCommand::Hover { session_id, slot });
+                    cx.notify();
+                } else if !*hovered && this.hovered == Some(slot) {
+                    this.hovered = None;
+                    cx.notify();
+                }
+            }))
+            .on_click(move |_, window, cx| {
+                cx.stop_propagation();
+                let _ = activate.send(OverlayCommand::Activate { session_id, slot });
+                window.remove_window();
+            });
+        // Position is owned by the fly-out: the slot starts under the cursor
+        // and flies to `home`, fading in on the way. Before the view is armed
+        // it just waits at the start. Reduce Motion renders the end state
+        // directly (GPUI's contract for one-shot animations), so the ring
+        // simply appears in place.
+        let fly_out = move |slot: gpui::Stateful<gpui::Div>, progress: f32| {
+            let (left, top) = fly_out_position(home, progress);
+            slot.left(px(left)).top(px(top)).opacity(progress)
+        };
+        Some(if armed {
+            element
+                .with_animation(
+                    ("ring-slot-fly-out", slot.index()),
+                    Animation::new(FLY_OUT).with_easing(ease_out_cubic),
+                    fly_out,
+                )
+                .into_any_element()
+        } else {
+            fly_out(element, 0.0).into_any_element()
+        })
     }
 }
 
+/// Where a slot sits `progress` (0..=1) of the way from the ring's centre to
+/// its `home` placement. Positions are the slot's top-left corner, as GPUI lays
+/// it out.
+fn fly_out_position(home: (f32, f32), progress: f32) -> (f32, f32) {
+    let centre = WINDOW_SIZE / 2.0 - SLOT_SIZE / 2.0;
+    (
+        centre + (home.0 - centre) * progress,
+        centre + (home.1 - centre) * progress,
+    )
+}
+
 impl Render for RingView {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let armed = std::mem::replace(&mut self.armed, true);
+        if !armed {
+            window.request_animation_frame();
+        }
         let session_id = self.invocation.session_id;
         let root_commands = self.commands.clone();
         let center_commands = self.commands.clone();
@@ -166,39 +232,38 @@ impl Render for RingView {
         });
         let slots = ActionRingSlot::ALL
             .into_iter()
-            .filter_map(|slot| self.slot_element(slot, cx))
+            .filter_map(|slot| self.slot_element(slot, armed, cx))
             .collect::<Vec<_>>();
 
+        // The cancel button is not animated: it marks the cursor the ring was
+        // raised at, and it is there on the first frame so the press reads as
+        // acknowledged before the slots have finished arriving.
         div()
             .id("ring-root")
             .relative()
             .size_full()
-            .child(
-                div()
-                    .absolute()
-                    .left(px(18.0))
-                    .top(px(18.0))
-                    .size(px(WINDOW_SIZE - 36.0))
-                    .rounded_full()
-                    .bg(PANEL)
-                    .shadow_lg(),
-            )
             .children(slots)
             .child(
                 div()
                     .id("ring-cancel")
                     .absolute()
-                    .left(px(WINDOW_SIZE / 2.0 - 24.0))
-                    .top(px(WINDOW_SIZE / 2.0 - 24.0))
-                    .size(px(48.0))
+                    .left(px(WINDOW_SIZE / 2.0 - CANCEL_SIZE / 2.0))
+                    .top(px(WINDOW_SIZE / 2.0 - CANCEL_SIZE / 2.0))
+                    .size(px(CANCEL_SIZE))
                     .flex()
                     .items_center()
                     .justify_center()
                     .rounded_full()
                     .bg(CANCEL_RESTING)
+                    .shadow_md()
                     .text_color(CANCEL_GLYPH)
                     .cursor_pointer()
-                    .child(svg().path(RING_CANCEL_ICON).size(px(20.0)).flex_none())
+                    .child(
+                        svg()
+                            .path(RING_CANCEL_ICON)
+                            .size(px(CANCEL_GLYPH_SIZE))
+                            .flex_none(),
+                    )
                     .on_click(move |_, window, cx| {
                         cx.stop_propagation();
                         let _ = center_commands.send(OverlayCommand::Cancel { session_id });
@@ -206,16 +271,30 @@ impl Render for RingView {
                     }),
             )
             .when_some(hovered_label, |ring, label| {
+                // With the desktop showing through the ring, the label brings
+                // its own dark pill so it stays legible over anything. It sits
+                // under the ring: the centre is too tight for text now, and
+                // below the bottom slot it never covers a target.
                 ring.child(
                     div()
                         .absolute()
                         .left(px(WINDOW_SIZE / 2.0 - 80.0))
-                        .top(px(WINDOW_SIZE / 2.0 + 34.0))
+                        .top(px(WINDOW_SIZE / 2.0 + RADIUS + SLOT_SIZE / 2.0 + 6.0))
                         .w(px(160.0))
-                        .text_center()
-                        .text_sm()
-                        .text_color(LABEL)
-                        .child(label),
+                        .flex()
+                        .justify_center()
+                        .child(
+                            div()
+                                .px_3()
+                                .py_1()
+                                .rounded_full()
+                                .bg(LABEL_PILL)
+                                .shadow_md()
+                                .text_center()
+                                .text_sm()
+                                .text_color(LABEL)
+                                .child(label),
+                        ),
                 )
             })
             .on_click(move |_, window, _| {
@@ -257,6 +336,24 @@ pub(crate) fn clamp_window_origin(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn slots_fly_out_from_the_centre_to_their_placement() {
+        let home = ActionRingSlot::Right.placement(WINDOW_SIZE, RADIUS, SLOT_SIZE);
+        let centre = WINDOW_SIZE / 2.0 - SLOT_SIZE / 2.0;
+        assert_eq!(fly_out_position(home, 0.0), (centre, centre));
+        assert_eq!(fly_out_position(home, 1.0), home);
+        let (mid_x, mid_y) = fly_out_position(home, 0.5);
+        assert!((mid_x - (centre + RADIUS / 2.0)).abs() < 1e-3);
+        assert!((mid_y - centre).abs() < 1e-3);
+    }
+
+    #[test]
+    fn the_fly_out_curve_is_front_loaded_and_lands_exactly() {
+        assert!((ease_out_cubic(0.0)).abs() < 1e-6);
+        assert!((ease_out_cubic(1.0) - 1.0).abs() < 1e-6);
+        assert!(ease_out_cubic(0.5) > 0.85);
+    }
 
     #[test]
     fn overlay_origin_is_clamped_to_the_display() {

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -17,6 +17,7 @@ use gpui::{
     WindowBackgroundAppearance, WindowKind, WindowOptions, div, prelude::FluentBuilder as _, px,
     svg,
 };
+use openlogi_core::action_ring::geometry::{CANCEL_DIAMETER, RADIUS, SLOT_DIAMETER};
 use openlogi_core::binding::{Action, ActionRingSlot};
 use openlogi_ipc::ActionRingInvocation;
 use openlogi_ui::action_icons::RING_CANCEL_ICON;
@@ -28,15 +29,11 @@ use tokio::sync::mpsc;
 use crate::agent::OverlayCommand;
 use crate::session::{ClickAwaySession, ShowingRing};
 
-/// Ring geometry. The radius is the mouse travel to any slot, so it is kept
-/// as tight as the slots allow: eight 48 pt slots on an 84 pt radius leave a
-/// 16 pt gap between neighbours, which is enough for the desktop to read
-/// through and for a slot's hover edge to be unambiguous. The window is the
-/// ring plus room for the hover label under it and the slot shadows.
+/// The window is the ring (`openlogi_core::action_ring::geometry`) plus room
+/// for the hover label under it and the slot shadows.
 pub(crate) const WINDOW_SIZE: f32 = 300.0;
-pub(crate) const SLOT_SIZE: f32 = 48.0;
-pub(crate) const RADIUS: f32 = 84.0;
-const CANCEL_SIZE: f32 = 36.0;
+pub(crate) const SLOT_SIZE: f32 = SLOT_DIAMETER;
+const CANCEL_SIZE: f32 = CANCEL_DIAMETER;
 const SLOT_GLYPH: f32 = 20.0;
 const CANCEL_GLYPH_SIZE: f32 = 16.0;
 

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -9,14 +9,14 @@
 //! slots fly out from the cursor to their places on the ring, so the motion
 //! itself says where the ring came from.
 
-#[cfg(any(not(target_os = "windows"), test))]
-use gpui::{Bounds, Pixels, Point, Size, point};
 use gpui::{
     Animation, AnimationExt as _, Context, Hsla, InteractiveElement, IntoElement, ParentElement,
     Render, SharedString, StatefulInteractiveElement as _, Styled, Window,
     WindowBackgroundAppearance, WindowKind, WindowOptions, div, prelude::FluentBuilder as _, px,
     svg,
 };
+#[cfg(any(not(target_os = "windows"), test))]
+use gpui::{Bounds, Pixels, Point, Size, point};
 use openlogi_core::action_ring::geometry::{CANCEL_DIAMETER, RADIUS, SLOT_DIAMETER};
 use openlogi_core::binding::{Action, ActionRingSlot};
 use openlogi_ipc::ActionRingInvocation;


### PR DESCRIPTION

## Summary

Restyles the Actions Ring so it reads as eight floating slots around the cursor instead of
a dark disc, opens with a short fly-out from the cursor, and takes ~30% less mouse travel to
reach a slot. The settings app's preview is drawn from the same geometry so it matches.

| Open | Hover label |
|---|---|
| ![ring open](https://raw.githubusercontent.com/isleofgreg/OpenLogi/assets/ring-restyle/ring-open.png) | ![hover label](https://raw.githubusercontent.com/isleofgreg/OpenLogi/assets/ring-restyle/ring-hover-label.png) |

![fly-out](https://raw.githubusercontent.com/isleofgreg/OpenLogi/assets/ring-restyle/ring-fly-out.gif)

- **No backing disc.** The desktop shows through between slots. Clicking a gap still
  dismisses (the root element covers the window). The hover label brings its own dark pill
  and now sits under the ring, where it never covers a target.
- **Fly-out on open.** Slots start under the cursor and travel to their places over 180 ms
  with a cubic ease-out, fading in. The cancel button is static so the press reads as
  acknowledged on the first frame. Reduce Motion renders the end state directly (GPUI's
  one-shot animation contract).
- **Tighter geometry.** 48 pt slots on an 84 pt radius, 36 pt cancel button, 300 pt window
  (was 54 / 122 / 48 / 360). Neighbouring slots keep a 16 pt gap. Measured against Logi
  Options+ (47 / 82 / 31 at 2×) — the radius is the mouse travel, and the old one was ~50%
  longer than the app most users are coming from.
- Colours are unchanged (dark slots, brand accent on hover).
- **Shared geometry.** Slot diameter, radius, and cancel diameter now live in
  `openlogi_core::action_ring::geometry`, next to `DISPLAY_LIFETIME` and for the same
  reason: the overlay and the settings app each drew the ring from their own numbers and
  the preview had drifted from what the user gets. The preview uses the constants, drops
  its disc, and shrinks its canvas to the tighter ring.

## One thing worth knowing for review

GPUI draws a new window once, synchronously, inside `open_window` — before the platform has
presented it. An animation clocked from that draw has spent most of its run before anyone
can see it; on macOS I saw only the last few frames. The view therefore parks the slots at
the cursor on its first render, requests a frame, and starts the animation on the next
render, which comes from the frame loop of a presented window. Documented on the `armed`
field.

## Test plan

- `cargo clippy -p openlogi-core -p openlogi-overlay -p openlogi-desktop --all-targets -- -D warnings`
  clean; overlay tests pass including new ones for the fly-out interpolation and the easing
  curve.
- Daily-driven on macOS 15 (MX Master 4, Bolt): open/dismiss, hover label, slot activation,
  click-away, screen-edge clamping, multi-display placement.
- Captures above are from the daily-driven build (macOS 15, dark desktop).
