### PR TITLE
fix(hook): give the macOS tap's capability probes their own watchdog budget

### DIFF
--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -908,7 +908,10 @@ fn spawn_lifecycle_watchdog(
                         let phase = signals.phase();
                         let still_hazardous = match reason {
                             LifecycleExitReason::TapThreadStalled => {
-                                matches!(phase, TapPhase::Arming | TapPhase::Armed)
+                                matches!(
+                                    phase,
+                                    TapPhase::Arming | TapPhase::Armed | TapPhase::Probing
+                                )
                             }
                             LifecycleExitReason::StopTimedOut => phase != TapPhase::ThreadExited,
                         };
@@ -918,6 +921,9 @@ fn spawn_lifecycle_watchdog(
                         let reason = match reason {
                             LifecycleExitReason::TapThreadStalled if phase == TapPhase::Arming => {
                                 "HID tap creation or activation stopped making progress"
+                            }
+                            LifecycleExitReason::TapThreadStalled if phase == TapPhase::Probing => {
+                                "HID tap capability probe stopped making progress"
                             }
                             LifecycleExitReason::TapThreadStalled => {
                                 "HID tap thread stopped making progress while tap remained active"
@@ -979,6 +985,13 @@ fn service_tap(tap: &CGEventTap<'_>, signals: &WatchdogSignals, tap_disabled: &A
             CFRunLoopRunResult::TimedOut | CFRunLoopRunResult::HandledSource => {}
         }
         signals.mark_tap_progress();
+        // Everything below this point is a WindowServer or TCC round trip, not
+        // tap servicing. Publish that so the lifecycle watchdog judges it
+        // against `TAP_PROBE_BUDGET`: while the display is asleep these calls
+        // have been measured at ~1.6 s, and charging them to the 1.5 s stall
+        // budget force-exited a perfectly healthy agent once a minute for the
+        // whole of display sleep (#952).
+        signals.set_phase(TapPhase::Probing);
         if !Backend::has_accessibility() {
             warn!(
                 "Accessibility revoked while the event tap was live — \
@@ -1001,6 +1014,12 @@ fn service_tap(tap: &CGEventTap<'_>, signals: &WatchdogSignals, tap_disabled: &A
         // Enabling is idempotent while the tap is already live. Only reached
         // while the live capability probe above still succeeds.
         tap.enable();
+        // Back to servicing the tap: the short stall budget applies again. The
+        // break paths above deliberately leave `Probing` published — the thread
+        // is still inside CoreGraphics for the synchronous teardown, and the
+        // watchdog stays armed on `Probing` either way.
+        signals.set_phase(TapPhase::Armed);
+        signals.mark_tap_progress();
     }
 }
 

--- a/crates/openlogi-hook/src/macos/watchdog.rs
+++ b/crates/openlogi-hook/src/macos/watchdog.rs
@@ -6,6 +6,17 @@ use std::time::{Duration, Instant};
 
 pub(super) const CALLBACK_STUCK_BUDGET: Duration = Duration::from_millis(200);
 pub(super) const TAP_SHUTDOWN_BUDGET: Duration = Duration::from_millis(1_500);
+/// How long the tap thread may stay inside one between-slice capability probe
+/// before the watchdog treats it as wedged.
+///
+/// [`TapPhase::Probing`] time is not the freeze hazard [`TAP_SHUTDOWN_BUDGET`]
+/// guards: the thread is inside CoreGraphics/TCC calls that are slow rather
+/// than stuck, and an active tap whose thread is not servicing its run loop is
+/// already bounded by CoreGraphics' own tap timeout, which disables the tap and
+/// lets events through. Only a probe that never returns is hazardous, so this
+/// budget is generous enough to clear the multi-second WindowServer round trips
+/// seen while the display is asleep (#952) and still bounded.
+pub(super) const TAP_PROBE_BUDGET: Duration = Duration::from_secs(10);
 /// How many re-arms the hook grants inside [`REARM_WINDOW`] before it gives
 /// the tap up.
 pub(super) const REARM_LIMIT: u32 = 10;
@@ -22,6 +33,11 @@ pub(super) enum TapPhase {
     /// The tap thread is creating or activating a tap that may already exist.
     Arming,
     Armed,
+    /// The tap is live and its thread is between run-loop slices, inside the
+    /// CoreGraphics and TCC calls that re-check the Accessibility grant and
+    /// re-arm the tap. Those are WindowServer round trips, not the tap's own
+    /// event servicing, so they are budgeted by [`TAP_PROBE_BUDGET`].
+    Probing,
     TapStopped,
     ThreadExited,
 }
@@ -38,7 +54,8 @@ impl TapPhase {
             0 => Self::Starting,
             1 => Self::Arming,
             2 => Self::Armed,
-            3 => Self::TapStopped,
+            3 => Self::Probing,
+            4 => Self::TapStopped,
             _ => Self::ThreadExited,
         }
     }
@@ -186,7 +203,7 @@ impl LifecycleWatchdog {
         match observation.phase {
             TapPhase::Starting => return LifecycleDecision::Continue,
             TapPhase::ThreadExited => return LifecycleDecision::Complete,
-            TapPhase::Arming | TapPhase::Armed | TapPhase::TapStopped => {}
+            TapPhase::Arming | TapPhase::Armed | TapPhase::Probing | TapPhase::TapStopped => {}
         }
 
         if observation.stop_requested {
@@ -198,7 +215,10 @@ impl LifecycleWatchdog {
 
         let timeout = if let Some(stopped) = self.stop_at {
             Some((LifecycleExitReason::StopTimedOut, stopped))
-        } else if matches!(observation.phase, TapPhase::Arming | TapPhase::Armed) {
+        } else if matches!(
+            observation.phase,
+            TapPhase::Arming | TapPhase::Armed | TapPhase::Probing
+        ) {
             Some((
                 LifecycleExitReason::TapThreadStalled,
                 observation.tap_progress_at,
@@ -210,7 +230,16 @@ impl LifecycleWatchdog {
             return LifecycleDecision::Continue;
         };
         let elapsed = now.saturating_sub(started);
-        if elapsed >= TAP_SHUTDOWN_BUDGET {
+        // A thread that published `Probing` reached that store, so it is alive
+        // and inside a named CoreGraphics/TCC call rather than wedged servicing
+        // the tap. Judge it against the probe budget for either exit reason —
+        // a stop request landing on a slow probe is the same situation.
+        let budget = if observation.phase == TapPhase::Probing {
+            TAP_PROBE_BUDGET
+        } else {
+            TAP_SHUTDOWN_BUDGET
+        };
+        if elapsed >= budget {
             LifecycleDecision::Exit { reason, elapsed }
         } else {
             LifecycleDecision::Continue
@@ -259,9 +288,10 @@ mod tests {
         assert_eq!(TapPhase::decode(0), TapPhase::Starting);
         assert_eq!(TapPhase::decode(1), TapPhase::Arming);
         assert_eq!(TapPhase::decode(2), TapPhase::Armed);
-        assert_eq!(TapPhase::decode(3), TapPhase::TapStopped);
-        assert_eq!(TapPhase::decode(4), TapPhase::ThreadExited);
-        assert_eq!(TapPhase::decode(5), TapPhase::Armed);
+        assert_eq!(TapPhase::decode(3), TapPhase::Probing);
+        assert_eq!(TapPhase::decode(4), TapPhase::TapStopped);
+        assert_eq!(TapPhase::decode(5), TapPhase::ThreadExited);
+        assert_eq!(TapPhase::decode(6), TapPhase::Armed);
         assert_eq!(TapPhase::decode(u8::MAX), TapPhase::Armed);
 
         let signals = WatchdogSignals::default();
@@ -335,6 +365,85 @@ mod tests {
                 observation(TapPhase::TapStopped, false, Duration::ZERO)
             ),
             LifecycleDecision::Complete
+        );
+    }
+
+    #[test]
+    fn a_slow_capability_probe_is_not_a_wedged_tap_thread() {
+        // #952: with the display asleep the between-slice `has_accessibility`
+        // probe (a WindowServer round trip) took ~1.6 s, which the watchdog
+        // charged against the 1.5 s stall budget and force-exited the agent
+        // once a minute for the whole sleep. The probe has its own budget.
+        let mut watchdog = LifecycleWatchdog::default();
+        let probing = observation(TapPhase::Probing, false, Duration::ZERO);
+        assert_eq!(
+            watchdog.evaluate(TAP_SHUTDOWN_BUDGET, probing),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(Duration::from_millis(1_740), probing),
+            LifecycleDecision::Continue
+        );
+        // The probe returning re-marks progress; the tap is healthy again.
+        assert_eq!(
+            watchdog.evaluate(
+                Duration::from_millis(1_800),
+                observation(TapPhase::Armed, false, Duration::from_millis(1_750))
+            ),
+            LifecycleDecision::Continue
+        );
+        // A probe that never returns is still the freeze hazard.
+        assert_eq!(
+            watchdog.evaluate(TAP_PROBE_BUDGET, probing),
+            LifecycleDecision::Exit {
+                reason: LifecycleExitReason::TapThreadStalled,
+                elapsed: TAP_PROBE_BUDGET,
+            }
+        );
+    }
+
+    #[test]
+    fn a_stop_request_landing_on_a_probe_waits_for_the_probe_budget() {
+        // Releasing the hook when the session or display gate closes lands the
+        // stop exactly when the probes are slowest; the shorter stop budget
+        // would kill the agent for the teardown it just asked for.
+        let mut watchdog = LifecycleWatchdog::default();
+        let probing = observation(TapPhase::Probing, true, Duration::ZERO);
+        assert_eq!(
+            watchdog.evaluate(Duration::ZERO, probing),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(TAP_SHUTDOWN_BUDGET, probing),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(TAP_PROBE_BUDGET, probing),
+            LifecycleDecision::Exit {
+                reason: LifecycleExitReason::StopTimedOut,
+                elapsed: TAP_PROBE_BUDGET,
+            }
+        );
+    }
+
+    #[test]
+    fn a_stopped_tap_still_exits_on_the_short_stop_budget() {
+        // The probe budget is scoped to the phase that publishes it: once the
+        // tap thread leaves `Probing`, an unfinished stop is judged as before.
+        let mut watchdog = LifecycleWatchdog::default();
+        let _ = watchdog.evaluate(
+            Duration::ZERO,
+            observation(TapPhase::Probing, true, Duration::ZERO),
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                TAP_SHUTDOWN_BUDGET,
+                observation(TapPhase::TapStopped, true, Duration::ZERO)
+            ),
+            LifecycleDecision::Exit {
+                reason: LifecycleExitReason::StopTimedOut,
+                elapsed: TAP_SHUTDOWN_BUDGET,
+            }
         );
     }
 


### PR DESCRIPTION
## Summary

When the Mac goes to sleep, the agent force-exits and launchd restarts it. Over one 2.5 h clamshell sleep my agent log records that cycle 27 times, and 43 times across the day. Refs #952.

`service_tap` marks tap progress immediately before and after its 500 ms `CFRunLoopRunInMode` slice, then runs the between-slice capability probe (`AXIsProcessTrusted()`, the throwaway `CGEventTapCreate` in `can_filter_events()`, `CGEventTapIsEnabled`, `CGEventTapEnable`) without marking again until the top of the next iteration. That window is charged to `TAP_SHUTDOWN_BUDGET`, so a probe slower than 1.5 s reads as a wedged tap thread and the lifecycle watchdog exits with `FREEZE_HAZARD_EXIT_CODE`.

Those calls are WindowServer and TCC round trips, and they take seconds while the system is going to sleep. Because the slice is capped at 500 ms and re-marks progress on both sides, every millisecond of the logged 1555-1809 ms overrun is inside the probe. The thread is slow, not wedged.

## Changes

- New `TapPhase::Probing`, published by the tap thread for the post-slice CoreGraphics/TCC window and cleared back to `Armed` (with a fresh progress mark) once `CGEventTapEnable` returns.
- `LifecycleWatchdog` judges `Probing` against a separate `TAP_PROBE_BUDGET` (10 s) for both exit reasons, so a stop request landing on a slow probe is treated the same way. Everything else keeps the 1.5 s budget.
- `Probing` stays hazardous for the re-check before exiting, so a probe that never returns (the TCC-revocation stall this watchdog exists for) still force-exits.
- The freeze exposure does not grow with the budget: an active tap whose thread is not servicing its run loop is already bounded by CoreGraphics' own tap timeout, which disables the tap and lets events through.

There is a second, independent defect in the same loop: each relaunched agent reopens the device-I/O gate at startup because no window-server level it reads can tell it is in a DarkWake. That is a gate concern rather than a hook one and is addressed separately in #1283. This change stands on its own, because the exit happens whether or not the gate is open.

## Evidence

From `~/.local/state/openlogi/agent.2026-09-05.log` (UTC). `pmset -g log` puts "Display is turned off" at 20:35:54 and "Display is turned on" at 23:04:29; 27 identical cycles fall between them:

```
2026-09-05T20:35:54.507206Z  INFO openlogi_agent::tray: display/session suspended — pausing device I/O
2026-09-05T20:36:02.865054Z ERROR openlogi_hook::macos: HID CGEventTap lifecycle did not make progress before deadline — exiting agent to restore system input reason="HID tap thread stopped making progress while tap remained active" elapsed_ms=1567 phase=Armed
2026-09-05T20:37:03.390336Z ERROR openlogi_hook::macos: HID CGEventTap lifecycle did not make progress before deadline — exiting agent to restore system input reason="HID tap thread stopped making progress while tap remained active" elapsed_ms=1636 phase=Armed
```

`elapsed_ms` never leaves the 1555-1809 range, and the loop stops the moment the machine really wakes.

## Update: it is the sleep transition, not the dark display

I originally described this as happening "while the display is asleep". That was the wrong frame — the display being off is incidental. I merged today's 43 watchdog exits with `pmset -g log`, and every one of them sits at a **system sleep transition**:

| offset | event |
|---|---|
| 0 s | `pmset`: `Entering Sleep state due to 'Maintenance Sleep'` (the first one of a run is `Clamshell Sleep`) |
| +3-12 s (median 4) | `HID CGEventTap lifecycle did not make progress before deadline` |
| +0.3 s | launchd restarts the agent; it logs `display/session resumed — enabling device I/O` |
| +7-19 s (median 12) | `pmset`: `DarkWake from Deep Idle [CDNP] : due to ATC0.PMGRCIOWakeup` — the Thunderbolt dock the Unifying receiver is attached to |
| +45 s | `Entering Sleep` again, and round it goes |

43 of 43 exits fit that shape; 16 of them ran back to back over 18:43-18:59. So the probe stalls because WindowServer stops answering as the system goes down, which is also why the machine never settles: with the lid closed it sleeps and DarkWakes on a 45-second cycle for as long as the loop runs. I am **not** claiming the relaunched agent's HID open is what wakes the dock — I have not proved that, only the correlation.

Two honest consequences for this PR:

- Whether a 10 s budget is enough to survive the sleep transition is **still unverified**. I have not caught a probe that overran and returned; every sample so far exited at 1.5-1.8 s, which is well inside 10 s, but I cannot yet rule out a transition where the probe takes longer than that.
- #1283 is what makes a relaunch harmless in the meantime: the restarted agent no longer reopens the device-I/O gate during the transition, so even if this budget is occasionally exceeded the relaunch stops touching hardware in a DarkWake.

I have both branches merged and installed on the affected machine and will report the next lid close here.

## Testing

Run (macOS 26.6.2, aarch64, `RUSTFLAGS="-D warnings"`):

- `cargo fmt --all -- --check`
- `cargo clippy -p openlogi-hook -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`
- `cargo test -p openlogi-hook` (23), `cargo test -p openlogi-agent-core` (218), `cargo test -p openlogi-agent -- --test-threads=1` (25)
- New tests: a 1.5 s and a 1.74 s probe are `Continue`, a 10 s probe still exits; a stop request landing on a probe waits for the probe budget; leaving `Probing` restores the short stop budget; the phase decoder stays total after renumbering.

Not run:

- `openlogi-desktop` / `openlogi-overlay` (in the affected set): this host cannot compile GPUI's Metal shaders (`cannot execute tool 'metal' due to missing Metal Toolchain`). The change is a private enum variant and a private const; neither crate references `TapPhase`.
- Linux/Windows cross-lint: only `aarch64-apple-darwin` installed; every changed line is inside macOS-only files.
- Hardware: installed now, not yet through a lid close. To test: MacBook in clamshell on an external display, close the lid for ten minutes, then check the agent log for `HID CGEventTap lifecycle did not make progress` lines and `pmset -g log` for the 45-second sleep/DarkWake cycle above.
