### PR TITLE
fix(overlay): fix Actions Ring position on a scaled Windows monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5719,6 +5719,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/openlogi-overlay/Cargo.toml
+++ b/crates/openlogi-overlay/Cargo.toml
@@ -44,5 +44,17 @@ objc2-app-kit = { workspace = true, features = ["NSApplication", "NSResponder", 
 # NSEvent global-monitor handlers are ObjC blocks (click-away dismissal).
 block2 = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+# MonitorFromPoint/GetMonitorInfoW/GetDpiForMonitor: placing the ring on the
+# cursor's display, and converting its physical-pixel position to GPUI's
+# logical points, needs a DPI query GPUI exposes no API for before a window
+# exists to ask.
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_HiDpi",
+    "Win32_UI_WindowsAndMessaging",
+] }
+
 [lints]
 workspace = true

--- a/crates/openlogi-overlay/src/platform.rs
+++ b/crates/openlogi-overlay/src/platform.rs
@@ -163,6 +163,10 @@ pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
     unsafe_code,
     reason = "MonitorFromPoint/GetMonitorInfoW/GetDpiForMonitor are plain Win32 FFI; GPUI exposes no DPI query before a window exists"
 )]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "native cursor coordinates are screen-sized and exactly usable as an i32 POINT"
+)]
 pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
     use windows_sys::Win32::Foundation::{POINT, RECT};
     use windows_sys::Win32::Graphics::Gdi::{

--- a/crates/openlogi-overlay/src/platform.rs
+++ b/crates/openlogi-overlay/src/platform.rs
@@ -89,13 +89,23 @@ pub fn watch_clicks_outside(_on_mouse_down: impl Fn() + 'static) -> Option<Click
 /// One display's global geometry, in the same top-left-origin global point
 /// space that `openlogi_hook::cursor_position()` reports.
 pub struct CursorDisplay {
-    /// Native display id; on macOS the `CGDirectDisplayID`, numerically equal
-    /// to GPUI's `DisplayId` for the same display.
+    /// Native display id; on macOS the `CGDirectDisplayID`, on Windows the
+    /// `HMONITOR` handle — both numerically equal to GPUI's `DisplayId` for
+    /// the same display.
     pub id: u64,
-    /// Global origin (top-left corner) of the display, in points.
+    /// Global origin (top-left corner) of the display, in the same unit as
+    /// `size` — GPUI logical points, already scaled down from whatever
+    /// physical unit the platform's raw display query reports.
     pub origin: (f64, f64),
-    /// Display size in points.
+    /// Display size, in the same logical unit as `origin`.
     pub size: (f64, f64),
+    /// Divide a raw `openlogi_hook::cursor_position()` coordinate by this to
+    /// reach the same logical unit as `origin`/`size`. `1.0` where the raw
+    /// cursor position already is that unit (macOS reports points, matching
+    /// `CGDisplayBounds` directly); on Windows `GetCursorPos` reports
+    /// physical pixels while GPUI positions windows in logical points, so
+    /// this is the monitor's DPI scale (`dpi / 96`).
+    pub scale: f64,
 }
 
 /// Find the display whose global bounds contain the point `(x, y)`.
@@ -131,13 +141,93 @@ pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
             id: u64::from(id),
             origin: (bounds.origin.x, bounds.origin.y),
             size: (bounds.size.width, bounds.size.height),
+            scale: 1.0,
         })
     })
 }
 
