### PR TITLE
fix(assets): resolve variants for depots whose manifests key on depot name or stem

### DIFF
--- a/crates/openlogi-desktop/src/services/assets.rs
+++ b/crates/openlogi-desktop/src/services/assets.rs
@@ -32,7 +32,10 @@ use openlogi_core::device::{DeviceKind, DeviceModelInfo};
 use tracing::{debug, warn};
 use walkdir::WalkDir;
 
-use self::images::{buttons_image_for, load_manifest, read_png_dimensions, variant_image_for};
+use self::images::{
+    buttons_image_for, find_variant_in_manifest, load_manifest, read_png_dimensions,
+    variant_image_for,
+};
 use self::paths::{bundle_assets_root, load_index, user_cache_root};
 
 /// Total bytes of the per-user asset cache — the tier [`sync`] writes and
@@ -247,14 +250,10 @@ impl AssetResolver {
             // Parse the manifest once and consult it for every candidate.
             let manifest = load_manifest(&dir);
             let buttons_name = manifest.as_ref().and_then(|m| {
-                entry
-                    .model_id_candidates()
-                    .find_map(|base| buttons_image_for(m, base, model.extended_model_id))
+                find_variant_in_manifest(m, entry, depot, model.extended_model_id, buttons_image_for)
             });
             let variant_front_name = manifest.as_ref().and_then(|m| {
-                entry
-                    .model_id_candidates()
-                    .find_map(|base| variant_image_for(m, base, model.extended_model_id))
+                find_variant_in_manifest(m, entry, depot, model.extended_model_id, variant_image_for)
             });
             // Front/hero render for the gallery: the colour variant's
             // `device_image`, falling back to the generic front renders. Resolved

--- a/crates/openlogi-desktop/src/services/assets/images.rs
+++ b/crates/openlogi-desktop/src/services/assets/images.rs
@@ -54,6 +54,49 @@ pub(super) fn variant_image_for(
         .map(str::to_string)
 }
 
+/// Helper that checks variants against candidate model IDs, including the depot name and
+/// any stripped `_ext\d+` stem (e.g. for depots like `pro_keyboard_ext1`).
+pub(super) fn find_variant_in_manifest<'a, F>(
+    manifest: &DepotManifest,
+    entry: &'a openlogi_assets::DeviceEntry,
+    depot: &'a str,
+    ext: u8,
+    lookup: F,
+) -> Option<String>
+where
+    F: Fn(&DepotManifest, &str, u8) -> Option<String>,
+{
+    let candidates = candidate_manifest_bases(entry, depot);
+    for base in candidates {
+        if let Some(res) = lookup(manifest, &base, ext) {
+            return Some(res);
+        }
+    }
+    None
+}
+
+/// Enumerate candidate manifest bases: model IDs, the depot name, and any stripped `_ext\d+` stem.
+pub(super) fn candidate_manifest_bases(
+    entry: &openlogi_assets::DeviceEntry,
+    depot: &str,
+) -> Vec<String> {
+    let mut candidates = Vec::new();
+    for id in entry.model_id_candidates() {
+        if !candidates.iter().any(|c: &String| c.eq_ignore_ascii_case(id)) {
+            candidates.push(id.to_string());
+        }
+    }
+    if !candidates.iter().any(|c: &String| c.eq_ignore_ascii_case(depot)) {
+        candidates.push(depot.to_string());
+    }
+    if let Some((stem, _)) = depot.split_once("_ext")
+        && !candidates.iter().any(|c: &String| c.eq_ignore_ascii_case(stem))
+    {
+        candidates.push(stem.to_string());
+    }
+    candidates
+}
+
 /// Like [`variant_image_for`] but returns the `device_buttons_image`
 /// resource (typically `side_*.png`) — that's the view Logi calibrates
 /// the assignment markers against, so the mouse-model render uses it.