-/// Away from macOS the GPUI display list already carries global origins, so
+/// Find the display whose global physical bounds contain the point `(x, y)`
+/// and convert its geometry to GPUI's logical points.
+///
+/// GPUI's `PlatformDisplay::bounds()` on Windows is already logical (divided
+/// by the monitor's DPI scale internally), so — unlike macOS — the display
+/// lookup itself could in principle use GPUI's own list. The reason this
+/// still goes native is the other half of the same problem `origin`/`scale`
+/// solve: `openlogi_hook::cursor_position()` calls `GetCursorPos`, which
+/// reports physical pixels, and there is no public GPUI API to learn a
+/// display's DPI before a window exists on it to ask. `MonitorFromPoint`
+/// takes the physical cursor point directly, sidestepping the need to
+/// convert it before knowing which monitor (and thus which scale) applies.
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    reason = "MonitorFromPoint/GetMonitorInfoW/GetDpiForMonitor are plain Win32 FFI; GPUI exposes no DPI query before a window exists"
+)]
+pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
+    use windows_sys::Win32::Foundation::{POINT, RECT};
+    use windows_sys::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MONITOR_DEFAULTTONULL, MONITORINFO, MonitorFromPoint,
+    };
+    use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+    use windows_sys::Win32::UI::WindowsAndMessaging::USER_DEFAULT_SCREEN_DPI;
+
+    let point = POINT {
+        x: x as i32,
+        y: y as i32,
+    };
+    // SAFETY: `point` is a valid POINT for the duration of the call; a null
+    // `HMONITOR` result (no monitor under the point) is checked below.
+    let monitor = unsafe { MonitorFromPoint(point, MONITOR_DEFAULTTONULL) };
+    if monitor.is_null() {
+        return None;
+    }
+    let mut dpi_x = 0u32;
+    let mut dpi_y = 0u32;
+    // SAFETY: `monitor` was just returned non-null by `MonitorFromPoint`;
+    // `dpi_x`/`dpi_y` are valid writable `u32`s for the call's duration.
+    if unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &raw mut dpi_x, &raw mut dpi_y) } != 0
+    {
+        return None;
+    }
+    let scale = f64::from(dpi_x) / f64::from(USER_DEFAULT_SCREEN_DPI);
+    let mut info = MONITORINFO {
+        cbSize: size_of::<MONITORINFO>() as u32,
+        rcMonitor: RECT {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        },
+        rcWork: RECT {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        },
+        dwFlags: 0,
+    };
+    // SAFETY: `monitor` is the same non-null handle just used above; `info`
+    // is a valid writable `MONITORINFO` with `cbSize` set, as the API
+    // requires.
+    if unsafe { GetMonitorInfoW(monitor, &raw mut info) } == 0 {
+        return None;
+    }
+    let rect = info.rcMonitor;
+    Some(CursorDisplay {
+        id: monitor as u64,
+        origin: (f64::from(rect.left) / scale, f64::from(rect.top) / scale),
+        size: (
+            f64::from(rect.right - rect.left) / scale,
+            f64::from(rect.bottom - rect.top) / scale,
+        ),
+        scale,
+    })
+}
+
+/// Away from macOS and Windows the GPUI display list already carries global
+/// origins in the same unit `openlogi_hook::cursor_position()` reports, so
 /// there is nothing to resolve natively.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub fn display_containing(_x: f64, _y: f64) -> Option<CursorDisplay> {
     None
 }

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -244,17 +244,14 @@ pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
         if let (Some(cursor), Some(display)) = (&cursor, native_display) {
             (
                 Some(gpui::DisplayId::from(display.id)),
-                point(
-                    px((cursor.x - display.origin.0) as f32),
-                    px((cursor.y - display.origin.1) as f32),
-                ),
+                cursor_in_display_space(cursor, &display),
                 Some(Bounds::new(
                     Point::default(),
                     Size::new(px(display.size.0 as f32), px(display.size.1 as f32)),
                 )),
             )
         } else {
-            // No cursor or no native lookup (non-macOS): GPUI's own display
+            // No cursor or no native lookup (Linux): GPUI's own display
             // list, centering on the display when the cursor is unknown.
             let cursor_point = cursor
                 .as_ref()
@@ -291,6 +288,26 @@ pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
         app_id: Some("openlogi-action-ring".to_string()),
         ..WindowOptions::default()
     }
+}
+
+/// Translate a raw, global cursor point into `display`'s local logical space.
+///
+/// `display.scale` converts the raw point into the same logical unit as
+/// `display.origin` — a no-op (`scale == 1.0`) on macOS, where both are
+/// already points; on Windows the raw point is physical pixels and `scale`
+/// is the monitor's DPI scale, without which the ring would land at
+/// `cursor / scale` on any monitor not running at 100%.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "native cursor coordinates are screen-sized and exactly usable as GPUI f32 pixels"
+)]
+pub(crate) fn cursor_in_display_space(
+    cursor: &openlogi_hook::CursorPosition,
+    display: &platform::CursorDisplay,
+) -> Point<Pixels> {
+    let x = cursor.x / display.scale - display.origin.0;
+    let y = cursor.y / display.scale - display.origin.1;
+    point(px(x as f32), px(y as f32))
 }
 
 pub(crate) fn clamp_window_origin(
@@ -330,6 +347,41 @@ mod tests {
         assert_eq!(
             clamp_window_origin(desired, Size::new(px(400.0), px(400.0)), display),
             desired
+        );
+    }
+
+    #[test]
+    fn cursor_in_display_space_is_unscaled_at_100_percent() {
+        // macOS shape: the raw cursor point is already in the same unit as
+        // `display.origin` (points), so `scale == 1.0` is a plain subtraction.
+        let cursor = openlogi_hook::CursorPosition { x: 620.0, y: 340.0 };
+        let display = platform::CursorDisplay {
+            id: 1,
+            origin: (100.0, 50.0),
+            size: (1600.0, 1000.0),
+            scale: 1.0,
+        };
+        assert_eq!(
+            cursor_in_display_space(&cursor, &display),
+            point(px(520.0), px(290.0))
+        );
+    }
+
+    #[test]
+    fn cursor_in_display_space_divides_out_a_windows_dpi_scale() {
+        // Windows shape: `GetCursorPos` reports physical pixels; a monitor at
+        // 150% scale (144 dpi) must have that physical point divided down to
+        // GPUI's logical points before it lines up with `display.origin`.
+        let cursor = openlogi_hook::CursorPosition { x: 930.0, y: 510.0 };
+        let display = platform::CursorDisplay {
+            id: 1,
+            origin: (100.0, 50.0),
+            size: (1600.0, 1000.0),
+            scale: 1.5,
+        };
+        assert_eq!(
+            cursor_in_display_space(&cursor, &display),
+            point(px(520.0), px(290.0))
         );
     }
 }