--- a/crates/openlogi-desktop/src/services/assets/images.rs
+++ b/crates/openlogi-desktop/src/services/assets/images.rs
@@ -89,7 +89,9 @@ pub(super) fn candidate_manifest_bases(
     if !candidates.iter().any(|c: &String| c.eq_ignore_ascii_case(depot)) {
         candidates.push(depot.to_string());
     }
-    if let Some((stem, _)) = depot.split_once("_ext")
+    if let Some((stem, suffix)) = depot.rsplit_once("_ext")
+        && !suffix.is_empty()
+        && suffix.chars().all(|c| c.is_ascii_digit())
         && !candidates.iter().any(|c: &String| c.eq_ignore_ascii_case(stem))
     {
         candidates.push(stem.to_string());

--- a/crates/openlogi-desktop/src/services/assets/sync.rs
+++ b/crates/openlogi-desktop/src/services/assets/sync.rs
@@ -182,7 +182,7 @@ fn sync_depot(
         "device_camera_image",
     ] {
         let Some(variant) =
-            pick_variant_filename(&manifest_path, &entry.model_id, ext, resource_key)
+            pick_variant_filename(&manifest_path, entry, depot, ext, resource_key)
         else {
             continue;
         };
@@ -232,7 +232,8 @@ fn fetch_to_cache(
 /// `None` when the manifest is missing, malformed, or lacks the variant.
 fn pick_variant_filename(
     manifest_path: &Path,
-    base_model_id: &str,
+    entry: &DeviceEntry,
+    depot: &str,
     ext: u8,
     resource_key: &str,
 ) -> Option<String> {
@@ -242,9 +243,13 @@ fn pick_variant_filename(
     let manifest = DepotManifest::load_from(manifest_path)
         .map_err(|e| warn!(error = %e, path = %manifest_path.display(), "manifest unreadable"))
         .ok()?;
-    manifest
-        .resource_for_variant(base_model_id, ext, resource_key)
-        .map(str::to_string)
+    let candidates = super::images::candidate_manifest_bases(entry, depot);
+    for base in candidates {
+        if let Some(src) = manifest.resource_for_variant(&base, ext, resource_key) {
+            return Some(src.to_string());
+        }
+    }
+    None
 }
 
 /// A manual asset action requested from the Settings → Assets tab, pushed to

--- a/crates/openlogi-desktop/src/services/assets/tests.rs
+++ b/crates/openlogi-desktop/src/services/assets/tests.rs
@@ -246,6 +246,64 @@ fn standalone_registry_lookup_does_not_cross_model_depots() {
 }
 
 #[test]
+fn resolves_depot_with_named_manifest_and_non_standard_render() {
+    let root = tempfile::tempdir().expect("create temp dir");
+    let depot = "pro_keyboard_ext1";
+    let dir = root.path().join(depot);
+    std::fs::create_dir_all(&dir).expect("create depot dir");
+    std::fs::write(
+        dir.join("manifest.json"),
+        r#"{"devices":[
+            {"modelId":"pro_keyboard_ext1","resources":[{"key":"device_image","src":"front_mx.png"}]},
+            {"modelId":"pro_keyboard_ext7","resources":[{"key":"device_image","src":"front_kda.png"}]}
+        ],"resources":[]}"#,
+    )
+    .expect("write manifest");
+    std::fs::write(
+        dir.join("metadata.json"),
+        r#"{"images":[{"key":"device_image","origin":{"width":500,"height":300}}]}"#,
+    )
+    .expect("write metadata");
+    std::fs::write(dir.join("front_mx.png"), png_header(500, 300)).expect("write front_mx.png");
+    std::fs::write(dir.join("front_kda.png"), png_header(500, 300)).expect("write front_kda.png");
+
+    let resolver = AssetResolver {
+        read_roots: vec![root.path().to_path_buf()],
+        write_root: root.path().to_path_buf(),
+        has_bundle: false,
+        index: None,
+    };
+    let entry = DeviceEntry {
+        model_id: "c339".to_string(),
+        model_ids: vec!["c339".to_string()],
+        display_name: "PRO".to_string(),
+        kind: "KEYBOARD".to_string(),
+        asset_path: format!("v1/devices/{depot}/"),
+        files: Vec::new(),
+    };
+
+    // Base model (ext == 0) resolves front_mx.png via pro_keyboard_ext1
+    let asset = resolver
+        .load_files(depot, &entry, &bare_model())
+        .expect("pro keyboard base variant should resolve");
+    assert_eq!(
+        asset.image_path.file_name().expect("filename"),
+        "front_mx.png"
+    );
+
+    // KDA variant (ext == 7) resolves front_kda.png via pro_keyboard stem + _ext7
+    let mut kda_model = bare_model();
+    kda_model.extended_model_id = 7;
+    let kda_asset = resolver
+        .load_files(depot, &entry, &kda_model)
+        .expect("pro keyboard KDA variant should resolve");
+    assert_eq!(
+        kda_asset.image_path.file_name().expect("filename"),
+        "front_kda.png"
+    );
+}
+
+#[test]
 fn unsafe_standalone_manifest_filename_is_rejected() {
     let root = tempfile::tempdir().expect("create temp dir");
     let depot = root.path().join("litra_glow");


### PR DESCRIPTION
## Summary

Fixes device image resolution and downloads for depots like `pro_keyboard_ext1` (Logitech PRO, `046d:c339`), `g203`, and `g305` where:

1. The depot ships no generic `front.png` or `front_core.png` (only variant filenames like `front_mx.png`, `front_kda.png`, etc.).
2. The depot's `manifest.json` keys devices by depot name or stem (`pro_keyboard_ext1`, `pro_keyboard_ext7`) rather than hex product IDs.

## Changes

- `openlogi-desktop::services::assets::images`: added `candidate_manifest_bases` and `find_variant_in_manifest` to inspect model IDs, depot name, and stripped `_ext\d+` stems against the manifest.
- `openlogi-desktop::services::assets::sync`: updated `pick_variant_filename` to resolve variants using the same candidate base list during asset syncing.
- Added unit test `resolves_depot_with_named_manifest_and_non_standard_render` verifying resolution for both base (`front_mx.png`) and extended variants (`front_kda.png`).