### PR DESCRIPTION
## Summary

A commenter on #1210 confirmed the same symptom reported there (fixed for Linux/Wayland in #1211) also happens on Windows 11: the ring opens offset from the pointer and isn't reliably above other windows.

## Root cause

`ring_window_options` fed `openlogi_hook::cursor_position()`'s raw `GetCursorPos` coordinates — physical pixels — straight into GPUI's window placement, which treats `WindowOptions` bounds as logical points.

Confirmed by reading `gpui_windows`'s own source rather than guessing: `WindowsDisplay::bounds()` (`display.rs`) divides each monitor's rect by its DPI scale before handing it to GPUI as `PlatformDisplay::bounds()`, and the window-creation path (`window.rs`) runs incoming coordinates through `logical_point(x, y, scale_factor)`. Neither macOS nor X11/Wayland has this split — both already report cursor position in the same unit GPUI expects. On any Windows monitor not running at 100% scaling, the ring lands at `cursor / scale`, offset toward the top-left corner — the higher the scale factor, the worse the offset.

## Changes

- `crates/openlogi-overlay/src/platform.rs`: added a Windows `display_containing` (`MonitorFromPoint` + `GetDpiForMonitor` + `GetMonitorInfoW`), mirroring the existing macOS CoreGraphics implementation in shape. `CursorDisplay` gained a `scale` field — `1.0` on macOS (already points), the monitor's DPI scale (`dpi / 96`) on Windows.
- `crates/openlogi-overlay/src/ring.rs`: extracted the cursor-to-display-space conversion into `cursor_in_display_space`, which now divides the raw cursor point by `display.scale` before subtracting the display origin.
- `crates/openlogi-overlay/Cargo.toml`: added `windows-sys` (already a workspace dependency, used elsewhere in `openlogi-hook`) as a `target.'cfg(target_os = "windows")'` dependency with the `Win32_Graphics_Gdi`/`Win32_UI_HiDpi`/`Win32_UI_WindowsAndMessaging` feature modules.

## On the "not always on top" half

`gpui_windows` already requests `WS_EX_TOPMOST` for `WindowKind::PopUp` (confirmed by reading `window.rs`), so this isn't a missing window style. I can't verify on real Windows hardware whether that's sufficient in practice, or whether the position bug alone explains what was reported — a ring rendered somewhere unexpected because of the DPI offset can read as a z-order failure. Flagging this honestly rather than guessing further; worth the reporter confirming after this lands whether the topmost behavior is still an issue on its own.

## Testing

Linux, x86_64, Rust 1.98.0:

```
cargo fmt --all -- --check
cargo clippy -p openlogi-overlay --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test -p openlogi-overlay                                   # 19 passed
cargo check --workspace --all-targets
```

All clean. Two new unit tests cover the pure `cursor_in_display_space` conversion at 100% and a 150% DPI scale. Confirmed `Cargo.lock`'s `gpui`/`gpui-component` git pins didn't move (only a feature-list addition to the existing `windows-sys` entry).

**The new `display_containing` implementation itself is `#[cfg(target_os = "windows")]` and does not compile on this host at all — I cannot `cargo check`/test it here.** I wrote it against `windows-sys` 0.61's actual API signatures (verified in the crate's own source under `~/.cargo/registry`, not guessed) and matched the project's existing raw-pointer FFI conventions (`&raw mut`, `SAFETY` comments) as closely as possible, but this needs Windows CI or real hardware to confirm it actually compiles and behaves. Not runtime-tested against real hardware — that verification is the maintainer's/reporter's to do.

Related: #1210, fixed for Linux/Wayland in #1211.
