### PR TITLE
fix(macos): stabilize MX Ergo S and M575 connections and shortcuts

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -23,8 +23,10 @@ use tokio::sync::watch;
 
 /// Hardware identity of one HID++ capture session.
 ///
-/// Equality is the rearm contract: changing any field requires restoring the
-/// old firmware diversion before a replacement session may start.
+/// Equality is the rearm contract: changing any field requires the old session
+/// to finish teardown before a replacement may start. Failed restoration on
+/// another route stays parked until that route is used again; it must not
+/// disable capture on the device's newly active transport.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CaptureTarget {
     /// Physical identity used to serialize firmware ownership even when the

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -21,8 +21,9 @@
 //! way regardless.
 
 mod dispatch;
+mod restores;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -38,6 +39,7 @@ use tokio::time::Instant;
 use tracing::{debug, warn};
 
 use self::dispatch::InputDispatcher;
+use self::restores::{PendingRestore, RestoreQueue};
 use super::capture_session::{CaptureSession, CompletionAction, ReconcileAction};
 use crate::capture_plan::{CaptureTarget, DeviceCapturePlan, DispatchPlan, SharedCapturePlans};
 use crate::receiver_access::{ReceiverAccess, ReceiverRequestState, SessionReceiverLease};
@@ -139,14 +141,9 @@ enum SessionEvent {
     Done(SessionDone),
 }
 
-struct PendingRestore {
-    token: PendingCaptureRestore,
-    retry_at: Instant,
-}
-
 struct GestureManagerState {
     sessions: HashMap<PhysicalDeviceKey, RunningSession>,
-    pending_restores: HashMap<PhysicalDeviceKey, PendingRestore>,
+    pending_restores: RestoreQueue<PendingCaptureRestore>,
     restart_after: HashMap<PhysicalDeviceKey, Instant>,
     input_dispatcher: InputDispatcher,
     lease: std::sync::Weak<SessionReceiverLease>,
@@ -283,27 +280,22 @@ fn acquire_session_lease(
 }
 
 async fn retry_pending_restores(
-    pending_restores: &mut HashMap<PhysicalDeviceKey, PendingRestore>,
+    pending_restores: &mut RestoreQueue<PendingCaptureRestore>,
+    due: Vec<PendingRestore<PendingCaptureRestore>>,
     registry: &openlogi_hid::ChannelRegistry,
-    now: Instant,
+    device_io: &DeviceIoGate,
 ) {
-    let keys: Vec<_> = pending_restores
-        .iter()
-        .filter(|(_, pending)| pending.retry_at <= now)
-        .map(|(key, _)| key.clone())
-        .collect();
-    for key in keys {
-        let Some(pending) = pending_restores.remove(&key) else {
+    for pending in due {
+        if !device_io.allows_io() {
+            pending_restores.retain(pending);
             continue;
-        };
+        }
         if let CaptureSessionOutcome::RestorePending(token) = pending.token.retry(registry).await {
-            pending_restores.insert(
-                key,
-                PendingRestore {
-                    token,
-                    retry_at: Instant::now() + RETRY_DELAY,
-                },
-            );
+            pending_restores.retain(PendingRestore {
+                token,
+                retry_at: Instant::now() + RETRY_DELAY,
+                ..pending
+            });
         }
     }
 }
@@ -311,15 +303,14 @@ async fn retry_pending_restores(
 fn next_deadline(
     requests: ReceiverRequestState,
     device_io_allowed: bool,
-    pending_restores: &HashMap<PhysicalDeviceKey, PendingRestore>,
+    restore_deadline: Option<Instant>,
     restart_after: &HashMap<PhysicalDeviceKey, Instant>,
 ) -> Option<Instant> {
     if requests.any() || !device_io_allowed {
         return None;
     }
-    pending_restores
-        .values()
-        .map(|pending| pending.retry_at)
+    restore_deadline
+        .into_iter()
         .chain(restart_after.values().copied())
         .min()
 }
@@ -328,31 +319,50 @@ fn restart_deadline(unexpected: bool, now: Instant) -> Option<Instant> {
     unexpected.then_some(now + RETRY_DELAY)
 }
 
+fn retain_restart_delays(
+    restart_after: &mut HashMap<PhysicalDeviceKey, Instant>,
+    published: &[DeviceCapturePlan],
+    now: Instant,
+) {
+    // An elapsed startup delay no longer constrains capture. Keeping it while
+    // restoration is pending makes the manager's select deadline permanently
+    // ready, spinning instead of waiting for the next bounded restore retry.
+    restart_after.retain(|key, deadline| {
+        *deadline > now
+            && published
+                .iter()
+                .any(|plan| plan.target.physical_key == *key)
+    });
+}
+
 impl GestureManagerState {
     fn new(outputs: GestureOutputs) -> Self {
         Self {
             sessions: HashMap::new(),
-            pending_restores: HashMap::new(),
+            pending_restores: RestoreQueue::default(),
             restart_after: HashMap::new(),
             input_dispatcher: InputDispatcher::new(outputs),
             lease: std::sync::Weak::new(),
         }
     }
 
-    fn deadline(&self, requests: ReceiverRequestState, device_io_allowed: bool) -> Option<Instant> {
+    fn deadline(
+        &self,
+        requests: ReceiverRequestState,
+        device_io_allowed: bool,
+        published: &[DeviceCapturePlan],
+    ) -> Option<Instant> {
+        let busy = self.sessions.keys().cloned().collect();
         next_deadline(
             requests,
             device_io_allowed,
-            &self.pending_restores,
+            self.pending_restores.next_deadline(&busy, published),
             &self.restart_after,
         )
     }
 
     fn expedite_pending_restores(&mut self) {
-        let now = Instant::now();
-        for pending in self.pending_restores.values_mut() {
-            pending.retry_at = now;
-        }
+        self.pending_restores.expedite(Instant::now());
     }
 
     async fn reconcile(
@@ -383,30 +393,38 @@ impl GestureManagerState {
                 .map(|plan| (&plan.target, &plan.dispatch));
             reconcile_session(session, wanted, &mut self.input_dispatcher);
         }
-        self.restart_after.retain(|key, _| {
-            published
-                .iter()
-                .any(|plan| plan.target.physical_key == *key)
-        });
+        retain_restart_delays(&mut self.restart_after, published, now);
 
-        // Firmware ownership outlives the desired plan. Keep the strong lease
-        // through successor spawning so restore→rearm is uninterrupted.
+        // A restore owns route-local feature indices, not the device's other
+        // transports. Park old-route debts during a handoff, including while
+        // its successor drains; never write a stale undivert under live input.
+        // Keep the strong lease through restore→rearm on the same route.
+        let busy: HashSet<_> = self.sessions.keys().cloned().collect();
         let due_restore = self
             .pending_restores
-            .values()
-            .any(|pending| pending.retry_at <= now);
+            .next_deadline(&busy, published)
+            .is_some_and(|deadline| deadline <= now);
         let restore_lease = if due_restore {
             acquire_session_lease(receiver_access, &mut self.lease)
         } else {
             None
         };
         if restore_lease.is_some() {
-            retry_pending_restores(&mut self.pending_restores, &channels.registry, now).await;
+            let due = self.pending_restores.take_due(now, &busy, published);
+            retry_pending_restores(
+                &mut self.pending_restores,
+                due,
+                &channels.registry,
+                &channels.device_io,
+            )
+            .await;
         }
 
         for plan in wanted {
             let key = &plan.target.physical_key;
-            if self.sessions.contains_key(key) || self.pending_restores.contains_key(key) {
+            if self.sessions.contains_key(key)
+                || self.pending_restores.blocks(key, &plan.target.route)
+            {
                 continue;
             }
             if self
@@ -474,13 +492,12 @@ impl GestureManagerState {
                     return false;
                 };
                 if let Some(pending) = done.pending_restore {
-                    self.pending_restores.insert(
-                        key.clone(),
-                        PendingRestore {
-                            token: pending,
-                            retry_at: Instant::now() + RETRY_DELAY,
-                        },
-                    );
+                    self.pending_restores.retain(PendingRestore {
+                        key: key.clone(),
+                        route: pending.route().clone(),
+                        token: pending,
+                        retry_at: Instant::now() + RETRY_DELAY,
+                    });
                 }
                 self.input_dispatcher.cancel_session(&dispatch_session);
                 if device_io_allowed
@@ -549,7 +566,7 @@ async fn manage(
         }
 
         let requests = *receiver_requests.borrow();
-        let deadline = state.deadline(requests, device_io.allows_io());
+        let deadline = state.deadline(requests, device_io.allows_io(), &capture_plans.borrow());
         if deadline.is_some_and(|deadline| deadline <= Instant::now()) {
             reconcile = true;
             continue;

--- a/crates/openlogi-agent-core/src/watchers/gesture/restores.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/restores.rs
@@ -1,0 +1,94 @@
+//! Route-scoped teardown debts. The payload is opaque to the scheduler so its
+//! transitions can be tested without opening a device or synthesizing input.
+
+use std::collections::HashSet;
+
+use openlogi_core::device_order::PhysicalDeviceKey;
+use openlogi_hid::DeviceRoute;
+use tokio::time::Instant;
+
+use crate::capture_plan::DeviceCapturePlan;
+
+pub(super) struct PendingRestore<T> {
+    pub(super) key: PhysicalDeviceKey,
+    pub(super) route: DeviceRoute,
+    pub(super) token: T,
+    pub(super) retry_at: Instant,
+}
+
+pub(super) struct RestoreQueue<T> {
+    pending: Vec<PendingRestore<T>>,
+}
+
+impl<T> Default for RestoreQueue<T> {
+    fn default() -> Self {
+        Self {
+            pending: Vec::new(),
+        }
+    }
+}
+
+impl<T> RestoreQueue<T> {
+    pub(super) fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    pub(super) fn retain(&mut self, pending: PendingRestore<T>) {
+        self.pending.push(pending);
+    }
+
+    pub(super) fn blocks(&self, key: &PhysicalDeviceKey, route: &DeviceRoute) -> bool {
+        self.pending
+            .iter()
+            .any(|pending| pending.key == *key && pending.route == *route)
+    }
+
+    pub(super) fn expedite(&mut self, now: Instant) {
+        for pending in &mut self.pending {
+            pending.retry_at = now;
+        }
+    }
+
+    pub(super) fn next_deadline(
+        &self,
+        busy: &HashSet<PhysicalDeviceKey>,
+        published: &[DeviceCapturePlan],
+    ) -> Option<Instant> {
+        self.pending
+            .iter()
+            .filter(|pending| pending.eligible(busy, published))
+            .map(|pending| pending.retry_at)
+            .min()
+    }
+
+    pub(super) fn take_due(
+        &mut self,
+        now: Instant,
+        busy: &HashSet<PhysicalDeviceKey>,
+        published: &[DeviceCapturePlan],
+    ) -> Vec<PendingRestore<T>> {
+        self.pending
+            .extract_if(.., |pending| {
+                pending.retry_at <= now && pending.eligible(busy, published)
+            })
+            .collect()
+    }
+}
+
+impl<T> PendingRestore<T> {
+    fn eligible(&self, busy: &HashSet<PhysicalDeviceKey>, published: &[DeviceCapturePlan]) -> bool {
+        if busy.contains(&self.key) {
+            return false;
+        }
+        // Never clear diversion underneath another live route of this device,
+        // nor restore stale state into a route now occupied by another device.
+        !published.iter().any(|plan| {
+            let target = &plan.target;
+            (target.physical_key == self.key && target.route != self.route)
+                || (target.route == self.route && target.physical_key != self.key)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-agent-core/src/watchers/gesture/restores/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/restores/tests.rs
@@ -1,0 +1,164 @@
+use super::*;
+use crate::capture_plan::plan_for_device;
+use openlogi_core::config::Config;
+use std::time::Duration;
+
+fn key(unit: &str) -> PhysicalDeviceKey {
+    PhysicalDeviceKey::parse(unit).expect("nonzero unit identity")
+}
+
+fn bluetooth() -> DeviceRoute {
+    DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xb027,
+    }
+}
+
+fn receiver() -> DeviceRoute {
+    DeviceRoute::Unifying {
+        receiver_uid: "receiver-a".into(),
+        slot: 3,
+    }
+}
+
+fn plan(key: &PhysicalDeviceKey, route: DeviceRoute) -> DeviceCapturePlan {
+    plan_for_device(
+        &Config::default(),
+        key.clone(),
+        key.as_str(),
+        route,
+        None,
+        0,
+        true,
+    )
+}
+
+fn debt(key: &PhysicalDeviceKey, route: DeviceRoute, token: u8) -> PendingRestore<u8> {
+    PendingRestore {
+        key: key.clone(),
+        route,
+        token,
+        retry_at: Instant::now(),
+    }
+}
+
+#[test]
+fn transport_switch_parks_old_cleanup_and_restores_it_before_return() {
+    let bolt = DeviceRoute::Bolt {
+        receiver_uid: "bolt-receiver".into(),
+        slot: 2,
+    };
+    for (old, new) in [
+        (bluetooth(), receiver()),
+        (receiver(), bluetooth()),
+        (bluetooth(), bolt.clone()),
+        (bolt, bluetooth()),
+    ] {
+        let mouse = key("unit:2916dbbe");
+        let mut queue = RestoreQueue::default();
+        queue.retain(debt(&mouse, old.clone(), 7));
+        let published = vec![plan(&mouse, new.clone())];
+        let idle = HashSet::new();
+
+        assert!(
+            !queue.blocks(&mouse, &new),
+            "an unavailable old transport must not disable capture on the new one"
+        );
+        assert!(queue.take_due(Instant::now(), &idle, &published).is_empty());
+        assert_eq!(queue.next_deadline(&idle, &published), None);
+        assert!(!queue.is_empty(), "the old teardown debt must not be lost");
+
+        let returning = vec![plan(&mouse, old.clone())];
+        assert!(queue.blocks(&mouse, &old));
+        let pending = queue.take_due(Instant::now(), &idle, &returning);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].token, 7);
+        assert_eq!(pending[0].route, old);
+        assert!(queue.is_empty());
+    }
+}
+
+#[test]
+fn active_or_draining_successor_excludes_cleanup_even_after_plan_removal() {
+    let mouse = key("unit:2916dbbe");
+    let mut queue = RestoreQueue::default();
+    queue.retain(debt(&mouse, bluetooth(), 1));
+    let busy = HashSet::from([mouse.clone()]);
+    queue.expedite(Instant::now());
+
+    assert!(queue.take_due(Instant::now(), &busy, &[]).is_empty());
+    assert_eq!(queue.next_deadline(&busy, &[]), None);
+    assert!(!queue.is_empty());
+
+    // Only ordered session completion releases the physical-device exclusion.
+    let pending = queue.take_due(Instant::now(), &HashSet::new(), &[]);
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].token, 1);
+}
+
+#[test]
+fn failed_cleanup_keeps_each_routes_token_and_retry_deadline() {
+    let mouse = key("unit:2916dbbe");
+    let mut queue = RestoreQueue::default();
+    queue.retain(debt(&mouse, bluetooth(), 1));
+    queue.retain(debt(&mouse, receiver(), 2));
+    let published = vec![plan(&mouse, receiver())];
+    let idle = HashSet::new();
+    let now = Instant::now();
+
+    let mut due = queue.take_due(now, &idle, &published);
+    assert_eq!(due.len(), 1);
+    let mut failed = due.pop().expect("receiver restore should be due");
+    assert_eq!(failed.token, 2);
+    failed.retry_at = now + Duration::from_secs(1);
+    queue.retain(failed);
+
+    assert!(queue.blocks(&mouse, &receiver()));
+    assert!(queue.blocks(&mouse, &bluetooth()));
+    assert!(queue.take_due(now, &idle, &published).is_empty());
+    assert_eq!(
+        queue.next_deadline(&idle, &published),
+        Some(now + Duration::from_secs(1))
+    );
+    let restored = queue.take_due(now + Duration::from_secs(1), &idle, &published);
+    assert_eq!(restored[0].token, 2);
+    assert!(!queue.blocks(&mouse, &receiver()));
+
+    let returned = vec![plan(&mouse, bluetooth())];
+    assert_eq!(queue.take_due(now, &idle, &returned)[0].token, 1);
+}
+
+#[test]
+fn receiver_route_reassigned_to_another_mouse_must_not_receive_stale_cleanup() {
+    let first = key("unit:2916dbbe");
+    let second = key("unit:2916dbbf");
+    let mut queue = RestoreQueue::default();
+    queue.retain(debt(&first, receiver(), 1));
+    let published = vec![plan(&second, receiver())];
+
+    assert!(!queue.blocks(&second, &receiver()));
+    assert!(
+        queue
+            .take_due(Instant::now(), &HashSet::new(), &published)
+            .is_empty()
+    );
+    assert_eq!(queue.next_deadline(&HashSet::new(), &published), None);
+    assert!(!queue.is_empty());
+}
+
+#[test]
+fn another_mouse_does_not_block_due_cleanup() {
+    let first = key("unit:2916dbbe");
+    let second = key("unit:2916dbbf");
+    let mut queue = RestoreQueue::default();
+    queue.retain(debt(&first, receiver(), 1));
+    let published = vec![plan(&first, receiver()), plan(&second, bluetooth())];
+    let busy = HashSet::from([second]);
+
+    assert!(queue.next_deadline(&busy, &published).is_some());
+    assert_eq!(
+        queue.take_due(Instant::now(), &busy, &published)[0].token,
+        1
+    );
+    assert!(queue.is_empty());
+}

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -104,24 +104,54 @@ fn suspended_device_io_disables_retry_deadlines() {
     let restart_after = HashMap::from([(physical_key(), retry_at)]);
 
     assert_eq!(
-        next_deadline(
-            ReceiverRequestState::default(),
-            true,
-            &HashMap::new(),
-            &restart_after,
-        ),
+        next_deadline(ReceiverRequestState::default(), true, None, &restart_after,),
         Some(retry_at),
     );
     assert_eq!(
-        next_deadline(
-            ReceiverRequestState::default(),
-            false,
-            &HashMap::new(),
-            &restart_after,
-        ),
+        next_deadline(ReceiverRequestState::default(), false, None, &restart_after,),
         None,
         "capture retries must stay dormant until visible resume",
     );
+}
+
+#[test]
+fn elapsed_restart_delay_does_not_spin_while_native_restore_is_pending() {
+    let now = Instant::now();
+    let plan = plan();
+    let mut restart_after = HashMap::from([(physical_key(), now)]);
+    let restore_at = now + RETRY_DELAY;
+
+    retain_restart_delays(&mut restart_after, &[plan], now);
+
+    assert_eq!(
+        next_deadline(
+            ReceiverRequestState::default(),
+            true,
+            Some(restore_at),
+            &restart_after,
+        ),
+        Some(restore_at),
+        "only the paced restore retry should wake the manager"
+    );
+    assert_eq!(
+        next_deadline(ReceiverRequestState::default(), true, None, &restart_after),
+        None,
+        "a parked transport must not leave a permanently ready deadline"
+    );
+}
+
+#[test]
+fn restart_delay_remains_until_due_but_is_removed_with_its_plan() {
+    let now = Instant::now();
+    let plan = plan();
+    let mut restart_after = HashMap::from([(physical_key(), now + RETRY_DELAY)]);
+    retain_restart_delays(&mut restart_after, &[plan], now);
+    assert_eq!(
+        restart_after.get(&physical_key()),
+        Some(&(now + RETRY_DELAY))
+    );
+    retain_restart_delays(&mut restart_after, &[], now);
+    assert!(restart_after.is_empty());
 }
 
 #[tokio::test]

--- a/crates/openlogi-agent/src/autostart/macos.rs
+++ b/crates/openlogi-agent/src/autostart/macos.rs
@@ -11,8 +11,9 @@
 //! job loaded from one of those files keeps serving the current session
 //! (killing a live agent for a file migration helps nobody) and disappears at
 //! the next login, when its plist is no longer there to load; if the GUI has
-//! registered the service meanwhile, the freshly started duplicate loses the
-//! singleton lock and exits cleanly.
+//! registered the service meanwhile, the supervised successor waits behind the
+//! singleton lock and takes over after an abnormal exit. Explicit Quit leaves
+//! a one-shot marker so the successor stays stopped too (`launchd_handoff`).
 
 use std::io;
 use std::path::PathBuf;

--- a/crates/openlogi-agent/src/launchd_handoff.rs
+++ b/crates/openlogi-agent/src/launchd_handoff.rs
@@ -1,0 +1,134 @@
+//! Singleton handoff for supervised macOS Agent starts.
+//!
+//! Registration belongs to the GUI's SMAppService integration. A supervised
+//! successor may still race a manually started or legacy Agent during an
+//! update; it waits for the singleton without creating a second input hook.
+//! Explicit Quit and stale-marker handling retain the previous recovery contract.
+
+use std::io;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+
+const LAUNCHD_ARGUMENT: &str = "--launchd";
+const CLEAN_EXIT_MARKER: &str = "launchd-clean-exit";
+const LOCK_RETRY_DELAY: Duration = Duration::from_millis(200);
+
+/// Whether this process was started from the generated LaunchAgent.
+pub fn started_by_launchd() -> bool {
+    std::env::args_os()
+        .skip(1)
+        .any(|argument| argument == LAUNCHD_ARGUMENT)
+}
+
+/// Wait for a manually-started predecessor to release the agent lock.
+///
+/// launchd starts the registered job immediately. Parking that copy behind the
+/// existing agent transfers ownership without running two hooks. An abnormal
+/// predecessor exit lets this copy continue; an explicit Quit writes a
+/// one-shot marker and this copy exits successfully, preserving Quit semantics.
+pub fn wait_for_predecessor(
+    lock_path: &std::path::Path,
+) -> Option<openlogi_core::single_instance::InstanceGuard> {
+    use openlogi_core::single_instance::{self, InstanceError};
+
+    info!(path = %lock_path.display(), "launchd agent waiting to take ownership from the running agent");
+    loop {
+        match single_instance::acquire("agent.lock") {
+            Ok(guard) => {
+                if consume_clean_exit_marker() {
+                    info!(
+                        "running agent exited by user request — launchd successor staying stopped"
+                    );
+                    return None;
+                }
+                info!("launchd agent took ownership after predecessor exit");
+                return Some(guard);
+            }
+            Err(InstanceError::AlreadyRunning { .. }) => {
+                std::thread::sleep(LOCK_RETRY_DELAY);
+            }
+            Err(error) => {
+                warn!(%error, "launchd agent could not acquire the singleton lock");
+                return None;
+            }
+        }
+    }
+}
+
+/// Preserve the user-visible contract that menu-bar Quit stops the agent.
+pub fn mark_user_quit() {
+    let path = clean_exit_marker_path();
+    let result = path.and_then(|path| {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, std::process::id().to_string())
+    });
+    if let Err(error) = result {
+        warn!(%error, "could not mark the explicit agent Quit for launchd");
+    }
+}
+
+/// Remove a marker left by an earlier launchd-owned process that exited via
+/// menu-bar Quit. A newly acquired singleton lock starts a new explicit run;
+/// the old marker must not suppress its future crash handoff.
+pub fn clear_stale_clean_exit_marker() {
+    let Ok(path) = clean_exit_marker_path() else {
+        return;
+    };
+    match std::fs::remove_file(path) {
+        Ok(()) => debug!("cleared stale explicit agent Quit marker"),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => warn!(%error, "could not clear stale explicit agent Quit marker"),
+    }
+}
+
+fn consume_clean_exit_marker() -> bool {
+    let Ok(path) = clean_exit_marker_path() else {
+        return false;
+    };
+    consume_marker_at(&path)
+}
+
+fn consume_marker_at(path: &std::path::Path) -> bool {
+    match std::fs::remove_file(path) {
+        Ok(()) => true,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        Err(error) => {
+            warn!(%error, "could not consume the explicit agent Quit marker");
+            false
+        }
+    }
+}
+
+fn clean_exit_marker_path() -> io::Result<PathBuf> {
+    openlogi_core::paths::config_dir()
+        .map(|directory| directory.join(CLEAN_EXIT_MARKER))
+        .map_err(io::Error::other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::consume_marker_at;
+
+    #[test]
+    fn explicit_quit_marker_stops_only_one_successor() {
+        let directory = tempfile::tempdir().expect("temporary marker directory");
+        let marker = directory.path().join("launchd-clean-exit");
+        std::fs::write(&marker, "123").expect("write explicit Quit marker");
+
+        assert!(consume_marker_at(&marker));
+        assert!(!consume_marker_at(&marker));
+        assert!(!marker.exists());
+    }
+
+    #[test]
+    fn abnormal_exit_without_a_marker_allows_handoff() {
+        let directory = tempfile::tempdir().expect("temporary marker directory");
+        assert!(!consume_marker_at(
+            &directory.path().join("launchd-clean-exit")
+        ));
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -1,8 +1,8 @@
 //! OpenLogi background agent — headless, always-on.
 //!
 //! Owns the CGEventTap hook and the HID++ device path (gesture capture, DPI,
-//! SmartShift), serves the GUI over a Unix-socket tarpc IPC, reconciles its own
-//! launchd autostart, and (macOS) hosts the menu-bar status item. The async
+//! SmartShift), serves the GUI over a Unix-socket tarpc IPC, reconciles platform
+//! autostart migration, and (macOS) hosts the menu-bar status item. The async
 //! core walks the state machine in `lifecycle` on a tokio runtime; on macOS
 //! the process main thread hosts the AppKit run loop the menu bar requires.
 
@@ -17,6 +17,8 @@
 
 mod autostart;
 mod binary_watch;
+#[cfg(target_os = "macos")]
+mod launchd_handoff;
 mod lifecycle;
 mod logging;
 mod overlay;
@@ -52,26 +54,11 @@ fn main() {
     // racing the GUI's one-shot auto-spawn could otherwise bring up two, and the
     // loser would steal the socket and install a duplicate event tap. Held for
     // the whole process; the OS releases it on exit (crash-recovery is free).
-    let _guard = match openlogi_core::single_instance::acquire("agent.lock") {
-        Ok(g) => g,
-        Err(openlogi_core::single_instance::InstanceError::AlreadyRunning { path }) => {
-            // The holder may be a leftover from before this binary's update —
-            // a pre-self-restart agent never exits on its own, and it would
-            // wedge the (newer) GUI on its connecting screen forever. If it
-            // provably speaks an older protocol, replace it; otherwise exit
-            // as the duplicate we are.
-            let Some(g) = takeover::try_replace_stale() else {
-                info!(path = %path.display(), "another openlogi-agent is already running — exiting");
-                return;
-            };
-            info!("replaced a stale agent — continuing as the new one");
-            g
-        }
-        Err(e) => {
-            warn!(error = %e, "single-instance check failed — exiting");
-            return;
-        }
+    let Some(_guard) = acquire_agent_lock() else {
+        return;
     };
+    #[cfg(target_os = "macos")]
+    launchd_handoff::clear_stale_clean_exit_marker();
 
     // Watch our own executable and restart as the new image when an app update
     // replaces it — see `binary_watch`. Only the lock-holding (real) agent
@@ -153,6 +140,35 @@ fn main() {
         drop(device_io_signal);
         runtime.block_on(lifecycle::run(config, uninstalled));
     }
+}
+
+/// Acquire the process-wide agent lock, including the macOS launchd handoff.
+fn acquire_agent_lock() -> Option<openlogi_core::single_instance::InstanceGuard> {
+    let guard = match openlogi_core::single_instance::acquire("agent.lock") {
+        Ok(g) => g,
+        Err(openlogi_core::single_instance::InstanceError::AlreadyRunning { path }) => {
+            // The holder may be a leftover from before this binary's update —
+            // a pre-self-restart agent never exits on its own, and it would
+            // wedge the (newer) GUI on its connecting screen forever. If it
+            // provably speaks an older protocol, replace it before waiting
+            // for a supervised handoff that could otherwise never happen.
+            if let Some(guard) = takeover::try_replace_stale() {
+                info!("replaced a stale agent — continuing as the new one");
+                return Some(guard);
+            }
+            #[cfg(target_os = "macos")]
+            if launchd_handoff::started_by_launchd() {
+                return launchd_handoff::wait_for_predecessor(&path);
+            }
+            info!(path = %path.display(), "another openlogi-agent is already running — exiting");
+            return None;
+        }
+        Err(e) => {
+            warn!(error = %e, "single-instance check failed — exiting");
+            return None;
+        }
+    };
+    Some(guard)
 }
 
 #[cfg(test)]

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -19,22 +19,20 @@
 )]
 
 use std::cell::RefCell;
-use std::sync::{Mutex, PoisonError};
+use std::sync::{Arc, Mutex, PoisonError};
 
-use dispatch2::DispatchQueue;
+use dispatch2::{DispatchQueue, DispatchTime};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject};
 use objc2::{
     AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel,
 };
 use objc2_app_kit::NSStatusItem;
-#[cfg(test)]
-use objc2_app_kit::NSWorkspaceDidWakeNotification;
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSImage, NSRunningApplication, NSWorkspace,
-    NSWorkspaceScreensDidSleepNotification, NSWorkspaceScreensDidWakeNotification,
-    NSWorkspaceSessionDidBecomeActiveNotification, NSWorkspaceSessionDidResignActiveNotification,
-    NSWorkspaceWillSleepNotification,
+    NSWorkspaceDidWakeNotification, NSWorkspaceScreensDidSleepNotification,
+    NSWorkspaceScreensDidWakeNotification, NSWorkspaceSessionDidBecomeActiveNotification,
+    NSWorkspaceSessionDidResignActiveNotification, NSWorkspaceWillSleepNotification,
 };
 use objc2_core_graphics::{CGDisplayIsAsleep, CGMainDisplayID};
 use objc2_foundation::{NSNotification, NSString};
@@ -111,14 +109,26 @@ pub fn relocalize() {
 }
 
 struct ActivityTargetIvars {
+    activity: Arc<ActivityGate>,
+}
+
+struct ActivityGate {
     signal: DeviceIoSignal,
-    suspended_by: Mutex<u8>,
+    state: Mutex<ActivityState>,
+}
+
+struct ActivityState {
+    suspended_by: u8,
+    display_probe: Option<u8>,
 }
 
 const SYSTEM_SLEEP: u8 = 1 << 0;
 const SCREEN_SLEEP: u8 = 1 << 1;
 const SESSION_INACTIVE: u8 = 1 << 2;
 const STARTUP: u8 = 1 << 3;
+const WAKE_VALIDATION: u8 = 1 << 4;
+const DISPLAY_PROBE_DELAY_NANOS: i64 = 750_000_000;
+const REQUIRED_VISIBLE_DISPLAY_SAMPLES: u8 = 2;
 
 define_class!(
     // SAFETY: NSObject has no subclassing requirements, and `ActivityTarget`
@@ -131,27 +141,34 @@ define_class!(
     impl ActivityTarget {
         #[unsafe(method(workspaceWillSleep:))]
         fn workspace_will_sleep(&self, _notification: &NSNotification) {
-            self.suspend_from(SYSTEM_SLEEP);
+            self.ivars().activity.suspend_from(SYSTEM_SLEEP);
         }
 
         #[unsafe(method(workspaceScreensDidSleep:))]
         fn workspace_screens_did_sleep(&self, _notification: &NSNotification) {
-            self.suspend_from(SCREEN_SLEEP);
+            self.ivars().activity.suspend_from(SCREEN_SLEEP);
         }
 
         #[unsafe(method(workspaceSessionDidResignActive:))]
         fn workspace_session_did_resign_active(&self, _notification: &NSNotification) {
-            self.suspend_from(SESSION_INACTIVE);
+            self.ivars().activity.suspend_from(SESSION_INACTIVE);
+        }
+
+        #[unsafe(method(workspaceDidWake:))]
+        fn workspace_did_wake(&self, _notification: &NSNotification) {
+            self.ivars().activity.request_display_reconciliation();
         }
 
         #[unsafe(method(workspaceScreensDidWake:))]
         fn workspace_screens_did_wake(&self, _notification: &NSNotification) {
-            self.resume_from(SYSTEM_SLEEP | SCREEN_SLEEP);
+            self.ivars().activity.confirm_visible_display();
         }
 
         #[unsafe(method(workspaceSessionDidBecomeActive:))]
         fn workspace_session_did_become_active(&self, _notification: &NSNotification) {
-            self.resume_from(SYSTEM_SLEEP | SESSION_INACTIVE);
+            self.ivars()
+                .activity
+                .resume_from(SYSTEM_SLEEP | SESSION_INACTIVE);
         }
     }
 );
@@ -163,30 +180,26 @@ impl ActivityTarget {
         // in tests and any future caller cannot accidentally start open.
         let _ = signal.suspend();
         let this = Self::alloc().set_ivars(ActivityTargetIvars {
-            signal,
-            suspended_by: Mutex::new(STARTUP),
+            activity: Arc::new(ActivityGate {
+                signal,
+                state: Mutex::new(ActivityState {
+                    suspended_by: STARTUP,
+                    display_probe: None,
+                }),
+            }),
         });
         // SAFETY: `init` initializes our freshly allocated NSObject subclass.
         unsafe { msg_send![super(this), init] }
     }
+}
 
-    fn finish_startup(&self, display_asleep: bool) {
-        if display_asleep {
-            self.suspend_from(SCREEN_SLEEP);
-        }
-        self.resume_from(STARTUP);
-    }
-
+impl ActivityGate {
     fn suspend_from(&self, source: u8) {
         let changed = {
-            let mut suspended_by = self
-                .ivars()
-                .suspended_by
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let was_allowed = *suspended_by == 0;
-            *suspended_by |= source;
-            was_allowed && self.ivars().signal.suspend()
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            let was_allowed = state.suspended_by == 0;
+            state.suspended_by |= source;
+            was_allowed && self.signal.suspend()
         };
         if changed {
             info!("display/session suspended — pausing device I/O");
@@ -195,17 +208,106 @@ impl ActivityTarget {
 
     fn resume_from(&self, sources: u8) {
         let changed = {
-            let mut suspended_by = self
-                .ivars()
-                .suspended_by
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let was_suspended = *suspended_by != 0;
-            *suspended_by &= !sources;
-            was_suspended && *suspended_by == 0 && self.ivars().signal.resume()
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            let was_suspended = state.suspended_by != 0;
+            state.suspended_by &= !sources;
+            was_suspended && state.suspended_by == 0 && self.signal.resume()
         };
         if changed {
             info!("display/session resumed — enabling device I/O");
+        }
+    }
+
+    /// Validate a generic system wake before touching HID. macOS sends
+    /// `NSWorkspaceDidWakeNotification` for maintenance DarkWake as well as a
+    /// real user wake, so one notification cannot safely reopen the gate.
+    fn request_display_reconciliation(self: &Arc<Self>) {
+        if self.begin_display_probe() {
+            self.schedule_display_probe();
+        }
+    }
+
+    fn begin_display_probe(&self) -> bool {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        if state.display_probe.is_some() {
+            return false;
+        }
+
+        let was_allowed = state.suspended_by == 0;
+        state.suspended_by |= WAKE_VALIDATION;
+        state.display_probe = Some(0);
+        if was_allowed && self.signal.suspend() {
+            info!("system wake pending display confirmation — pausing device I/O");
+        }
+        true
+    }
+
+    fn schedule_display_probe(self: &Arc<Self>) {
+        let activity = Arc::clone(self);
+        let when = DispatchTime::NOW.time(DISPLAY_PROBE_DELAY_NANOS);
+        let _ = DispatchQueue::main().after(when, move || activity.run_display_probe());
+    }
+
+    fn run_display_probe(self: Arc<Self>) {
+        let display_asleep = CGDisplayIsAsleep(CGMainDisplayID());
+        if self.observe_display_sample(display_asleep) {
+            self.schedule_display_probe();
+        }
+    }
+
+    /// Apply one CoreGraphics display-state sample. Two separated visible
+    /// samples are required because the first value can still describe the
+    /// pre-transition state while macOS enters or leaves DarkWake.
+    fn observe_display_sample(&self, display_asleep: bool) -> bool {
+        let (changed, sample_again) = {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            let Some(visible_samples) = state.display_probe.as_mut() else {
+                return false;
+            };
+
+            if display_asleep {
+                let was_allowed = state.suspended_by == 0;
+                state.suspended_by |= SCREEN_SLEEP;
+                state.suspended_by &= !(STARTUP | WAKE_VALIDATION);
+                state.display_probe = None;
+                (was_allowed && self.signal.suspend(), false)
+            } else {
+                *visible_samples = visible_samples.saturating_add(1);
+                if *visible_samples < REQUIRED_VISIBLE_DISPLAY_SAMPLES {
+                    (false, true)
+                } else {
+                    let was_suspended = state.suspended_by != 0;
+                    state.suspended_by &=
+                        !(STARTUP | SYSTEM_SLEEP | SCREEN_SLEEP | WAKE_VALIDATION);
+                    state.display_probe = None;
+                    (
+                        was_suspended && state.suspended_by == 0 && self.signal.resume(),
+                        false,
+                    )
+                }
+            }
+        };
+
+        if changed {
+            if display_asleep {
+                info!("display reconciliation confirmed sleep — pausing device I/O");
+            } else {
+                info!("display reconciliation confirmed wake — enabling device I/O");
+            }
+        }
+        sample_again
+    }
+
+    fn confirm_visible_display(&self) {
+        let changed = {
+            let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+            state.display_probe = None;
+            let was_suspended = state.suspended_by != 0;
+            state.suspended_by &= !(STARTUP | SYSTEM_SLEEP | SCREEN_SLEEP | WAKE_VALIDATION);
+            was_suspended && state.suspended_by == 0 && self.signal.resume()
+        };
+        if changed {
+            info!("visible display wake confirmed — enabling device I/O");
         }
     }
 }
@@ -285,6 +387,7 @@ fn quit_agent() -> ! {
             .output();
     }
     crate::overlay::evict_on_quit();
+    crate::launchd_handoff::mark_user_quit();
     info!("menu-bar Quit — exiting agent");
     #[expect(
         clippy::exit,
@@ -343,9 +446,14 @@ pub fn run_app_loop(
     // `NSWorkspaceSessionDidResignActiveNotification` between its will- and
     // did-finish-launching notifications. Finish that lifecycle while STARTUP
     // still holds the hardware gate closed, then snapshot display sleep before
-    // permitting the core's initial inventory scan.
+    // permitting the core's initial inventory scan. The delayed two-sample
+    // reconciliation avoids trusting CoreGraphics while a DarkWake transition
+    // is still settling.
     app.finishLaunching();
-    activity_target.finish_startup(CGDisplayIsAsleep(CGMainDisplayID()));
+    activity_target
+        .ivars()
+        .activity
+        .request_display_reconciliation();
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
@@ -357,9 +465,10 @@ pub fn run_app_loop(
 }
 
 /// Observe display/session sleep and user-visible resume transitions. Generic
-/// `NSWorkspaceDidWakeNotification` is deliberately not registered: macOS
-/// emits it for maintenance DarkWake, where opening BLE HID is exactly what can
-/// promote an otherwise invisible wake into a full display wake (#656).
+/// `NSWorkspaceDidWakeNotification` is a fallback for macOS occasionally
+/// dropping `NSWorkspaceScreensDidWakeNotification`; it only starts a delayed
+/// CoreGraphics confirmation and therefore does not open HID during maintenance
+/// DarkWake (#656).
 fn install_activity_observer(signal: DeviceIoSignal) -> Retained<ActivityTarget> {
     let target = ActivityTarget::new(signal);
     let workspace = NSWorkspace::sharedWorkspace();
@@ -370,6 +479,8 @@ fn install_activity_observer(signal: DeviceIoSignal) -> Retained<ActivityTarget>
     let screen_sleep = unsafe { NSWorkspaceScreensDidSleepNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let session_inactive = unsafe { NSWorkspaceSessionDidResignActiveNotification };
+    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+    let system_wake = unsafe { NSWorkspaceDidWakeNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
@@ -393,6 +504,12 @@ fn install_activity_observer(signal: DeviceIoSignal) -> Retained<ActivityTarget>
             &target,
             sel!(workspaceSessionDidResignActive:),
             Some(session_inactive),
+            Some(&workspace),
+        );
+        center.addObserver_selector_name_object(
+            &target,
+            sel!(workspaceDidWake:),
+            Some(system_wake),
             Some(&workspace),
         );
         center.addObserver_selector_name_object(
@@ -507,12 +624,22 @@ mod tests {
     // so one test's session-inactive event cannot suspend the other test's gate.
     static WORKSPACE_NOTIFICATIONS: Mutex<()> = Mutex::new(());
 
+    fn finish_visible_startup(target: &ActivityTarget) {
+        let activity = &target.ivars().activity;
+        assert!(activity.begin_display_probe());
+        assert!(
+            activity.observe_display_sample(false),
+            "the first visible sample must keep the startup gate closed",
+        );
+        assert!(!activity.observe_display_sample(false));
+    }
+
     #[test]
     fn overlapping_suspend_sources_all_clear_before_device_io_resumes() {
         let _notifications = WORKSPACE_NOTIFICATIONS.lock().unwrap();
         let (signal, gate) = device_io_channel();
         let target = install_activity_observer(signal);
-        target.finish_startup(false);
+        finish_visible_startup(&target);
         let workspace = NSWorkspace::sharedWorkspace();
         let center = workspace.notificationCenter();
 
@@ -533,8 +660,8 @@ mod tests {
         unsafe { center.postNotificationName_object(session_inactive, Some(&workspace)) };
         assert!(!gate.allows_io());
 
-        // `DidWake` is a maintenance/system wake and intentionally has no
-        // observer, so posting it must leave the gate closed.
+        // Generic `DidWake` may describe DarkWake. Its observer must keep the
+        // gate closed until the display probe confirms a visible wake.
         // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
         let darkwake = unsafe { NSWorkspaceDidWakeNotification };
         // SAFETY: `workspace` is live and notification delivery is synchronous.
@@ -569,7 +696,9 @@ mod tests {
         let target = install_activity_observer(signal);
         assert!(!gate.allows_io(), "startup must fail closed");
 
-        target.finish_startup(true);
+        let activity = &target.ivars().activity;
+        assert!(activity.begin_display_probe());
+        assert!(!activity.observe_display_sample(true));
         assert!(
             !gate.allows_io(),
             "an initially sleeping display must retain the suspension",
@@ -586,5 +715,56 @@ mod tests {
 
         // SAFETY: This is the same live target registered with `center` above.
         unsafe { center.removeObserver(&target) };
+    }
+
+    #[test]
+    fn startup_requires_two_visible_samples_before_device_io_begins() {
+        let (signal, gate) = device_io_channel();
+        let target = ActivityTarget::new(signal);
+        let activity = &target.ivars().activity;
+
+        assert!(activity.begin_display_probe());
+        assert!(activity.observe_display_sample(false));
+        assert!(
+            !gate.allows_io(),
+            "one transition-time sample must not open HID during DarkWake",
+        );
+        assert!(!activity.observe_display_sample(false));
+        assert!(gate.allows_io());
+    }
+
+    #[test]
+    fn delayed_display_probe_recovers_a_missed_screen_wake() {
+        let (signal, gate) = device_io_channel();
+        let target = ActivityTarget::new(signal);
+        finish_visible_startup(&target);
+        let activity = &target.ivars().activity;
+
+        activity.suspend_from(SYSTEM_SLEEP | SCREEN_SLEEP);
+        assert!(!gate.allows_io());
+        assert!(activity.begin_display_probe());
+        assert!(activity.observe_display_sample(false));
+        assert!(!gate.allows_io());
+        assert!(!activity.observe_display_sample(false));
+        assert!(
+            gate.allows_io(),
+            "a confirmed visible wake must recover even without ScreensDidWake",
+        );
+    }
+
+    #[test]
+    fn darkwake_probe_keeps_device_io_suspended() {
+        let (signal, gate) = device_io_channel();
+        let target = ActivityTarget::new(signal);
+        finish_visible_startup(&target);
+        let activity = &target.ivars().activity;
+
+        activity.suspend_from(SYSTEM_SLEEP | SCREEN_SLEEP);
+        assert!(activity.begin_display_probe());
+        assert!(!activity.observe_display_sample(true));
+        assert!(
+            !gate.allows_io(),
+            "an asleep display must never reopen HID during DarkWake",
+        );
     }
 }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -149,6 +149,97 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Import physical keys and route aliases written by pre-release custom
+    /// builds that used `device:<identity>` plus a top-level
+    /// `device_aliases` table.
+    ///
+    /// Only explicit alias evidence is converted into [`DeviceConfig::links`].
+    /// An alias whose target has no persisted device entry is deliberately
+    /// ignored: guessing its owner from a model name could merge two physical
+    /// mice of the same model. The caller keeps the original source as a
+    /// migration backup before the normalized config is saved.
+    #[cfg(feature = "fs")]
+    pub(crate) fn migrate_legacy_device_keys(
+        &mut self,
+        legacy_aliases: BTreeMap<String, String>,
+    ) -> bool {
+        fn normalized_identity_key(key: &str) -> Option<String> {
+            let identity = key.strip_prefix("device:")?;
+            PhysicalDeviceKey::parse(identity).map(|_| identity.to_string())
+        }
+
+        fn normalized_route_key(key: &str) -> Option<String> {
+            if let Some(rest) = key.strip_prefix("direct:") {
+                let mut parts = rest.splitn(3, ':');
+                let vendor = parts.next()?;
+                let product = parts.next()?;
+                let identity = parts.next()?;
+                PhysicalDeviceKey::parse(identity)?;
+                return Some(format!("direct:{vendor}:{product}"));
+            }
+            key.starts_with("receiver:").then(|| key.to_string())
+        }
+
+        let mut changed = false;
+        let old_keys = self.devices.keys().cloned().collect::<Vec<_>>();
+        for old in old_keys {
+            let Some(new) = normalized_identity_key(&old) else {
+                continue;
+            };
+            let Some(legacy) = self.devices.remove(&old) else {
+                continue;
+            };
+            if let Some(existing) = self.devices.get_mut(&new) {
+                // A mixed custom/current file can contain both spellings.
+                // Preserve any disagreement on the historical key instead of
+                // overwriting either side silently.
+                identity::fold(existing, legacy, &old);
+            } else {
+                self.devices.insert(new, legacy);
+            }
+            changed = true;
+        }
+
+        if let Some(new) = self
+            .selected_device
+            .as_deref()
+            .and_then(normalized_identity_key)
+        {
+            self.selected_device = Some(new);
+            changed = true;
+        }
+        for device in self.devices.values_mut() {
+            for target in &mut device.host_switch_targets {
+                if let Some(new) = normalized_identity_key(target) {
+                    *target = new;
+                    changed = true;
+                }
+            }
+            device.host_switch_targets.sort();
+            device.host_switch_targets.dedup();
+        }
+
+        for (alias, target) in legacy_aliases {
+            let target = normalized_identity_key(&target).unwrap_or(target);
+            let Some(canonical) = PhysicalDeviceKey::parse(&target) else {
+                continue;
+            };
+            if !self.devices.contains_key(canonical.as_str()) {
+                tracing::warn!(
+                    %alias,
+                    target = %canonical.as_str(),
+                    "legacy device alias has no persisted target; leaving it unmerged"
+                );
+                continue;
+            }
+            let Some(route) = normalized_route_key(&alias) else {
+                continue;
+            };
+            changed |= self.adopt_route(&canonical, &route, None);
+        }
+        changed
+    }
+
     /// A config that never touches the on-disk file: [`Self::save_atomic`] is
     /// a no-op. For tests that drive the state layer's persistence paths —
     /// with a default config those would overwrite the developer's real

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -1,7 +1,7 @@
 //! Version-aware configuration loading and conflict-safe persistence.
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     ffi::OsString,
     fs, io,
     path::{Path, PathBuf},
@@ -123,9 +123,9 @@ impl ConfigFile {
     pub fn load_from_path(path: &Path) -> Result<(Config, Self), ConfigError> {
         match fs::read_to_string(path) {
             Ok(source) => {
-                let (config, loaded_version) = parse_config(path, &source)?;
-                let migrated_from =
-                    (loaded_version < SCHEMA_VERSION).then(|| (loaded_version, source.clone()));
+                let (config, loaded_version, migrated_legacy_keys) = parse_config(path, &source)?;
+                let migrated_from = (loaded_version < SCHEMA_VERSION || migrated_legacy_keys)
+                    .then(|| (loaded_version, source.clone()));
                 Ok((
                     config,
                     Self {
@@ -245,9 +245,10 @@ impl Config {
 }
 
 /// Parse `source`, applying every migration its declared `schema_version`
-/// needs. Returns the migrated config plus the version the file actually
-/// declared, so callers can tell a migrated load from an already-current one.
-fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError> {
+/// needs. Returns the migrated config, the version the file actually declared,
+/// and whether same-schema private-build keys were normalized, so callers can
+/// retain a recovery copy before either kind of migration is saved.
+fn parse_config(path: &Path, source: &str) -> Result<(Config, u32, bool), ConfigError> {
     let header: ConfigHeader = toml::from_str(source).map_err(|source| ConfigError::Parse {
         path: path.to_path_buf(),
         source: Box::new(source),
@@ -259,10 +260,29 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
         });
     }
     reject_obsolete_fields(path, source, header.schema_version)?;
-    let mut config: Config = toml::from_str(source).map_err(|source| ConfigError::Parse {
+    let mut value: toml::Value = toml::from_str(source).map_err(|source| ConfigError::Parse {
         path: path.to_path_buf(),
         source: Box::new(source),
     })?;
+    // Private builds predating schema 6 persisted transport aliases in a
+    // top-level `device_aliases` table. It was never part of the released
+    // schema, so keep the strict Config shape and consume it only inside this
+    // one-way migration adapter.
+    let legacy_aliases = value
+        .as_table_mut()
+        .and_then(|table| table.remove("device_aliases"))
+        .map(toml::Value::try_into)
+        .transpose()
+        .map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        })?
+        .unwrap_or_else(BTreeMap::new);
+    let mut config: Config = value.try_into().map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })?;
+    let migrated_legacy_keys = config.migrate_legacy_device_keys(legacy_aliases);
     if header.schema_version <= 3 {
         config.migrate_owner_locked_gestures();
     }
@@ -280,7 +300,7 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
     }
     config.repair_duplicate_routes();
     config.schema_version = SCHEMA_VERSION;
-    Ok((config, header.schema_version))
+    Ok((config, header.schema_version, migrated_legacy_keys))
 }
 
 fn reject_obsolete_fields(path: &Path, source: &str, version: u32) -> Result<(), ConfigError> {

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1935,6 +1935,83 @@ dpi = 1600
 }
 
 #[test]
+fn custom_device_aliases_migrate_to_identity_keys_and_links() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    let original = r#"
+schema_version = 6
+selected_device = "device:serial:abc123"
+
+[device_aliases]
+"direct:046d:b03e:serial:abc123" = "device:serial:abc123"
+"receiver:82839805:slot:2" = "device:serial:abc123"
+"receiver:82839805:slot:3" = "device:unit:05060708"
+
+[devices."device:serial:abc123"]
+dpi = 1600
+
+[devices."device:serial:abc123".identity]
+display_name = "MX Ergo S"
+kind = "trackball"
+
+[devices."device:serial:abc123".identity.capabilities]
+buttons = true
+pointer = true
+lighting = false
+scroll_inversion = false
+hires_wheel = false
+thumbwheel = false
+haptic_feedback = false
+haptic_panel = false
+
+[devices."device:unit:01020304"]
+dpi = 800
+
+[devices."device:unit:01020304".identity]
+display_name = "MX Ergo S"
+kind = "trackball"
+
+[devices."device:unit:01020304".identity.capabilities]
+buttons = true
+pointer = true
+lighting = false
+scroll_inversion = false
+hires_wheel = false
+thumbwheel = false
+haptic_feedback = false
+haptic_panel = false
+"#;
+    fs::write(&path, original).expect("write custom config");
+
+    let (config, mut file) = ConfigFile::load_from_path(&path).expect("load custom config");
+    assert_eq!(config.selected_device.as_deref(), Some("serial:abc123"));
+    assert!(config.devices.contains_key("serial:abc123"));
+    assert!(config.devices.contains_key("unit:01020304"));
+    assert!(!config.devices.contains_key("device:serial:abc123"));
+    let links = &config.devices["serial:abc123"].links;
+    assert!(links.contains_key("direct:046d:b03e"));
+    assert!(links.contains_key("receiver:82839805:slot:2"));
+    assert!(
+        config
+            .devices
+            .values()
+            .all(|device| !device.links.contains_key("receiver:82839805:slot:3")),
+        "an alias whose target has no persisted identity is not guessed onto a same-model mouse"
+    );
+
+    file.save(&config).expect("save migrated config");
+    assert_eq!(
+        fs::read(path.with_file_name("config.toml.v6.bak")).expect("read migration backup"),
+        original.as_bytes(),
+        "same-schema custom migrations still preserve their original source"
+    );
+    let written = fs::read_to_string(&path).expect("read migrated config");
+    assert!(!written.contains("device_aliases"));
+    assert!(!written.contains("device:serial:"));
+    assert!(!written.contains("device:unit:"));
+}
+
+#[test]
 fn migrating_two_direct_routes_of_one_device_folds_instead_of_dropping_one() {
     // An MX Master 3S reached over USB *and* over Bluetooth-direct has two v4
     // entries whose keys both rename to `unit:6be9d300`. Inserting would let

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1938,8 +1938,9 @@ dpi = 1600
 fn custom_device_aliases_migrate_to_identity_keys_and_links() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
-    let original = r#"
-schema_version = 6
+    let original = format!(
+        r#"
+schema_version = {SCHEMA_VERSION}
 selected_device = "device:serial:abc123"
 
 [device_aliases]
@@ -1980,8 +1981,9 @@ hires_wheel = false
 thumbwheel = false
 haptic_feedback = false
 haptic_panel = false
-"#;
-    fs::write(&path, original).expect("write custom config");
+"#
+    );
+    fs::write(&path, &original).expect("write custom config");
 
     let (config, mut file) = ConfigFile::load_from_path(&path).expect("load custom config");
     assert_eq!(config.selected_device.as_deref(), Some("serial:abc123"));
@@ -2001,7 +2003,8 @@ haptic_panel = false
 
     file.save(&config).expect("save migrated config");
     assert_eq!(
-        fs::read(path.with_file_name("config.toml.v6.bak")).expect("read migration backup"),
+        fs::read(path.with_file_name(format!("config.toml.v{SCHEMA_VERSION}.bak")))
+            .expect("read migration backup"),
         original.as_bytes(),
         "same-schema custom migrations still preserve their original source"
     );

--- a/crates/openlogi-desktop/Cargo.toml
+++ b/crates/openlogi-desktop/Cargo.toml
@@ -67,7 +67,7 @@ embed-resource = "3.0.9"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSApplication", "NSAppearance"] }
-objc2-foundation = { workspace = true, features = ["NSProcessInfo", "NSString", "NSError"] }
+objc2-foundation = { workspace = true, features = ["NSBundle", "NSProcessInfo", "NSString", "NSError"] }
 objc2-service-management = { workspace = true, features = ["std", "SMAppService", "SMErrors", "objc2", "objc2-foundation"] }
 
 [lints]

--- a/crates/openlogi-desktop/src/features/mouse/geometry.rs
+++ b/crates/openlogi-desktop/src/features/mouse/geometry.rs
@@ -230,9 +230,9 @@ fn map_slot_name(name: &str) -> Option<MouseControlId> {
         }
         "SLOT_NAME_BACK_BUTTON" => Some(MouseControlId::Button(ButtonId::Back)),
         "SLOT_NAME_FORWARD_BUTTON" => Some(MouseControlId::Button(ButtonId::Forward)),
-        "SLOT_NAME_MODESHIFT_BUTTON" | "SLOT_NAME_DPI_BUTTON" => {
-            Some(MouseControlId::Button(ButtonId::DpiToggle))
-        }
+        "SLOT_NAME_MODESHIFT_BUTTON"
+        | "SLOT_NAME_DPI_BUTTON"
+        | "SLOT_NAME_CHANGE_POINTER_SPEED" => Some(MouseControlId::Button(ButtonId::DpiToggle)),
         "SLOT_NAME_THUMBWHEEL" => Some(MouseControlId::ThumbwheelRotation),
         "SLOT_NAME_GESTURE_BUTTON" => Some(MouseControlId::Button(ButtonId::GestureButton)),
         // The MX Master 4 Haptic Sense Panel. Logi names the slot after its
@@ -281,6 +281,33 @@ mod tests {
         assert_eq!(
             map_slot_name("SLOT_NAME_DPI_BUTTON"),
             Some(MouseControlId::Button(ButtonId::DpiToggle))
+        );
+    }
+
+    #[test]
+    fn mx_ergo_s_metadata_maps_all_six_rebindable_controls() {
+        let mapped: Vec<_> = [
+            "SLOT_NAME_MIDDLE_BUTTON",
+            "SLOT_NAME_SCROLL_LEFT",
+            "SLOT_NAME_SCROLL_RIGHT",
+            "SLOT_NAME_FORWARD_BUTTON",
+            "SLOT_NAME_BACK_BUTTON",
+            "SLOT_NAME_CHANGE_POINTER_SPEED",
+        ]
+        .into_iter()
+        .filter_map(map_slot_name)
+        .collect();
+
+        assert_eq!(
+            mapped,
+            vec![
+                MouseControlId::Button(ButtonId::MiddleClick),
+                MouseControlId::Button(ButtonId::WheelTiltLeft),
+                MouseControlId::Button(ButtonId::WheelTiltRight),
+                MouseControlId::Button(ButtonId::Forward),
+                MouseControlId::Button(ButtonId::Back),
+                MouseControlId::Button(ButtonId::DpiToggle),
+            ]
         );
     }
 

--- a/crates/openlogi-desktop/src/platform/registration/macos.rs
+++ b/crates/openlogi-desktop/src/platform/registration/macos.rs
@@ -1,5 +1,5 @@
 //! The macOS implementation: `SMAppService` over `objc2-service-management`,
-//! plus the version marker that drives re-registration after an app update.
+//! plus the build marker that drives re-registration after an app update.
 
 use super::ServiceStatus;
 
@@ -35,7 +35,7 @@ enum EnsureAction {
 /// - Absent (`NotRegistered`) → register. `NotFound` also attempts it, so a
 ///   broken bundle surfaces an informative framework error instead of
 ///   silence.
-/// - `Enabled` with a stale version marker → re-register.
+/// - `Enabled` with a stale build marker → re-register.
 /// - `RequiresApproval` → nothing, ever: the user's System Settings choice
 ///   outranks the update path too.
 fn ensure_action(status: ServiceStatus, stale: bool) -> Option<EnsureAction> {
@@ -63,13 +63,46 @@ pub(super) fn ensure_registered() -> Result<(), String> {
     Ok(())
 }
 
-/// Whether the recorded registering version differs from this build. A
-/// missing marker reads as stale, so installs that registered before the
-/// marker existed get their one catch-up re-registration.
+/// Whether the recorded registering build differs from this bundle. A
+/// missing or legacy package-version-only marker reads as stale, so installs
+/// that registered before the build marker existed get their one catch-up
+/// re-registration.
+///
+/// `CARGO_PKG_VERSION` alone is not sufficient: local packages can replace an
+/// installed app several times without changing the release version. launchd
+/// keeps the parent bundle context from the registration that it accepted, so
+/// such an in-place replacement must still perform Apple's unregister/register
+/// update dance. The outer bundle's `CFBundleVersion` is stamped uniquely by
+/// local packaging and is the canonical build identity at runtime.
 fn registration_is_stale() -> bool {
+    let current = current_registration_marker();
     registered_version_path()
         .and_then(|path| std::fs::read_to_string(path).ok())
-        .is_none_or(|recorded| recorded.trim() != env!("CARGO_PKG_VERSION"))
+        .is_none_or(|recorded| recorded.trim() != current)
+}
+
+fn current_registration_marker() -> String {
+    registration_marker(
+        env!("CARGO_PKG_VERSION"),
+        current_bundle_build_version().as_deref(),
+    )
+}
+
+fn registration_marker(package_version: &str, bundle_build_version: Option<&str>) -> String {
+    let build = bundle_build_version.unwrap_or(package_version);
+    format!("{package_version}:{build}")
+}
+
+/// Read the outer app's stamped build number. `NSBundle::mainBundle` is the
+/// registering GUI bundle, not the nested agent bundle.
+fn current_bundle_build_version() -> Option<String> {
+    use objc2_foundation::{NSBundle, NSString};
+
+    let key = NSString::from_str("CFBundleVersion");
+    NSBundle::mainBundle()
+        .objectForInfoDictionaryKey(&key)?
+        .downcast_ref::<NSString>()
+        .map(ToString::to_string)
 }
 
 /// Marker file under the data dir recording which app version last
@@ -88,7 +121,7 @@ fn record_registered_version() {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&path, env!("CARGO_PKG_VERSION"))
+        std::fs::write(&path, current_registration_marker())
     };
     if let Err(error) = write() {
         // Worst case the next launch re-registers once more.
@@ -223,6 +256,19 @@ mod tests {
             ensure_action(ServiceStatus::Enabled, true),
             Some(EnsureAction::Reregister)
         );
+    }
+
+    #[test]
+    fn registration_marker_distinguishes_rebuilds_of_one_release() {
+        assert_ne!(
+            registration_marker("0.8.3", Some("20260904.144728")),
+            registration_marker("0.8.3", Some("20260905.062532"))
+        );
+    }
+
+    #[test]
+    fn unbundled_registration_marker_falls_back_to_package_version() {
+        assert_eq!(registration_marker("0.8.3", None), "0.8.3:0.8.3");
     }
 
     #[test]

--- a/crates/openlogi-desktop/src/state/devices.rs
+++ b/crates/openlogi-desktop/src/state/devices.rs
@@ -7,7 +7,7 @@ use openlogi_camera::Camera;
 use openlogi_core::config::{Config, DeviceIdentity, canonical_device_key};
 use openlogi_core::device::{
     BatteryInfo, Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
-    LightCapabilities, StandaloneDevice,
+    LightCapabilities, PairedDevice, StandaloneDevice,
 };
 use openlogi_core::device_order::{
     DeviceIdentity as RouteIdentity, DeviceStableId, PhysicalDeviceKey,
@@ -161,82 +161,11 @@ pub(super) fn build_device_list(
 ) -> Vec<DeviceRecord> {
     let mut list = Vec::new();
     for inv in inventories {
-        for paired in &inv.paired {
-            let route = DeviceRoute::device_route_for(inv, paired.slot);
-            let (model_key, asset, model_info, codename, serial_number, unit_id) =
-                if let Some(model) = paired.model_info.as_ref() {
-                    let asset = cache.resolve(model, paired.codename.as_deref());
-                    (
-                        model.config_key(),
-                        asset,
-                        Some(model.clone()),
-                        paired.codename.clone(),
-                        model.serial_number.clone(),
-                        model.unit_id,
-                    )
-                } else {
-                    // No HID++ 2.0 model info — HID++ 1.0 device or feature walk
-                    // timed out. Surface the device anyway using the wpid (or slot
-                    // as a last-resort model key) so it appears in the gallery
-                    // with a stable display fallback.
-                    let key = paired.wpid.map_or_else(
-                        || format!("slot{}", paired.slot),
-                        |w| format!("wpid{w:04x}"),
-                    );
-                    (key, None, None, paired.codename.clone(), None, [0u8; 4])
-                };
-            let stable_id = DeviceStableId::from_parts(
-                route.as_ref(),
-                paired.slot,
-                serial_number.as_deref(),
-                unit_id,
-            );
-            let identity = RouteIdentity::from_parts(serial_number.as_deref(), unit_id);
-            let (config_key, persistent) = config
-                .resolve_device_key(&stable_id, paired.online.then_some(&identity))
-                .map_or_else(
-                    || (stable_id.runtime_key(), false),
-                    |key| (key.into_string(), true),
-                );
-            let canonical_key =
-                canonical_device_key(&stable_id, paired.online.then_some(&identity))
-                    .map(PhysicalDeviceKey::into_string);
-            let route_key = stable_id.route_key();
-
-            let display_name = asset
-                .as_ref()
-                .map(|a| a.display_name.clone())
-                .or_else(|| paired.codename.as_deref().map(prettify_codename))
-                .unwrap_or_else(|| {
-                    tr!("device.receiver_slot_number", number => paired.slot.to_string())
-                        .to_string()
-                });
-            let kind = effective_kind(paired.kind, asset.as_ref().and_then(|a| a.kind));
-            list.push(DeviceRecord {
-                config_key,
-                canonical_key,
-                persistent,
-                route_key,
-                model_key,
-                model_name: display_name.clone(),
-                display_name,
-                asset,
-                model_info,
-                codename,
-                serial_number,
-                unit_id,
-                driver_id: None,
-                registry_model_id: None,
-                route,
-                capture_id: None,
-                kind,
-                capabilities: paired.capabilities,
-                light_capabilities: None,
-                slot: paired.slot,
-                online: paired.online,
-                battery: paired.battery.clone(),
-            });
-        }
+        list.extend(
+            inv.paired
+                .iter()
+                .filter_map(|paired| paired_record(inv, paired, cache, config)),
+        );
     }
     append_standalone(&mut list, standalone, cache, config);
     #[cfg(debug_assertions)]
@@ -266,6 +195,126 @@ pub(super) fn build_device_list(
     apply_custom_names(&mut list, config);
     sort_device_list(&mut list);
     list
+}
+
+/// Build one receiver/direct inventory record, or suppress an unknown offline
+/// receiver pairing until it has been observed online once.
+fn paired_record(
+    inventory: &DeviceInventory,
+    paired: &PairedDevice,
+    cache: &AssetResolver,
+    config: &Config,
+) -> Option<DeviceRecord> {
+    let route = DeviceRoute::device_route_for(inventory, paired.slot);
+    let (model_key, asset, model_info, codename, serial_number, unit_id) =
+        if let Some(model) = paired.model_info.as_ref() {
+            let asset = cache.resolve(model, paired.codename.as_deref());
+            (
+                model.config_key(),
+                asset,
+                Some(model.clone()),
+                paired.codename.clone(),
+                model.serial_number.clone(),
+                model.unit_id,
+            )
+        } else {
+            // No HID++ 2.0 model info — HID++ 1.0 device or feature walk
+            // timed out. Surface an online device using WPID (or slot as the
+            // last-resort model key) so it remains actionable.
+            let key = paired.wpid.map_or_else(
+                || format!("slot{}", paired.slot),
+                |wpid| format!("wpid{wpid:04x}"),
+            );
+            (key, None, None, paired.codename.clone(), None, [0; 4])
+        };
+    let stable_id = DeviceStableId::from_parts(
+        route.as_ref(),
+        paired.slot,
+        serial_number.as_deref(),
+        unit_id,
+    );
+    let identity = RouteIdentity::from_parts(serial_number.as_deref(), unit_id);
+    // Receiver pairing registers retain a physical unit id while the mouse
+    // sleeps or uses Bluetooth. That identity is authoritative even when
+    // offline; all-zero identities remain excluded by `config_key()`.
+    let physical_identity = identity.config_key().is_some().then_some(&identity);
+    let (config_key, persistent) = config
+        .resolve_device_key(&stable_id, physical_identity)
+        .map_or_else(
+            || (stable_id.runtime_key(), false),
+            |key| (key.into_string(), true),
+        );
+    let canonical_key =
+        canonical_device_key(&stable_id, physical_identity).map(PhysicalDeviceKey::into_string);
+    let route_key = stable_id.route_key();
+
+    // A receiver can retain pairings OpenLogi has never observed. An offline
+    // slot with no persisted device entry has neither actionable settings nor
+    // reliable presentation metadata and used to render as anonymous `Slot N`
+    // cards. Known devices remain visible for continuity.
+    let receiver_route = matches!(
+        route.as_ref(),
+        Some(DeviceRoute::Bolt { .. } | DeviceRoute::Unifying { .. })
+    );
+    if receiver_route && !paired.online && !config.devices.contains_key(&config_key) {
+        return None;
+    }
+
+    let display_name = asset
+        .as_ref()
+        .map(|asset| asset.display_name.clone())
+        .or_else(|| paired.codename.as_deref().map(prettify_codename))
+        .unwrap_or_else(|| {
+            tr!("device.receiver_slot_number", number => paired.slot.to_string()).to_string()
+        });
+    let kind = effective_kind(paired.kind, asset.as_ref().and_then(|asset| asset.kind));
+    let record = DeviceRecord {
+        config_key,
+        canonical_key,
+        persistent,
+        route_key,
+        model_key,
+        model_name: display_name.clone(),
+        display_name,
+        asset,
+        model_info,
+        codename,
+        serial_number,
+        unit_id,
+        driver_id: None,
+        registry_model_id: None,
+        route,
+        capture_id: None,
+        kind,
+        capabilities: paired.capabilities,
+        light_capabilities: None,
+        slot: paired.slot,
+        online: paired.online,
+        battery: paired.battery.clone(),
+    };
+    Some(hydrate_offline_linked_record(record, cache, config))
+}
+
+/// Restore persisted model metadata for an offline sighting attributed to a
+/// known physical device through its recorded route link.
+fn hydrate_offline_linked_record(
+    record: DeviceRecord,
+    cache: &AssetResolver,
+    config: &Config,
+) -> DeviceRecord {
+    // A receiver continues to enumerate its paired slot after the device
+    // switches to another transport or goes to sleep. That sighting often has
+    // neither model info nor a WPID, but `resolve_device_key` can still
+    // attribute the route to the physical device previously adopted online.
+    // Never guess by model name: two devices of the same model stay distinct.
+    if record.online {
+        return record;
+    }
+    let Some(identity) = config.device_identity(&record.config_key) else {
+        return record;
+    };
+    let known = offline_record(&record.config_key, identity, cache);
+    adopt_transient_record(&known, record)
 }
 
 fn apply_custom_names(list: &mut [DeviceRecord], config: &Config) {

--- a/crates/openlogi-desktop/src/state/devices/tests.rs
+++ b/crates/openlogi-desktop/src/state/devices/tests.rs
@@ -9,11 +9,133 @@ use std::collections::HashSet;
 
 use super::{
     Camera, Capabilities, DeviceIdentity, DeviceKind, DeviceModelInfo, DeviceRecord,
-    DeviceTransports, append_offline_known, build_device_list, direct_key_prefix, effective_kind,
-    fold_by_inventory_key, offline_record, pick_initial_device,
+    DeviceTransports, PhysicalDeviceKey, append_offline_known, build_device_list,
+    direct_key_prefix, effective_kind, fold_by_inventory_key, offline_record, pick_initial_device,
 };
 use crate::state::inventory::adopt_routes;
 use openlogi_core::hid::Dpi;
+
+#[test]
+fn unknown_offline_receiver_slots_do_not_create_gallery_cards() {
+    let mut slot_one = paired_device_no_model_info(1, Some(0x4051));
+    slot_one.online = false;
+    let mut slot_two = paired_device_no_model_info(2, None);
+    slot_two.online = false;
+
+    let list = build_device_list(
+        &[inventory_with(vec![slot_one, slot_two])],
+        &[],
+        &AssetResolver::new(),
+        &Config::default(),
+        &[],
+    );
+
+    assert!(
+        list.is_empty(),
+        "never-seen offline pairings must not render as anonymous Slot cards"
+    );
+}
+
+#[test]
+fn offline_unifying_unit_id_resolves_the_known_physical_device() {
+    let unit_id = [0x29, 0x16, 0xdb, 0xbe];
+    let model = DeviceModelInfo {
+        entity_count: 0,
+        serial_number: None,
+        unit_id,
+        transports: DeviceTransports {
+            equad: true,
+            btle: true,
+            ..DeviceTransports::default()
+        },
+        model_ids: [0xb027, 0x4051, 0],
+        extended_model_id: 0,
+    };
+    let mut config = Config::default();
+    config.set_device_identity(
+        "unit:2916dbbe",
+        DeviceIdentity {
+            display_name: "Ergo M575".into(),
+            kind: DeviceKind::Trackball,
+            capabilities: Capabilities::presumed_from_kind(DeviceKind::Trackball),
+            light_capabilities: None,
+            model_info: Some(model.clone()),
+            codename: Some("Ergo M575".into()),
+            driver_id: None,
+            registry_model_id: None,
+        },
+    );
+    let mut paired = paired_device_no_model_info(3, Some(0x4051));
+    paired.online = false;
+    paired.kind = DeviceKind::Trackball;
+    paired.model_info = Some(model);
+
+    let list = build_device_list(
+        &[inventory_with(vec![paired])],
+        &[],
+        &AssetResolver::new(),
+        &config,
+        &[],
+    );
+
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].config_key, "unit:2916dbbe");
+    assert_eq!(list[0].display_name, "Ergo M575");
+    assert!(!list[0].online);
+}
+
+#[test]
+fn adopted_offline_receiver_route_uses_its_persisted_identity() {
+    let route_key = "receiver:da2699e1:slot:2";
+    let canonical = PhysicalDeviceKey::parse("serial:2540zae0hzr8")
+        .expect("the test key is a physical identity");
+    let mut config = Config::default();
+    config.set_device_identity(
+        canonical.as_str(),
+        DeviceIdentity {
+            display_name: "MX Ergo S".into(),
+            kind: DeviceKind::Trackball,
+            capabilities: Capabilities::presumed_from_kind(DeviceKind::Trackball),
+            light_capabilities: None,
+            model_info: Some(DeviceModelInfo {
+                entity_count: 4,
+                serial_number: Some("2540ZAE0HZR8".into()),
+                unit_id: [0; 4],
+                transports: DeviceTransports::default(),
+                model_ids: [0xb03e, 0, 0],
+                extended_model_id: 0,
+            }),
+            codename: Some("MX Ergo S".into()),
+            driver_id: None,
+            registry_model_id: None,
+        },
+    );
+    assert!(config.adopt_route(&canonical, route_key, None));
+
+    let mut paired = paired_device_no_model_info(2, None);
+    paired.codename = Some("MX Ergo S".into());
+    paired.kind = DeviceKind::Mouse;
+    paired.online = false;
+    let list = build_device_list(
+        &[inventory_with(vec![paired])],
+        &[],
+        &AssetResolver::new(),
+        &config,
+        &[],
+    );
+
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].config_key, canonical.as_str());
+    assert_eq!(list[0].display_name, "MX Ergo S");
+    assert_eq!(list[0].kind, DeviceKind::Trackball);
+    assert_eq!(
+        list[0].model_info.as_ref().map(|info| info.model_ids[0]),
+        Some(0xb03e)
+    );
+    assert_eq!(list[0].route_key, route_key);
+    assert!(list[0].route.is_some());
+    assert!(!list[0].online);
+}
 
 fn paired_device_no_model_info(slot: u8, wpid: Option<u16>) -> PairedDevice {
     PairedDevice {

--- a/crates/openlogi-desktop/src/state/devices/tests.rs
+++ b/crates/openlogi-desktop/src/state/devices/tests.rs
@@ -38,7 +38,7 @@ fn unknown_offline_receiver_slots_do_not_create_gallery_cards() {
 
 #[test]
 fn offline_unifying_unit_id_resolves_the_known_physical_device() {
-    let unit_id = [0x29, 0x16, 0xdb, 0xbe];
+    let unit_id = [0x11, 0x22, 0x33, 0x44];
     let model = DeviceModelInfo {
         entity_count: 0,
         serial_number: None,
@@ -53,7 +53,7 @@ fn offline_unifying_unit_id_resolves_the_known_physical_device() {
     };
     let mut config = Config::default();
     config.set_device_identity(
-        "unit:2916dbbe",
+        "unit:11223344",
         DeviceIdentity {
             display_name: "Ergo M575".into(),
             kind: DeviceKind::Trackball,
@@ -79,7 +79,7 @@ fn offline_unifying_unit_id_resolves_the_known_physical_device() {
     );
 
     assert_eq!(list.len(), 1);
-    assert_eq!(list[0].config_key, "unit:2916dbbe");
+    assert_eq!(list[0].config_key, "unit:11223344");
     assert_eq!(list[0].display_name, "Ergo M575");
     assert!(!list[0].online);
 }
@@ -87,7 +87,7 @@ fn offline_unifying_unit_id_resolves_the_known_physical_device() {
 #[test]
 fn adopted_offline_receiver_route_uses_its_persisted_identity() {
     let route_key = "receiver:da2699e1:slot:2";
-    let canonical = PhysicalDeviceKey::parse("serial:2540zae0hzr8")
+    let canonical = PhysicalDeviceKey::parse("serial:testserial01")
         .expect("the test key is a physical identity");
     let mut config = Config::default();
     config.set_device_identity(
@@ -99,7 +99,7 @@ fn adopted_offline_receiver_route_uses_its_persisted_identity() {
             light_capabilities: None,
             model_info: Some(DeviceModelInfo {
                 entity_count: 4,
-                serial_number: Some("2540ZAE0HZR8".into()),
+                serial_number: Some("TESTSERIAL01".into()),
                 unit_id: [0; 4],
                 transports: DeviceTransports::default(),
                 model_ids: [0xb03e, 0, 0],

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     hash::Hash,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use futures_concurrency::future::Join as _;
@@ -40,9 +40,9 @@ use probe::{NodeProbe, probe_one};
 /// ping; we err on the side of waiting.
 const ARRIVAL_DRAIN: Duration = Duration::from_millis(1500);
 
-/// Maximum number of pairing slots a Bolt receiver supports. We iterate this
-/// range to surface paired-but-offline devices that won't fire arrival events.
-const MAX_BOLT_SLOTS: u8 = 6;
+/// Maximum number of pairing slots a receiver supports. We iterate this range
+/// to surface paired-but-offline devices that won't fire arrival events.
+const MAX_RECEIVER_SLOTS: u8 = 6;
 
 /// Upper bound on probing one HID node. `hidpp`'s request/response has no
 /// timeout of its own, so without this a single unresponsive (e.g. asleep)
@@ -693,7 +693,6 @@ impl Enumerator {
     async fn enumerate_reporting_completeness(
         &mut self,
     ) -> Result<(Vec<DeviceInventory>, bool, bool), InventoryError> {
-        let now = Instant::now();
         let backend = Arc::clone(&self.backend);
         let candidates = backend.enumerate_hidpp().await?;
         debug!(count = candidates.len(), "HID++ candidate interfaces");
@@ -729,7 +728,7 @@ impl Enumerator {
                     };
                     let probe = timeout(
                         budget,
-                        probe_one(info, Arc::clone(&channel), cache, now, events.as_ref()),
+                        probe_one(info, Arc::clone(&channel), cache, events.as_ref()),
                     )
                     .await;
                     (node, channel, probe, budget, receiver)
@@ -845,7 +844,7 @@ impl Enumerator {
                     self.cache_dirty |= persist::is_persistable(&key);
                     self.cache.insert(key, cached);
                 }
-                CacheOutcome::Update(key, cached) => {
+                CacheOutcome::Update(key, cached) | CacheOutcome::Bind(key, cached) => {
                     seen_keys.insert(key.clone());
                     self.cache.insert(key, cached);
                 }

--- a/crates/openlogi-device/src/inventory/cache.rs
+++ b/crates/openlogi-device/src/inventory/cache.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Weak};
 
 use hidpp::channel::HidppChannel;
 use openlogi_core::device::{BatteryInfo, BatteryStatus};
@@ -8,17 +7,6 @@ use super::events::{EventFeatureIndices, EventSubscriptionHandle};
 use super::features::{BatteryProbe, ProbedFeatures, probe_features, read_battery};
 use crate::backend::NodeId;
 
-/// How long a device's probe is reused before a fresh read.
-/// The expensive part of a probe (the `enumerate_features` feature-table walk)
-/// reads *immutable* data — model, capabilities, marketing type — so it never
-/// needs re-reading for a known device; the periodic full probe is kept only as
-/// a self-healing pass (e.g. a firmware update reshuffling the feature table).
-/// The volatile battery does NOT ride this window: cache hits re-read it every
-/// reconciliation through the memoized feature index (see [`read_battery`]).
-/// Elapsed time rather than scan count preserves cache freshness now that
-/// event-driven scans are intentionally irregular.
-pub(super) const REFRESH_INTERVAL: Duration = Duration::from_secs(30);
-
 /// Stable identity used to memoize a device's probe across `enumerate` ticks.
 /// Keyed on the device's *own* identity (never its slot) so a re-paired or
 /// moved device can't inherit another device's cached probe.
@@ -26,11 +14,8 @@ pub(super) const REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 pub(super) enum CacheKey {
     /// Bolt: the unit id from the pairing register (cheap, read every tick).
     Bolt { unit_id: [u8; 4] },
-    /// Unifying: keyed on the full receiver serial number + pairing slot.
-    /// Using the complete serial (not just a prefix) avoids collisions between
-    /// two receivers whose serials share a common prefix (e.g. "DA2699E1" and
-    /// "DA2604F2" share "DA2").
-    UnifyingSlot { receiver_uid: String, slot: u8 },
+    /// Unifying: the unit id from the extended pairing register.
+    Unifying { unit_id: [u8; 4] },
     /// Direct (Bluetooth/USB): the OS-assigned HID node id (macOS registry-entry
     /// id, Linux dev path, Windows interface path). Unique *per node*, so two
     /// units of the same model never collide, and stable while connected so the
@@ -43,7 +28,13 @@ pub(super) enum CacheKey {
 /// device's memoized data.
 pub(super) const CACHE_MISS_GRACE: u8 = 3;
 
-/// A memoized probe result plus the instant it was taken.
+/// A memoized immutable probe result and the channel generation that produced
+/// (or last validated) it.
+///
+/// `None` is a persisted warm-start entry. The first live channel adopts it
+/// without a feature-table walk. A replacement channel validates it once
+/// before reuse, preventing runtime feature indexes from leaking across
+/// reconnects without periodically interrupting live control capture.
 #[derive(Clone)]
 pub(super) struct Cached {
     pub(super) probe: ProbedFeatures,
@@ -54,7 +45,25 @@ pub(super) struct Cached {
     pub(super) battery: Option<BatteryProbe>,
     /// Event-capable feature indexes found by the same immutable table walk.
     pub(super) events: EventFeatureIndices,
-    pub(super) probed_at: Instant,
+    pub(super) channel: Option<Weak<HidppChannel>>,
+}
+
+impl Cached {
+    fn belongs_to(&self, channel: &Arc<HidppChannel>) -> bool {
+        self.channel.as_ref().is_some_and(|cached| {
+            cached
+                .upgrade()
+                .is_some_and(|cached| Arc::ptr_eq(&cached, channel))
+        })
+    }
+
+    fn bind_to(&mut self, channel: &Arc<HidppChannel>) {
+        self.channel = Some(Arc::downgrade(channel));
+    }
+
+    pub(super) fn needs_validation(&self, channel: &Arc<HidppChannel>) -> bool {
+        self.channel.is_some() && !self.belongs_to(channel)
+    }
 }
 
 /// The legacy `0x1000` battery feature (MX2S-era mice) reports `discharge_level
@@ -95,13 +104,17 @@ fn hold_percentage_while_charging(
 }
 
 /// What a probed device contributes to the cache this tick. The key lets stale
-/// entries be evicted; `Fresh` (a full probe) and `Update` (a cache hit whose
-/// volatile battery was re-read) also carry the value to insert. `Unkeyed` is a
-/// device we can't (or won't) cache — an all-zero unit id, or a rejected
-/// non-peripheral — so its key is neither inserted nor kept alive.
+/// entries be evicted; `Fresh` (a full probe), `Update` (a cache hit whose
+/// volatile battery was re-read), and `Bind` (runtime channel association
+/// only) also carry the value to insert. `Unkeyed` is a device we can't (or
+/// won't) cache — an all-zero unit id, or a rejected non-peripheral — so its
+/// key is neither inserted nor kept alive.
 pub(super) enum CacheOutcome {
     Fresh(CacheKey, Cached),
     Update(CacheKey, Cached),
+    /// Associate immutable data with a runtime channel without claiming that
+    /// volatile device I/O succeeded.
+    Bind(CacheKey, Cached),
     Seen(CacheKey),
     Unkeyed,
 }
@@ -111,13 +124,9 @@ pub(super) fn seen(id: Option<CacheKey>) -> CacheOutcome {
     id.map_or(CacheOutcome::Unkeyed, CacheOutcome::Seen)
 }
 
-/// Whether `cached` is stale enough that the device should be re-probed.
-pub(super) fn is_stale(cached: &Cached, now: Instant) -> bool {
-    now.saturating_duration_since(cached.probed_at) >= REFRESH_INTERVAL
-}
-
-/// Decide a device's probe: reuse a fresh cache, or (online + miss/stale)
-/// re-probe — but keep the last-known immutable data if the re-probe fails
+/// Decide a device's probe: reuse a cache associated with this channel, or
+/// (online + miss/replacement channel) re-probe — but keep the last-known
+/// immutable data if the re-probe fails
 /// rather than overwriting it with an empty default. An unprobed offline device
 /// with no cache yields a default probe. Returns the probe plus its cache
 /// contribution (only a *successful* probe is cached).
@@ -127,13 +136,13 @@ pub(super) async fn probe_or_reuse(
     id: Option<CacheKey>,
     cached: Option<&Cached>,
     online: bool,
-    now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
 ) -> (ProbedFeatures, CacheOutcome) {
     if let (Some(cached), Some(subscriptions)) = (cached, subscriptions) {
         subscriptions.register_device(index, cached.events);
     }
-    if online && cached.is_none_or(|c| is_stale(c, now)) {
+    let channel_replaced = cached.is_some_and(|c| c.needs_validation(channel));
+    if online && (cached.is_none() || channel_replaced) {
         let (mut fresh, battery, events) = probe_features(channel, index, subscriptions).await;
         if let (Some(reading), Some(probe)) = (fresh.battery.take(), battery) {
             fresh.battery = Some(hold_percentage_while_charging(
@@ -150,19 +159,25 @@ pub(super) async fn probe_or_reuse(
             }
             // A first-sight probe whose identity reads failed is served but not
             // memoized: caching it would pin a wrong (all-zero unit or
-            // serial-less) config key for `REFRESH_INTERVAL` (#482). The next
-            // reconciliation re-probes instead.
+            // serial-less) config key for this channel's lifetime (#482). The
+            // next tick re-probes instead.
             if fresh.identity_incomplete && cached.is_none() {
                 return (fresh, seen(id));
             }
             // Same reasoning for a capability read that failed part-way: the
-            // walk understates the device, and memoizing that hides a panel in
-            // the GUI for `REFRESH_INTERVAL`. A previous complete walk
-            // outranks this partial one, so defer to it and re-probe next
-            // reconciliation.
+            // walk understates the device, and memoizing it would hide a panel
+            // for this channel's lifetime. A previous complete walk outranks
+            // this partial one and is rebound to the new channel.
             if fresh.capabilities_incomplete {
                 if let Some(c) = cached {
                     keep_known_capabilities(&mut fresh, &c.probe);
+                    if let Some(key) = id {
+                        let mut value = c.clone();
+                        value.probe = fresh.clone();
+                        value.battery = battery.or(c.battery);
+                        value.bind_to(channel);
+                        return (fresh, CacheOutcome::Bind(key, value));
+                    }
                 }
                 return (fresh, seen(id));
             }
@@ -171,8 +186,8 @@ pub(super) async fn probe_or_reuse(
                     let value = Cached {
                         probe: fresh.clone(),
                         battery,
+                        channel: Some(Arc::downgrade(channel)),
                         events,
-                        probed_at: now,
                     };
                     (fresh, CacheOutcome::Fresh(key, value))
                 }
@@ -182,9 +197,14 @@ pub(super) async fn probe_or_reuse(
         // Re-probe failed: don't cache the failure. Fall back to the last-known
         // data so a transient glitch doesn't drop the device or its battery.
         // No battery re-read either — the device just proved unresponsive.
-        return match cached {
-            Some(c) => (c.probe.clone(), seen(id)),
-            None => (fresh, seen(id)),
+        return match (cached, id) {
+            (Some(c), Some(key)) => {
+                let mut value = c.clone();
+                value.bind_to(channel);
+                (c.probe.clone(), CacheOutcome::Bind(key, value))
+            }
+            (Some(c), None) => (c.probe.clone(), CacheOutcome::Unkeyed),
+            (None, id) => (fresh, seen(id)),
         };
     }
     match cached {
@@ -202,7 +222,16 @@ pub(super) async fn probe_or_reuse(
                     hold_percentage_while_charging(battery, c.probe.battery.as_ref(), probe);
                 let mut entry = c.clone();
                 entry.probe.battery = Some(battery);
+                entry.bind_to(channel);
                 return (entry.probe.clone(), CacheOutcome::Update(key, entry));
+            }
+            if online
+                && c.channel.is_none()
+                && let Some(key) = id
+            {
+                let mut entry = c.clone();
+                entry.bind_to(channel);
+                return (entry.probe.clone(), CacheOutcome::Bind(key, entry));
             }
             (c.probe.clone(), seen(id))
         }
@@ -305,5 +334,115 @@ mod hold_tests {
             BatteryProbe::Unified(0),
         );
         assert_eq!(live.percentage, 0);
+    }
+}
+
+#[cfg(test)]
+mod channel_generation_tests {
+    use std::sync::Arc;
+
+    use openlogi_core::device::Capabilities;
+
+    use super::{CacheKey, CacheOutcome, Cached, ProbedFeatures, probe_or_reuse};
+    use crate::channel::scripted::{ScriptedRawHidChannel, feature_error, scripted_channel};
+
+    fn reject_feature_request(request: &[u8]) -> Option<Vec<u8>> {
+        let _report_id = request.first()?;
+        Some(feature_error(request, 2))
+    }
+
+    async fn rejecting_channel() -> (
+        Arc<hidpp::channel::HidppChannel>,
+        crate::channel::scripted::ScriptedRawHidHandle,
+    ) {
+        let (raw, handle) = ScriptedRawHidChannel::with_responder(reject_feature_request);
+        (scripted_channel(raw).await, handle)
+    }
+
+    fn cached_for(channel: &Arc<hidpp::channel::HidppChannel>) -> Cached {
+        Cached {
+            probe: ProbedFeatures {
+                capabilities: Some(Capabilities::default()),
+                ..ProbedFeatures::default()
+            },
+            battery: None,
+            events: super::EventFeatureIndices::default(),
+            channel: Some(Arc::downgrade(channel)),
+        }
+    }
+
+    #[tokio::test]
+    async fn immutable_probe_is_reused_for_the_whole_channel_generation() {
+        let (channel, handle) = rejecting_channel().await;
+        let cached = cached_for(&channel);
+        let id = CacheKey::Bolt { unit_id: [1; 4] };
+
+        for _ in 0..32 {
+            let (_, outcome) =
+                probe_or_reuse(&channel, 1, Some(id.clone()), Some(&cached), true, None).await;
+            assert!(matches!(outcome, CacheOutcome::Seen(_)));
+        }
+
+        assert!(
+            handle.written_reports().is_empty(),
+            "time alone must never trigger another feature-table walk"
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_channel_is_validated_once_even_when_probe_fails() {
+        let (old_channel, _) = rejecting_channel().await;
+        let cached = cached_for(&old_channel);
+        let (replacement, handle) = rejecting_channel().await;
+        let id = CacheKey::Bolt { unit_id: [2; 4] };
+
+        let (_, outcome) =
+            probe_or_reuse(&replacement, 1, Some(id.clone()), Some(&cached), true, None).await;
+        let rebound = match outcome {
+            CacheOutcome::Bind(key, rebound) => {
+                assert_eq!(key, id);
+                rebound
+            }
+            _ => panic!("a cached fallback must bind to the replacement channel"),
+        };
+        assert!(!rebound.needs_validation(&replacement));
+        assert!(!handle.written_reports().is_empty());
+
+        let writes_after_validation = handle.written_reports().len();
+        let (_, outcome) =
+            probe_or_reuse(&replacement, 1, Some(id), Some(&rebound), true, None).await;
+        assert!(matches!(outcome, CacheOutcome::Seen(_)));
+        assert_eq!(
+            handle.written_reports().len(),
+            writes_after_validation,
+            "a failed validation must not become a two-second retry loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn persisted_cache_adoption_does_not_claim_live_io() {
+        let (channel, handle) = rejecting_channel().await;
+        let cached = Cached {
+            probe: ProbedFeatures::default(),
+            battery: None,
+            events: super::EventFeatureIndices::default(),
+            channel: None,
+        };
+        let id = CacheKey::Bolt { unit_id: [3; 4] };
+
+        let (_, outcome) =
+            probe_or_reuse(&channel, 1, Some(id.clone()), Some(&cached), true, None).await;
+        let rebound = match outcome {
+            CacheOutcome::Bind(key, rebound) => {
+                assert_eq!(key, id);
+                rebound
+            }
+            _ => panic!("adoption without live I/O must not claim a volatile update"),
+        };
+        assert!(!rebound.needs_validation(&channel));
+        assert!(
+            handle.written_reports().is_empty(),
+            "warm-start adoption should not repeat the immutable probe"
+        );
     }
 }

--- a/crates/openlogi-device/src/inventory/events.rs
+++ b/crates/openlogi-device/src/inventory/events.rs
@@ -365,6 +365,60 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn warm_cache_restores_lifecycle_events_without_another_feature_walk() {
+        use super::super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse};
+        use super::super::features::ProbedFeatures;
+        use crate::channel::scripted::{ScriptedRawHidChannel, scripted_channel};
+
+        let (raw, handle) = ScriptedRawHidChannel::with_responder(|_| None);
+        let channel = scripted_channel(raw).await;
+        let cached = Cached {
+            probe: ProbedFeatures::default(),
+            battery: None,
+            channel: None,
+            events: EventFeatureIndices {
+                wireless_status: Some(5),
+                unified_battery: Some(7),
+            },
+        };
+        let state = state(None);
+        let subscriptions = EventSubscriptionHandle {
+            state: Arc::clone(&state),
+        };
+        let (_, outcome) = probe_or_reuse(
+            &channel,
+            3,
+            Some(CacheKey::Unifying {
+                unit_id: [1, 2, 3, 4],
+            }),
+            Some(&cached),
+            true,
+            Some(&subscriptions),
+        )
+        .await;
+
+        assert!(matches!(outcome, CacheOutcome::Bind(..)));
+        assert!(
+            handle.written_reports().is_empty(),
+            "warm start must not re-walk immutable features"
+        );
+        let wireless = v20::Message::Long(
+            v20::MessageHeader {
+                device_index: 3,
+                feature_index: 5,
+                function_id: U4::from_lo(0),
+                software_id: U4::from_lo(0),
+            },
+            [0; 16],
+        )
+        .into();
+        assert_eq!(
+            state.decode(wireless, false),
+            Some(HidppEventSource::WirelessDeviceStatus)
+        );
+    }
+
     #[test]
     fn event_requests_are_bounded_and_coalesced() {
         let (notifier, mut receiver) = event_channel();

--- a/crates/openlogi-device/src/inventory/features.rs
+++ b/crates/openlogi-device/src/inventory/features.rs
@@ -56,7 +56,7 @@ pub(super) struct ProbedFeatures {
     pub(super) identity_incomplete: bool,
     /// A capability read *failed* (vs. the device not having the capability),
     /// so `capabilities` above understates what the device can do. Memoizing
-    /// that would hide a panel in the GUI for `REFRESH_INTERVAL`.
+    /// that would hide a panel in the GUI for the channel's lifetime.
     pub(super) capabilities_incomplete: bool,
 }
 
@@ -347,9 +347,9 @@ async fn probe_extra_capabilities(
 /// Whether the device exposes a divertable haptic panel, or `None` when a read
 /// failed part-way through the ~40-entry control walk.
 ///
-/// The distinction matters because the answer is memoized for `REFRESH_INTERVAL`:
-/// reporting a lost reply as `false` hides the Actions Ring binding for half a
-/// minute on a device that has the panel.
+/// The distinction matters because the answer is memoized for the channel's
+/// lifetime: reporting a lost reply as `false` could hide the Actions Ring
+/// binding until the device reconnects.
 async fn has_haptic_panel(feature: &ReprogControlsFeature) -> Option<bool> {
     let count = feature.get_count().await.ok()?;
     for index in 0..count {

--- a/crates/openlogi-device/src/inventory/persist.rs
+++ b/crates/openlogi-device/src/inventory/persist.rs
@@ -7,22 +7,18 @@
 //! fully probed once keeps its identity across restarts, even on transports
 //! where a fresh walk is slow or failing (see `BOLT_SLOT_PROBE`).
 //!
-//! Only Bolt identities are persisted, because only they are keyed on the
-//! device's *own* identity (the pairing-register unit id), which no re-pairing
-//! can silently reassign. A `CacheKey::UnifyingSlot` is `receiver + slot`: a
-//! different device paired into that slot while the agent is down would
-//! inherit the previous occupant's probe on warm start. A `CacheKey::Direct`
-//! is an OS-runtime node id with no cross-boot stability. Loaded entries
-//! restart the elapsed refresh window, so the regular self-healing pass
-//! re-walks them on schedule; until (and unless) that walk succeeds, the
-//! persisted data serves exactly like an in-memory cache hit.
+//! Bolt and Unifying identities are persisted because both are keyed on the
+//! device's *own* unit id from their pairing registers, which no re-pairing can
+//! silently reassign. A `CacheKey::Direct` is an OS-runtime node id with no
+//! cross-boot stability. Loaded entries have no runtime channel association.
+//! The first live channel adopts them without repeating the immutable
+//! feature-table walk; a replacement channel validates them once before reuse.
 //!
 //! *Where* a snapshot is kept is the host's business, not this module's: the
 //! enumerator writes through a [`ProbeCacheStore`]; `openlogi-hid` supplies
 //! the file-backed one every native build uses.
 
 use std::collections::HashMap;
-use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -33,9 +29,9 @@ use super::features::{BatteryProbe, ProbedFeatures};
 
 /// Bumped when the persisted shape changes; a mismatched snapshot is discarded
 /// (the cache is a warm-start optimization, not data anyone must keep).
-/// v2 dropped the `UnifyingSlot` key (slot-keyed, so not re-pair-safe).
-/// v3 adds event-capable feature indexes discovered by the immutable walk.
-const SCHEMA_VERSION: u32 = 3;
+/// v4 combines physical Unifying unit ids with event-capable feature indexes.
+/// Both development branches used v3 for different shapes; neither is reused.
+const SCHEMA_VERSION: u32 = 4;
 
 impl ProbeCacheError {
     /// Report why a store could not keep a snapshot.
@@ -89,16 +85,18 @@ struct PersistedEntry {
     events: EventFeatureIndices,
 }
 
-/// The persistable subset of [`CacheKey`] — Bolt only (see the module docs).
+/// The persistable subset of [`CacheKey`] (see the module docs).
 #[derive(Clone, Copy, Serialize, Deserialize)]
 enum PersistedKey {
     Bolt { unit_id: [u8; 4] },
+    Unifying { unit_id: [u8; 4] },
 }
 
 fn persistable(key: &CacheKey) -> Option<PersistedKey> {
     match key {
         CacheKey::Bolt { unit_id } => Some(PersistedKey::Bolt { unit_id: *unit_id }),
-        CacheKey::UnifyingSlot { .. } | CacheKey::Direct(_) => None,
+        CacheKey::Unifying { unit_id } => Some(PersistedKey::Unifying { unit_id: *unit_id }),
+        CacheKey::Direct(_) => None,
     }
 }
 
@@ -112,6 +110,7 @@ pub(super) fn is_persistable(key: &CacheKey) -> bool {
 fn runtime_key(key: PersistedKey) -> CacheKey {
     match key {
         PersistedKey::Bolt { unit_id } => CacheKey::Bolt { unit_id },
+        PersistedKey::Unifying { unit_id } => CacheKey::Unifying { unit_id },
     }
 }
 
@@ -180,12 +179,8 @@ impl ProbeCacheSnapshot {
                     Cached {
                         probe: entry.probe,
                         battery: entry.battery,
+                        channel: None,
                         events: entry.events,
-                        // Restart the refresh clock: the entry serves
-                        // immediately as a cache hit, and the periodic
-                        // self-healing re-walk decides when it is due for a
-                        // fresh read.
-                        probed_at: Instant::now(),
                     },
                 )
             })
@@ -196,7 +191,6 @@ impl ProbeCacheSnapshot {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::time::Instant;
 
     use openlogi_core::device::{
         BatteryInfo, BatteryLevel, BatteryStatus, DeviceModelInfo, DeviceTransports,
@@ -211,7 +205,7 @@ mod tests {
     /// the whole point of the snapshot — but only the parts that are actually
     /// immutable, and only for keys a re-pair cannot silently reassign.
     #[test]
-    fn a_snapshot_keeps_bolt_identity_and_drops_the_volatile_reading() {
+    fn a_snapshot_keeps_receiver_identities_and_drops_volatile_readings() {
         let model = DeviceModelInfo {
             entity_count: 1,
             serial_number: Some("TESTSERIAL01".into()),
@@ -237,28 +231,33 @@ mod tests {
                     ..Default::default()
                 },
                 battery: Some(BatteryProbe::Unified(9)),
+                channel: None,
                 events: EventFeatureIndices {
                     wireless_status: Some(7),
                     unified_battery: Some(9),
                 },
-                probed_at: Instant::now(),
             },
         );
+        let unifying_key = CacheKey::Unifying {
+            unit_id: [0x11, 0x22, 0x33, 0x44],
+        };
         cache.insert(
-            CacheKey::UnifyingSlot {
-                receiver_uid: "DA2699E1".into(),
-                slot: 2,
-            },
+            unifying_key.clone(),
             Cached {
-                probe: ProbedFeatures::default(),
+                probe: ProbedFeatures {
+                    model_info: Some(DeviceModelInfo {
+                        unit_id: [0x11, 0x22, 0x33, 0x44],
+                        ..model.clone()
+                    }),
+                    ..Default::default()
+                },
                 battery: None,
+                channel: None,
                 events: EventFeatureIndices::default(),
-                probed_at: Instant::now(),
             },
         );
 
         let snapshot = ProbeCacheSnapshot::of(&cache);
-        let restored_after = Instant::now();
         let restored = snapshot.into_entries();
 
         let bolt = restored
@@ -285,16 +284,12 @@ mod tests {
             "the battery *reading* is volatile — restoring it would resurrect a stale value"
         );
         assert!(
-            bolt.probed_at >= restored_after,
-            "a restored entry restarts the refresh clock"
+            bolt.channel.is_none(),
+            "a restored entry must not retain a runtime channel"
         );
         assert!(
-            !restored.contains_key(&CacheKey::UnifyingSlot {
-                receiver_uid: "DA2699E1".into(),
-                slot: 2,
-            }),
-            "unifying entries are slot-keyed, so a re-pair while the agent is \
-             down could hand them to a different device — never persisted"
+            restored.contains_key(&unifying_key),
+            "a Unifying unit id is a physical identity and survives restart"
         );
     }
 
@@ -302,9 +297,24 @@ mod tests {
     /// not read. Re-probing is always correct; guessing is not.
     #[test]
     fn a_foreign_schema_yields_a_cold_start() {
-        let mut snapshot = ProbeCacheSnapshot::of(&HashMap::new());
-        snapshot.version = SCHEMA_VERSION + 1;
-
-        assert!(snapshot.into_entries().is_empty());
+        let cache = HashMap::from([(
+            CacheKey::Bolt {
+                unit_id: [1, 2, 3, 4],
+            },
+            Cached {
+                probe: ProbedFeatures::default(),
+                battery: None,
+                events: EventFeatureIndices::default(),
+                channel: None,
+            },
+        )]);
+        assert_eq!(ProbeCacheSnapshot::of(&cache).into_entries().len(), 1);
+        // Both pre-merge branches used v3 with incompatible entry shapes.
+        // A future schema is equally unsafe to adopt without validation.
+        for version in [SCHEMA_VERSION - 1, SCHEMA_VERSION + 1] {
+            let mut snapshot = ProbeCacheSnapshot::of(&cache);
+            snapshot.version = version;
+            assert!(snapshot.into_entries().is_empty());
+        }
     }
 }

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{collections::HashMap, sync::Arc};
 
 use futures_concurrency::future::Join as _;
 use hidpp::{
@@ -14,7 +14,9 @@ use hidpp::{
         },
     },
 };
-use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
+use openlogi_core::device::{
+    DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
+};
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
@@ -23,10 +25,11 @@ use super::mappings::{map_kind, map_unifying_kind, resolve_device_kind};
 use crate::backend::NodeInfo;
 use crate::channel::route::DIRECT_DEVICE_INDEX;
 
-use super::cache::{CacheKey, CacheOutcome, Cached, is_stale, probe_or_reuse, seen};
+use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse, seen};
 use super::features::ProbedFeatures;
 use super::{
-    ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
+    ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_RECEIVER_SLOTS, UNIFYING_CACHED_SLOT_PROBE,
+    UNIFYING_SLOT_PROBE,
 };
 
 /// One node probe's verdict about its own trustworthiness. Three-valued on
@@ -96,22 +99,21 @@ pub(super) async fn probe_one(
     info: NodeInfo,
     channel: Arc<HidppChannel>,
     cache: &HashMap<CacheKey, Cached>,
-    now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     match receiver::detect(Arc::clone(&channel)) {
         Some(Receiver::Bolt(bolt)) => {
-            probe_bolt_receiver(channel, info, bolt, cache, now, subscriptions).await
+            probe_bolt_receiver(channel, info, bolt, cache, subscriptions).await
         }
         Some(Receiver::Unifying(unifying)) => {
-            probe_unifying_receiver(channel, info, unifying, cache, now, subscriptions).await
+            probe_unifying_receiver(channel, info, unifying, cache, subscriptions).await
         }
         None | Some(_) => {
             // No recognised receiver — this might be a directly-paired device
             // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
             // addresses the device's own features. Probe in case it answers.
             // P2.4 — verified path; no Bolt-pairing slot indirection needed.
-            probe_direct(channel, &info, cache, now, subscriptions).await
+            probe_direct(channel, &info, cache, subscriptions).await
         }
     }
 }
@@ -121,7 +123,6 @@ async fn probe_bolt_receiver(
     info: NodeInfo,
     bolt: BoltReceiver,
     cache: &HashMap<CacheKey, Cached>,
-    now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     let unique_id = bolt.get_unique_id().await.ok();
@@ -140,7 +141,7 @@ async fn probe_bolt_receiver(
     // (wrong unit id / online / kind). They are cheap register reads, so
     // serializing them costs little.
     let mut identities = Vec::new();
-    for slot in 1u8..=MAX_BOLT_SLOTS {
+    for slot in 1u8..=MAX_RECEIVER_SLOTS {
         if let Some(identity) =
             read_bolt_slot_identity(&bolt, &channel, by_slot.get(&slot), slot).await
         {
@@ -156,7 +157,7 @@ async fn probe_bolt_receiver(
     // device list stable across ticks without an explicit sort.
     let slot_results = identities
         .iter()
-        .map(|identity| walk_bolt_slot(&channel, identity, cache, now, subscriptions))
+        .map(|identity| walk_bolt_slot(&channel, identity, cache, subscriptions))
         .collect::<Vec<_>>()
         .join()
         .await;
@@ -211,7 +212,6 @@ async fn probe_unifying_receiver(
     info: NodeInfo,
     unifying: UnifyingReceiver,
     cache: &HashMap<CacheKey, Cached>,
-    now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     // Pairing count is the health gate for this path: without it the result is
@@ -229,84 +229,69 @@ async fn probe_unifying_receiver(
     debug!(pairing_count, "receiver reports pairing count");
     let unique_id = unifying.get_unique_id().await.ok();
 
-    // Trigger device-arrival events and collect one event per paired slot.
-    // Each event carries the slot index, kind, wpid, and a link-status bit —
-    // enough to build a PairedDevice entry, online or not.
-    //
-    // Note: the Unifying `0xB5/0x5N` pairing-info register uses a different
-    // sub-register base than Bolt, so paired slots are not polled directly.
-    // A slot whose re-broadcast goes missing this tick cannot be backfilled
-    // until that register format is resolved.
-    //
-    // The drain is therefore the *only* device source on this path, so a
-    // failed arrival trigger is "couldn't check", not "no devices online":
-    // settle it as a failed probe and let the ledger replay the last snapshot.
-    let Some(connections) =
-        drain_device_arrival_unifying(&unifying, pairing_count, subscriptions).await
-    else {
-        return NodeProbe::failed();
-    };
-    debug!(events = connections.len(), "drained device-arrival events");
-
-    // The receiver can re-broadcast the same 0x41 for a slot more than once per
-    // trigger, so keep one connection per slot — otherwise the device is listed
-    // twice. Last write wins: a later event carries the freshest online flag.
-    let mut connections: Vec<_> = connections
+    // Arrival events remain the liveness authority, but they are not an
+    // inventory authority: a sleeping device often emits no event at all.
+    // Read every occupied slot from the receiver registers as the durable
+    // inventory, then overlay the freshest event's online bit when present.
+    let arrivals = drain_device_arrival_unifying(&unifying, pairing_count, subscriptions).await;
+    let arrival_ok = arrivals.is_some();
+    let by_slot: HashMap<u8, UnifyingDeviceConnection> = arrivals
+        .unwrap_or_default()
         .into_iter()
-        .map(|c| (c.index, c))
-        .collect::<HashMap<_, _>>()
-        .into_values()
+        .map(|connection| (connection.index, connection))
         .collect();
-    // HashMap iteration is unordered; sort by slot so the device list is stable
-    // across probe cycles instead of jittering.
-    connections.sort_by_key(|c| c.index);
+    debug!(events = by_slot.len(), "drained device-arrival events");
 
-    // Probe all online slots concurrently so a slow HID++ 2.0 feature walk on
-    // one device doesn't push the next slot past the PROBE_BUDGET deadline.
-    // Pass the receiver UID so each slot's cache key is scoped to this specific
-    // receiver — two Unifying receivers sharing a slot number must not share a
-    // cache entry (different devices, different capabilities).
-    let receiver_uid_fallback;
-    let receiver_uid = if let Some(uid) = unique_id.as_deref() {
-        uid
-    } else {
-        // UID fetch failed — use the product ID as a weaker discriminant so
-        // two receivers with the same PID still collide, but a receiver and a
-        // direct device never share a cache entry.
-        tracing::warn!("Unifying receiver UID unavailable; cache isolation may be degraded");
-        receiver_uid_fallback = format!("pid:{:04x}", info.product_id);
-        &receiver_uid_fallback
-    };
-    let slot_results = connections
+    // Pairing and extended-pairing reads all address receiver register 0xB5.
+    // The channel correlates those replies by register rather than by the slot
+    // encoded in the payload, so issue them sequentially. Extended pairing
+    // supplies the physical unit id that lets receiver and Bluetooth routes
+    // resolve to one device without ever merging two same-model units.
+    let mut identities = Vec::new();
+    for slot in 1u8..=MAX_RECEIVER_SLOTS {
+        if let Some(identity) =
+            read_unifying_slot_identity(&unifying, by_slot.get(&slot), slot).await
+        {
+            identities.push(identity);
+            if identities.len() == usize::from(pairing_count) {
+                break;
+            }
+        }
+    }
+
+    // Feature walks address separate device indexes and are safe to run in
+    // parallel. A sleeping slot skips I/O and still surfaces with its stable
+    // receiver-stored identity.
+    let mut slot_results = identities
         .iter()
-        .map(|conn| probe_unifying_slot(&channel, conn, receiver_uid, cache, now, subscriptions))
+        .map(|identity| walk_unifying_slot(&channel, identity, cache, subscriptions))
         .collect::<Vec<_>>()
         .join()
         .await;
 
-    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().flatten().unzip();
+    // Legacy receiver codenames also share register 0xB5. Preserve the old
+    // fallback, but serialize it after feature walks so one missing receiver
+    // ACK cannot block a healthy HID++ 2.0 device from being identified.
+    for (device, _) in &mut slot_results {
+        if device.codename.is_none() && device.capabilities.is_some() {
+            device.codename = read_codename_unifying(&channel, device.slot).await;
+        }
+    }
+
+    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().unzip();
 
     if paired.len() != usize::from(pairing_count) {
         debug!(
             expected = pairing_count,
             found = paired.len(),
-            "arrival drain reported fewer slots than the pairing count"
+            "pairing registers reported fewer slots than the pairing count"
         );
     }
-    // Unlike Bolt, a count/list shortfall is tolerated here: not every
-    // firmware re-broadcasts all paired slots (offline slots in particular can
-    // go missing), and there is no register poll to backfill them, so ledger
-    // health can't ride on it. The
-    // ledger health signal is the pairing-count register answering at all: that
-    // proves the receiver round-trip worked this cycle, while `None` (e.g. a
-    // parked channel) is "couldn't fully check" — the ledger then replays the
-    // last good snapshot instead of presenting a possibly-empty list (#218).
-    //
-    // The one-shot CLI path still needs a retry when the count says more
-    // devices may appear after a late arrival drain. Report that separately as
-    // `complete: false`; the unchanged-inventory fallback stops expected
-    // offline Unifying shortfalls after they stabilize.
     let complete = paired.len() == usize::from(pairing_count);
+    // A missing arrival trigger means online state was not checked. Publish
+    // the register inventory as a fallback only after the ledger's normal
+    // failure grace; until then replay the last-good liveness snapshot.
+    let healthy = complete && arrival_ok;
 
     NodeProbe {
         inventory: Some(DeviceInventory {
@@ -318,9 +303,76 @@ async fn probe_unifying_receiver(
             },
             paired,
         }),
-        verdict: ProbeVerdict::Healthy { complete },
+        verdict: ProbeVerdict::healthy_when(healthy),
         outcomes,
     }
+}
+
+/// Receiver-stored identity for one occupied Unifying slot.
+///
+/// The unit id is physical-device identity; slot and WPID are only route/model
+/// metadata. An all-zero unit id remains unkeyed and is never cached.
+pub(super) struct UnifyingSlotIdentity {
+    pub(super) slot: u8,
+    pub(super) id: Option<CacheKey>,
+    pub(super) unit_id: [u8; 4],
+    pub(super) online: bool,
+    pub(super) register_kind: DeviceKind,
+    pub(super) wpid: u16,
+}
+
+pub(super) async fn read_unifying_slot_identity(
+    unifying: &UnifyingReceiver,
+    event: Option<&UnifyingDeviceConnection>,
+    slot: u8,
+) -> Option<UnifyingSlotIdentity> {
+    let pairing = match unifying.get_device_pairing_information(slot).await {
+        Ok(pairing) => Some(pairing),
+        Err(error) => {
+            debug!(slot, ?error, "Unifying slot empty or unreadable");
+            None
+        }
+    };
+    // Older Nano/Lightspeed receivers may emit arrivals without implementing
+    // the Unifying pairing registers. Retain that authoritative observation,
+    // but never invent a physical unit id or reuse another slot's cache.
+    let (register_kind, wpid) = match (pairing.as_ref(), event) {
+        (Some(pairing), _) => (map_unifying_kind(pairing.kind), pairing.wpid),
+        (None, Some(connection)) => (map_unifying_kind(connection.kind), connection.wpid),
+        (None, None) => return None,
+    };
+    let unit_id = if pairing.is_some() {
+        match unifying.get_device_extended_pairing_information(slot).await {
+            Ok(extended) => extended.unit_id,
+            Err(error) => {
+                debug!(slot, ?error, "Unifying extended identity unavailable");
+                [0; 4]
+            }
+        }
+    } else {
+        [0; 4]
+    };
+    // A late arrival for a previous slot occupant cannot establish liveness
+    // for a different WPID now stored in the receiver's pairing register.
+    let online = event.is_some_and(|connection| connection.online && connection.wpid == wpid);
+    let id = (unit_id != [0; 4]).then_some(CacheKey::Unifying { unit_id });
+    debug!(
+        slot,
+        online,
+        wpid = format_args!("{wpid:04x}"),
+        ?register_kind,
+        ?unit_id,
+        has_event = event.is_some(),
+        "Unifying paired slot"
+    );
+    Some(UnifyingSlotIdentity {
+        slot,
+        id,
+        unit_id,
+        online,
+        register_kind,
+        wpid,
+    })
 }
 
 /// Identity read from the receiver's registers for one occupied Bolt slot
@@ -395,7 +447,6 @@ async fn walk_bolt_slot(
     channel: &Arc<HidppChannel>,
     identity: &BoltSlotIdentity,
     cache: &HashMap<CacheKey, Cached>,
-    now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
 ) -> (PairedDevice, CacheOutcome) {
     let &BoltSlotIdentity {
@@ -415,15 +466,7 @@ async fn walk_bolt_slot(
     // mirroring the Unifying path (#218).
     let probe_result = timeout(
         BOLT_SLOT_PROBE,
-        probe_or_reuse(
-            channel,
-            slot,
-            id.clone(),
-            cached,
-            online,
-            now,
-            subscriptions,
-        ),
+        probe_or_reuse(channel, slot, id.clone(), cached, online, subscriptions),
     )
     .await;
     let (probe, outcome) = if let Ok(r) = probe_result {
@@ -487,7 +530,6 @@ async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &NodeInfo,
     cache: &HashMap<CacheKey, Cached>,
-    now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
     let id = CacheKey::Direct(info.id.clone());
@@ -500,7 +542,6 @@ async fn probe_direct(
         Some(id),
         cached,
         true,
-        now,
         subscriptions,
     )
     .await;
@@ -627,10 +668,9 @@ async fn drain_device_arrival(
 }
 
 /// `None` when the receiver could not be asked: the arrival trigger failed,
-/// or the notification-flag fallback write did. Unlike Bolt (whose paired
-/// list comes from the slot registers), the drain is the only Unifying device
-/// source, so the caller must treat that as a failed probe rather than an
-/// empty receiver.
+/// or the notification-flag fallback write did. Pairing registers still carry
+/// identity, but only the drain establishes current liveness; a failed drain
+/// must not publish an authoritative offline snapshot.
 async fn drain_device_arrival_unifying(
     unifying: &UnifyingReceiver,
     pairing_count: u8,
@@ -693,31 +733,19 @@ async fn drain_device_arrival_unifying(
     }
 }
 
-/// Probe a Unifying slot from a live device-connection event.
-///
-/// Device-arrival events carry the slot index, kind, wpid, and online status —
-/// enough to surface an entry for every currently-connected device. The
-/// unit_id (needed for stable caching across ticks) is not available without a
-/// working `get_device_pairing_information` call; we derive a stable cache key
-/// from the receiver UID + slot so the feature-table walk is amortised at ~30s
-/// and two receivers sharing a slot number don't collide in the cache.
-pub(super) async fn probe_unifying_slot(
+/// Walk one Unifying slot using the receiver-stored physical identity read in
+/// phase 1. Sleeping devices perform no device I/O but still carry their unit
+/// id into the inventory, allowing an offline receiver route to reconcile with
+/// the same unit's Bluetooth route.
+pub(super) async fn walk_unifying_slot(
     channel: &Arc<HidppChannel>,
-    event: &UnifyingDeviceConnection,
-    receiver_uid: &str,
+    identity: &UnifyingSlotIdentity,
     cache: &HashMap<CacheKey, Cached>,
-    now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
-) -> Option<(PairedDevice, CacheOutcome)> {
-    let slot = event.index;
-    // Cache key: full receiver serial + slot so two Unifying receivers with
-    // a device on the same slot number never share a cache entry.
-    let id = CacheKey::UnifyingSlot {
-        receiver_uid: receiver_uid.to_string(),
-        slot,
-    };
-    let cached = cache.get(&id);
-    let register_kind = map_unifying_kind(event.kind);
+) -> (PairedDevice, CacheOutcome) {
+    let slot = identity.slot;
+    let id = identity.id.clone();
+    let cached = id.as_ref().and_then(|key| cache.get(key));
 
     // The 0x41 re-broadcast is the receiver's own slot report and its
     // link-status bit is the liveness authority (Solaar's trigger scan trusts
@@ -726,16 +754,15 @@ pub(super) async fn probe_unifying_slot(
     // announced itself into "offline" — and don't probe an offline slot at
     // all, which would burn the budget on a link the receiver just reported
     // as not established.
-    let probe_budget = unifying_probe_budget(cached, now);
+    let probe_budget = unifying_probe_budget(cached, channel);
     let probe_result = timeout(
         probe_budget,
         probe_or_reuse(
             channel,
             slot,
-            Some(id.clone()),
+            id.clone(),
             cached,
-            event.online,
-            now,
+            identity.online,
             subscriptions,
         ),
     )
@@ -746,26 +773,15 @@ pub(super) async fn probe_unifying_slot(
         debug!(slot, budget = ?probe_budget,
             "Unifying slot probe timed out; using cached data if available");
         let probe = cached.map_or_else(ProbedFeatures::default, |entry| entry.probe.clone());
-        (probe, CacheOutcome::Seen(id))
+        (probe, seen(id))
     };
 
-    // HID++ 2.0's marketing name is the same identity we need for display and
-    // avoids another receiver-register round trip. Keep the legacy codename
-    // read only for a completed feature walk that did not expose a name; never
-    // put it in front of the feature probe, where one missing receiver ACK can
-    // otherwise starve a healthy Lightspeed mouse forever.
-    let codename = if let Some(name) = probe.marketing_name.clone() {
-        Some(name)
-    } else if probe.capabilities.is_some() {
-        read_codename_unifying(channel, slot).await
-    } else {
-        None
-    };
+    let codename = probe.marketing_name.clone();
     debug!(
         slot,
-        online = event.online,
-        wpid = format_args!("{:04x}", event.wpid),
-        kind = ?event.kind,
+        online = identity.online,
+        wpid = format_args!("{:04x}", identity.wpid),
+        kind = ?identity.register_kind,
         codename = ?codename,
         "unifying paired slot"
     );
@@ -773,18 +789,23 @@ pub(super) async fn probe_unifying_slot(
     let device = assemble_unifying_device(
         slot,
         codename,
-        event.wpid,
-        register_kind,
+        identity.wpid,
+        identity.unit_id,
+        identity.register_kind,
         probe,
-        event.online,
+        identity.online,
     );
-    Some((device, outcome))
+    (device, outcome)
 }
 
-/// A fresh cache hit needs only an optional battery refresh; first-sight and
-/// stale entries retain the larger budget needed for a complete feature walk.
-pub(super) fn unifying_probe_budget(cached: Option<&Cached>, now: Instant) -> std::time::Duration {
-    if cached.is_some_and(|entry| !is_stale(entry, now)) {
+/// A cache hit needs only an optional battery refresh; first sight retains the
+/// larger budget needed for a complete feature walk. A cache bound to a
+/// replaced channel also gets the full budget for its one validation walk.
+pub(super) fn unifying_probe_budget(
+    cached: Option<&Cached>,
+    channel: &Arc<HidppChannel>,
+) -> std::time::Duration {
+    if cached.is_some_and(|entry| !entry.needs_validation(channel)) {
         UNIFYING_CACHED_SLOT_PROBE
     } else {
         UNIFYING_SLOT_PROBE
@@ -795,10 +816,34 @@ pub(super) fn assemble_unifying_device(
     slot: u8,
     codename: Option<String>,
     wpid: u16,
+    unit_id: [u8; 4],
     register_kind: DeviceKind,
-    probe: ProbedFeatures,
+    mut probe: ProbedFeatures,
     online: bool,
 ) -> PairedDevice {
+    // The extended pairing register is readable even while the device sleeps
+    // and is the same physical unit id HID++ 2.0 reports over Bluetooth. Fold
+    // it into the model payload so downstream identity resolution can unify
+    // routes without any model-name heuristic. A HID++ 1.0/offline device may
+    // have no feature-table model info at all; synthesize only the fields the
+    // receiver authoritatively owns.
+    if unit_id != [0; 4] {
+        if let Some(model) = probe.model_info.as_mut() {
+            model.unit_id = unit_id;
+        } else {
+            probe.model_info = Some(DeviceModelInfo {
+                entity_count: 0,
+                serial_number: None,
+                unit_id,
+                transports: DeviceTransports {
+                    equad: true,
+                    ..DeviceTransports::default()
+                },
+                model_ids: [wpid, 0, 0],
+                extended_model_id: 0,
+            });
+        }
+    }
     PairedDevice {
         slot,
         codename,

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use hidpp::protocol::v10::{Message, MessageHeader};
 use hidpp::receiver::unifying::{Event as UnifyingEvent, decode_notification};
@@ -10,14 +9,14 @@ use openlogi_core::device::{
 };
 
 use super::cache::{
-    CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_INTERVAL, backfill_identity,
-    is_stale, keep_known_capabilities,
+    CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, backfill_identity, keep_known_capabilities,
 };
 use super::events::EventFeatureIndices;
 use super::features::ProbedFeatures;
 use super::probe::{
-    NodeProbe, ProbeVerdict, assemble_bolt_probe, assemble_unifying_device,
-    parse_codename_unifying, preferred_direct_codename, probe_unifying_slot, unifying_probe_budget,
+    NodeProbe, ProbeVerdict, UnifyingSlotIdentity, assemble_bolt_probe, assemble_unifying_device,
+    parse_codename_unifying, preferred_direct_codename, read_unifying_slot_identity,
+    unifying_probe_budget, walk_unifying_slot,
 };
 use super::{
     ChannelCache, Enumerator, ONESHOT_ATTEMPTS, OneShotScan, ScanPass, UNIFYING_CACHED_SLOT_PROBE,
@@ -32,9 +31,95 @@ fn cache_entry() -> Cached {
     Cached {
         probe: ProbedFeatures::default(),
         battery: None,
+        channel: None,
         events: EventFeatureIndices::default(),
-        probed_at: Instant::now(),
     }
+}
+
+#[tokio::test]
+async fn live_unifying_arrival_survives_unsupported_pairing_registers() {
+    use hidpp::receiver::unifying::Receiver;
+
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(|request| {
+        Some(vec![
+            0x10, request[1], 0x8f, request[2], request[3], 0x02, 0,
+        ])
+    });
+    let mut channel = scripted_channel(raw).await;
+    Arc::get_mut(&mut channel)
+        .expect("unshared test channel")
+        .product_id = 0xc52b;
+    let receiver = Receiver::new(channel).expect("known Unifying receiver");
+    let message = Message::Short(
+        MessageHeader {
+            device_index: 1,
+            sub_id: 0x41,
+        },
+        [0x04, 0x02, 0xb8, 0x40],
+    );
+    let Some(UnifyingEvent::DeviceConnection(arrival)) = decode_notification(&message) else {
+        panic!("expected a device-connection event");
+    };
+
+    let identity = read_unifying_slot_identity(&receiver, Some(&arrival), 1)
+        .await
+        .expect("a live arrival must not disappear when register 0xb5 is unsupported");
+    assert!(identity.online);
+    assert_eq!(identity.wpid, arrival.wpid);
+    assert_eq!(identity.register_kind, DeviceKind::Mouse);
+    assert_eq!(identity.unit_id, [0; 4]);
+    assert!(identity.id.is_none(), "no stable unit id was observed");
+    assert_eq!(handle.written_reports().len(), 1);
+
+    assert!(
+        read_unifying_slot_identity(&receiver, None, 2)
+            .await
+            .is_none(),
+        "an unreadable slot without an arrival is not an observed device"
+    );
+}
+
+#[tokio::test]
+async fn late_arrival_cannot_mark_a_different_paired_device_online() {
+    use hidpp::receiver::unifying::Receiver;
+
+    let (raw, _) = ScriptedRawHidChannel::with_responder(|request| {
+        let mut response = vec![0; 20];
+        response[..5].copy_from_slice(&[0x11, 0xff, 0x83, 0xb5, request[4]]);
+        match request[4] {
+            0x22 => {
+                response[7..9].copy_from_slice(&[0x40, 0x96]);
+                response[11] = 0x08;
+            }
+            0x32 => response[5..9].copy_from_slice(&[1, 2, 3, 4]),
+            _ => return None,
+        }
+        Some(response)
+    });
+    let mut channel = scripted_channel(raw).await;
+    Arc::get_mut(&mut channel)
+        .expect("unshared test channel")
+        .product_id = 0xc52b;
+    let receiver = Receiver::new(channel).expect("known Unifying receiver");
+    let message = Message::Short(
+        MessageHeader {
+            device_index: 3,
+            sub_id: 0x41,
+        },
+        [0x04, 0x02, 0xb8, 0x40],
+    );
+    let Some(UnifyingEvent::DeviceConnection(arrival)) = decode_notification(&message) else {
+        panic!("expected a device-connection event");
+    };
+
+    let identity = read_unifying_slot_identity(&receiver, Some(&arrival), 3)
+        .await
+        .expect("pairing-register identity");
+    assert!(!identity.online);
+    assert_eq!(identity.wpid, 0x4096);
+    assert_eq!(identity.register_kind, DeviceKind::Trackball);
+    assert_eq!(identity.unit_id, [1, 2, 3, 4]);
+    assert!(matches!(identity.id, Some(CacheKey::Unifying { .. })));
 }
 
 #[test]
@@ -48,15 +133,12 @@ fn direct_codename_prefers_hidpp_marketing_name_over_generic_os_name() {
 
 #[test]
 fn cache_dirty_tracks_only_persistable_keys() {
-    // A system whose devices never persist (direct-only, or Unifying) must not
+    // A system whose devices never persist (direct-only) must not
     // rewrite probe-cache.json on every refresh pass: the file's content
     // wouldn't change.
     let mut e = Enumerator::with_backend(ScriptedBackend::new(Vec::new()));
-    let unifying = CacheKey::UnifyingSlot {
-        receiver_uid: "DA2699E1".into(),
-        slot: 1,
-    };
-    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying.clone(), cache_entry())]);
+    let direct = CacheKey::Direct("node-1".to_string().into());
+    e.apply_outcomes(vec![CacheOutcome::Fresh(direct.clone(), cache_entry())]);
     assert!(
         !e.cache_dirty,
         "non-persistable fresh probe dirtied the cache"
@@ -67,10 +149,10 @@ fn cache_dirty_tracks_only_persistable_keys() {
     for _ in 0..=CACHE_MISS_GRACE {
         e.evict_unseen(&nobody);
     }
-    assert!(!e.cache.contains_key(&unifying), "entry should be evicted");
+    assert!(!e.cache.contains_key(&direct), "entry should be evicted");
     assert!(!e.cache_dirty, "non-persistable eviction dirtied the cache");
 
-    // A Bolt probe is what the file stores — that one dirties it.
+    // Receiver probes have physical unit ids and do dirty the snapshot.
     let bolt = CacheKey::Bolt {
         unit_id: [1, 2, 3, 4],
     };
@@ -78,6 +160,15 @@ fn cache_dirty_tracks_only_persistable_keys() {
     assert!(
         e.cache_dirty,
         "persistable fresh probe must dirty the cache"
+    );
+    e.cache_dirty = false;
+    let unifying = CacheKey::Unifying {
+        unit_id: [5, 6, 7, 8],
+    };
+    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying, cache_entry())]);
+    assert!(
+        e.cache_dirty,
+        "a Unifying physical unit id must be persistable"
     );
 }
 
@@ -123,40 +214,26 @@ fn being_seen_resets_the_miss_counter() {
     );
 }
 
-#[test]
-fn cached_probe_is_reused_until_refresh_interval() {
-    let probed_at = Instant::now();
-    let cached = Cached {
-        probe: ProbedFeatures::default(),
-        battery: None,
-        events: EventFeatureIndices::default(),
-        probed_at,
-    };
-    assert!(!is_stale(&cached, probed_at), "same instant is fresh");
-    assert!(
-        !is_stale(&cached, probed_at + Duration::from_secs(29)),
-        "just under the window is still fresh"
-    );
-    assert!(
-        is_stale(&cached, probed_at + REFRESH_INTERVAL),
-        "at the window the probe is refreshed"
-    );
-}
-
-#[test]
-fn unifying_cache_hits_use_only_the_battery_refresh_budget() {
-    let cached = cache_entry();
+#[tokio::test]
+async fn unifying_cache_hits_use_only_the_battery_refresh_budget() {
+    let (raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+    let channel = scripted_channel(raw).await;
+    let mut cached = cache_entry();
+    cached.channel = Some(Arc::downgrade(&channel));
     assert_eq!(
-        unifying_probe_budget(Some(&cached), cached.probed_at),
+        unifying_probe_budget(Some(&cached), &channel),
         UNIFYING_CACHED_SLOT_PROBE
     );
+
+    let (replacement_raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+    let replacement = scripted_channel(replacement_raw).await;
     assert_eq!(
-        unifying_probe_budget(Some(&cached), cached.probed_at + REFRESH_INTERVAL),
+        unifying_probe_budget(Some(&cached), &replacement),
         UNIFYING_SLOT_PROBE,
-        "stale entries still get enough time for a full feature walk"
+        "a replacement channel needs enough time for one validation walk"
     );
     assert_eq!(
-        unifying_probe_budget(None, Instant::now()),
+        unifying_probe_budget(None, &channel),
         UNIFYING_SLOT_PROBE,
         "first sight still gets the full feature-walk budget"
     );
@@ -184,9 +261,17 @@ async fn offline_arrival_rebroadcasts_surface_without_probing_the_device() {
     let writes_before = handle.written_reports().len();
 
     let cache = HashMap::new();
-    let (device, _) = probe_unifying_slot(&channel, &event, "SERIAL", &cache, Instant::now(), None)
-        .await
-        .expect("an offline slot still surfaces from its re-broadcast");
+    let identity = UnifyingSlotIdentity {
+        slot: event.index,
+        id: Some(CacheKey::Unifying {
+            unit_id: [1, 2, 3, 4],
+        }),
+        unit_id: [1, 2, 3, 4],
+        online: event.online,
+        register_kind: DeviceKind::Mouse,
+        wpid: event.wpid,
+    };
+    let (device, _) = walk_unifying_slot(&channel, &identity, &cache, None).await;
 
     assert!(!device.online);
     assert_eq!(device.wpid, Some(0x4069));
@@ -203,6 +288,7 @@ fn unifying_arrival_liveness_survives_missing_feature_data() {
         1,
         None,
         0x40b8,
+        [0; 4],
         DeviceKind::Mouse,
         ProbedFeatures::default(),
         true,
@@ -593,8 +679,8 @@ fn probed(model_info: Option<DeviceModelInfo>, identity_incomplete: bool) -> Pro
 }
 
 /// A control-table read that fails half way reads exactly like "no haptic
-/// panel", and the answer is memoized for `REFRESH_INTERVAL` — so the Actions Ring
-/// binding would vanish from the GUI for half a minute on a device that has it.
+/// panel", and the answer is memoized for the channel's lifetime — so the
+/// Actions Ring binding would otherwise vanish until the device reconnects.
 #[test]
 fn an_incomplete_capability_walk_keeps_the_last_complete_answer() {
     let mut fresh = probed(None, false);

--- a/crates/openlogi-device/src/session/capture_restore.rs
+++ b/crates/openlogi-device/src/session/capture_restore.rs
@@ -82,7 +82,9 @@ pub enum CaptureSessionOutcome {
     /// Every diverted control was restored before the session returned.
     Restored,
     /// Firmware restoration is incomplete. The caller must retain this token
-    /// and retry it before arming a successor for the same physical device.
+    /// and retry it before arming a successor on the same route. A manager may
+    /// park it while that physical device is captured through another route,
+    /// but must not retry it until that successor has also finished teardown.
     RestorePending(PendingCaptureRestore),
 }
 
@@ -154,6 +156,15 @@ impl fmt::Debug for PendingCaptureRestore {
 }
 
 impl PendingCaptureRestore {
+    /// Route whose feature indices and reporting state this token owns.
+    ///
+    /// Restoration must never retarget these cached protocol values to a
+    /// different transport, even when it reaches the same physical device.
+    #[must_use]
+    pub fn route(&self) -> &DeviceRoute {
+        &self.route
+    }
+
     pub(crate) fn new(
         retired: &SharedChannel,
         reprog: Option<ReprogRestore>,

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -137,6 +137,61 @@ async fn restore_retries_when_inventory_changes_during_an_awaited_write() {
 }
 
 #[tokio::test]
+async fn pending_restore_never_sends_cached_feature_indices_to_another_transport() {
+    let bluetooth = DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xb027,
+    };
+    let receiver = DeviceRoute::Unifying {
+        receiver_uid: "receiver-a".into(),
+        slot: 3,
+    };
+    let (retired_raw, retired_handle) = ScriptedRawHidChannel::with_responder(|_| None);
+    let retired = SharedChannel::new(scripted_channel(retired_raw).await, bluetooth.clone());
+    let pending = PendingCaptureRestore::new(
+        &retired,
+        ReprogRestore::new(
+            0x22,
+            vec![ArmedReporting {
+                cid: reprog_controls::GESTURE_BUTTON_CID,
+                original: reporting(false, None),
+            }],
+        ),
+        None,
+    )
+    .expect("a captured control owns a restore token");
+    assert_eq!(pending.route(), &bluetooth);
+    let registry = ChannelRegistry::default();
+    let (receiver_raw, receiver_handle) =
+        ScriptedRawHidChannel::with_responder(|request| Some(request.to_vec()));
+    registry.replace_node(
+        NodeId::from("receiver-node".to_owned()),
+        [receiver],
+        scripted_channel(receiver_raw).await,
+    );
+
+    let CaptureSessionOutcome::RestorePending(pending) = pending.retry(&registry).await else {
+        panic!("the absent Bluetooth route must retain its own teardown debt");
+    };
+    assert!(receiver_handle.written_reports().is_empty());
+    assert!(retired_handle.written_reports().is_empty());
+
+    let (returning_raw, returning_handle) =
+        ScriptedRawHidChannel::with_responder(|request| Some(request.to_vec()));
+    registry.replace_node(
+        NodeId::from("bluetooth-node".to_owned()),
+        [bluetooth],
+        scripted_channel(returning_raw).await,
+    );
+    assert!(matches!(
+        pending.retry(&registry).await,
+        CaptureSessionOutcome::Restored
+    ));
+    assert_eq!(returning_handle.written_reports().len(), 1);
+    assert!(receiver_handle.written_reports().is_empty());
+}
+
+#[tokio::test]
 async fn failed_setup_rollback_returns_its_restore_capability() {
     let route = DeviceRoute::Direct {
         vendor_id: 0x046d,

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -5,7 +5,8 @@
 //! that path by pre-filtering to the Logitech HID++ vendor collections at
 //! enumeration time (see [`HIDPP_LONG_COLLECTIONS`]) and reporting support
 //! straight from [`hidpp::channel::RawHidChannel::supports_short_long_hidpp`]: USB / receiver
-//! collections carry both reports; BLE-direct collections are long-only, and the
+//! collections carry both reports; BLE-direct collections and the Generic
+//! Desktop fallback exposed by some MX Ergo devices are long-only, and the
 //! `hidpp` channel up-converts outgoing short messages to long for them.
 
 use std::error::Error;
@@ -165,11 +166,27 @@ const HIDPP_LONG_COLLECTIONS: [(u16, u16, bool); 3] = [
     (0xff43, 0x0602, false),
 ];
 
+/// Generic Desktop Controls usage page.
+const GENERIC_DESKTOP_PAGE: u16 = 0x0001;
+/// Generic Desktop mouse usage.
+const GENERIC_DESKTOP_MOUSE: u16 = 0x0002;
+
 /// Whether `(usage_page, usage_id)` is one of the HID++ long-report collections.
 fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
     HIDPP_LONG_COLLECTIONS
         .iter()
         .any(|&(page, usage, _)| (page, usage) == (usage_page, usage_id))
+}
+
+/// Whether this is the fallback collection used by Logitech Bluetooth mice
+/// that do not publish a separate vendor-defined HID++ collection.
+///
+/// Direct Bluetooth product IDs use the `0xb0xx` family (including MX Ergo
+/// `0xb01d` and MX Ergo S `0xb03e`). Receiver and wired product IDs use other
+/// families, so their ordinary mouse collections remain excluded.
+fn is_bluetooth_mouse_fallback(product_id: u16, usage_page: u16, usage_id: u16) -> bool {
+    product_id & 0xff00 == 0xb000
+        && (usage_page, usage_id) == (GENERIC_DESKTOP_PAGE, GENERIC_DESKTOP_MOUSE)
 }
 
 /// Whether the matched HID++ collection exposes only the long report, so short
@@ -188,10 +205,11 @@ fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
         reason = "long-only up-conversion is the non-Windows AsyncHidChannel path"
     )
 )]
-fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
-    HIDPP_LONG_COLLECTIONS
-        .iter()
-        .any(|&(page, usage, long_only)| long_only && (page, usage) == (usage_page, usage_id))
+fn is_long_only_collection(product_id: u16, usage_page: u16, usage_id: u16) -> bool {
+    is_bluetooth_mouse_fallback(product_id, usage_page, usage_id)
+        || HIDPP_LONG_COLLECTIONS
+            .iter()
+            .any(|&(page, usage, long_only)| long_only && (page, usage) == (usage_page, usage_id))
 }
 
 /// Process-wide HID backend, created once and reused for every enumeration.
@@ -253,7 +271,8 @@ pub(crate) async fn enumerate_devices() -> Result<Vec<async_hid::Device>, Backen
             pid = format_args!("{:04x}", d.product_id),
             usage_page = format_args!("{:#06x}", d.usage_page),
             usage_id = format_args!("{:#06x}", d.usage_id),
-            matched = is_hidpp_long_collection(d.usage_page, d.usage_id),
+            matched = is_hidpp_long_collection(d.usage_page, d.usage_id)
+                || is_bluetooth_mouse_fallback(d.product_id, d.usage_page, d.usage_id),
             "logitech HID node"
         );
     }
@@ -265,14 +284,22 @@ pub(crate) async fn enumerate_devices() -> Result<Vec<async_hid::Device>, Backen
 ///
 /// Wraps [`is_hidpp_candidate`] with the parts only this backend can answer:
 /// the platform node id needed to recognise a `hid-logitech-dj` child node.
-pub(crate) fn is_hidpp_node(device: &async_hid::Device) -> bool {
-    is_hidpp_candidate(
+pub(crate) fn is_hidpp_node(device: &async_hid::Device, vendor_collection_available: bool) -> bool {
+    is_preferred_hidpp_candidate(
         device.vendor_id,
         device.product_id,
         device.usage_page,
         device.usage_id,
         is_receiver_child_node(&device.id),
+        vendor_collection_available,
     )
+}
+
+/// Whether this node is a vendor-defined HID++ collection rather than the
+/// Generic Desktop fallback used by a subset of Bluetooth mice.
+pub(crate) fn is_vendor_hidpp_node(device: &async_hid::Device) -> bool {
+    device.vendor_id == LOGITECH_VENDOR_ID
+        && is_hidpp_long_collection(device.usage_page, device.usage_id)
 }
 
 /// Whether an enumerated node belongs to the HID++ channel path.
@@ -289,9 +316,24 @@ fn is_hidpp_candidate(
     receiver_child: bool,
 ) -> bool {
     vendor_id == LOGITECH_VENDOR_ID
-        && is_hidpp_long_collection(usage_page, usage_id)
+        && (is_hidpp_long_collection(usage_page, usage_id)
+            || is_bluetooth_mouse_fallback(product_id, usage_page, usage_id))
         && !matches_litra(vendor_id, product_id, usage_page, usage_id)
         && !receiver_child
+}
+
+/// Apply collection preference after the basic HID++ candidate check.
+fn is_preferred_hidpp_candidate(
+    vendor_id: u16,
+    product_id: u16,
+    usage_page: u16,
+    usage_id: u16,
+    receiver_child: bool,
+    vendor_collection_available: bool,
+) -> bool {
+    is_hidpp_candidate(vendor_id, product_id, usage_page, usage_id, receiver_child)
+        && !(vendor_collection_available
+            && is_bluetooth_mouse_fallback(product_id, usage_page, usage_id))
 }
 
 /// Returns `true` when a HID++ node is a virtual per-device interface created by
@@ -431,7 +473,7 @@ pub(crate) async fn open_hidpp_channel(
         }
         // BLE-direct devices expose only the long HID++ report; flag the channel so
         // it advertises short-unsupported and the `hidpp` channel up-converts shorts.
-        let long_only = is_long_only_collection(info.usage_page, info.usage_id);
+        let long_only = is_long_only_collection(info.product_id, info.usage_page, info.usage_id);
         let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only, device_io);
         let channel = match HidppChannel::from_raw_channel(raw).await {
             Ok(mut c) => {

--- a/crates/openlogi-hid/src/transport/native.rs
+++ b/crates/openlogi-hid/src/transport/native.rs
@@ -4,7 +4,7 @@
 //! through this type. It is the only implementor in the tree today; a scripted
 //! one for tests and a WebHID one under wasm are the reasons the trait exists.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock, Mutex, PoisonError};
 
 use async_hid::{AsyncHidWrite as _, Device, DeviceWriter};
@@ -17,8 +17,8 @@ use openlogi_device::backend::{
 };
 
 use super::{
-    device_io_gate, device_io_suspended, enumerate_devices, is_hidpp_node, open_hidpp_channel,
-    watch_nodes,
+    device_io_gate, device_io_suspended, enumerate_devices, is_hidpp_node, is_vendor_hidpp_node,
+    open_hidpp_channel, watch_nodes,
 };
 
 /// One logical top-level collection exposed by an OS HID node.
@@ -137,11 +137,22 @@ impl HidBackend for NativeBackend {
     }
 
     async fn enumerate_hidpp(&self) -> Result<Vec<NodeInfo>, BackendError> {
-        Ok(self
-            .refresh()
-            .await?
+        let devices = self.refresh().await?;
+        // On macOS every logical collection of one physical device carries the
+        // same IOKit registry id. Suppress its Generic Desktop fallback only
+        // when that exact physical node also exposes a vendor HID++ collection;
+        // keying by PID alone would hide a second same-model mouse.
+        let vendor_collections: HashSet<(NodeId, u16)> = devices
             .iter()
-            .filter(|device| is_hidpp_node(device))
+            .filter(|device| is_vendor_hidpp_node(device))
+            .map(|device| (super::node_id(device), device.product_id))
+            .collect();
+        Ok(devices
+            .iter()
+            .filter(|device| {
+                let key = (super::node_id(device), device.product_id);
+                is_hidpp_node(device, vendor_collections.contains(&key))
+            })
             .map(|device| super::node_info(device))
             .collect())
     }

--- a/crates/openlogi-hid/src/transport/tests.rs
+++ b/crates/openlogi-hid/src/transport/tests.rs
@@ -19,10 +19,36 @@ fn litra_ble_collection_is_not_a_hidpp_candidate() {
 
 #[test]
 fn only_ble_collection_is_long_only() {
-    assert!(is_long_only_collection(0xff43, 0x0202)); // BLE-direct → short-unsupported
-    assert!(!is_long_only_collection(0xff00, 0x0002)); // USB / receiver carries both reports
-    assert!(!is_long_only_collection(0xff43, 0x0602)); // wired G-series keyboard carries both
-    assert!(!is_long_only_collection(0x0001, 0x0002)); // not a HID++ collection at all
+    assert!(is_long_only_collection(0xb023, 0xff43, 0x0202)); // BLE vendor collection
+    assert!(is_long_only_collection(0xb01d, 0x0001, 0x0002)); // MX Ergo BT fallback
+    assert!(is_long_only_collection(0xb027, 0x0001, 0x0002)); // Ergo M575 BT fallback
+    assert!(is_long_only_collection(0xb03e, 0x0001, 0x0002)); // MX Ergo S BT fallback
+    assert!(!is_long_only_collection(0xc548, 0xff00, 0x0002)); // receiver has both
+    assert!(!is_long_only_collection(0xc33c, 0xff43, 0x0602)); // wired has both
+    assert!(!is_long_only_collection(0xc548, 0x0001, 0x0002)); // receiver mouse node
+}
+
+#[test]
+fn trackball_bluetooth_mouse_collection_is_a_candidate() {
+    assert!(is_hidpp_candidate(0x046d, 0xb01d, 0x0001, 0x0002, false));
+    assert!(is_hidpp_candidate(0x046d, 0xb027, 0x0001, 0x0002, false));
+    assert!(is_hidpp_candidate(0x046d, 0xb03e, 0x0001, 0x0002, false));
+    assert!(!is_hidpp_candidate(0x046d, 0xc548, 0x0001, 0x0002, false));
+    assert!(!is_hidpp_candidate(0x046d, 0xb01d, 0x0001, 0x0006, false));
+    assert!(!is_hidpp_candidate(0x1234, 0xb01d, 0x0001, 0x0002, false));
+}
+
+#[test]
+fn vendor_collection_wins_over_generic_bluetooth_fallback() {
+    assert!(is_preferred_hidpp_candidate(
+        0x046d, 0xb023, 0xff43, 0x0202, false, true,
+    ));
+    assert!(!is_preferred_hidpp_candidate(
+        0x046d, 0xb023, 0x0001, 0x0002, false, true,
+    ));
+    assert!(is_preferred_hidpp_candidate(
+        0x046d, 0xb01d, 0x0001, 0x0002, false, false,
+    ));
 }
 
 #[test]

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{FutureExt, channel::oneshot, select};
+use futures::{FutureExt, channel::oneshot, lock::Mutex as AsyncMutex, select};
 use tracing::trace;
 
 use crate::{nibble::U4, sync::lock};
@@ -163,6 +163,16 @@ pub struct HidppChannel {
     /// The request ID assigned to the next pending message.
     pending_message_id: AtomicU64,
 
+    /// Serializes complete request/response transactions on this transport.
+    ///
+    /// Fixed/leased software ids make overlapping identical request headers
+    /// indistinguishable. Even with rotating ids, overlapping requests can
+    /// overrun receiver firmware while one
+    /// consumer inventories and another audits capture state. Keep the gate
+    /// for the response wait, not only the report write, so exactly one
+    /// transaction is in flight on a physical channel.
+    request_gate: AsyncMutex<()>,
+
     /// Registered listeners that will receive notifications about incoming
     /// messages.
     message_listeners: Arc<Mutex<HashMap<u32, MessageListener>>>,
@@ -312,6 +322,7 @@ impl HidppChannel {
             sw_id_policy: SwIdPolicy::default(),
             pending_messages: pending_messages_rc,
             pending_message_id: AtomicU64::new(1),
+            request_gate: AsyncMutex::new(()),
             next_listener_hdl: AtomicU32::new(1),
             message_listeners: message_listeners_rc,
             read_thread_close: Some(close_sender),
@@ -403,13 +414,17 @@ impl HidppChannel {
     }
 
     /// Sends a HID++ message across the channel and waits for a response,
-    /// bounding the whole request — the report write plus the wait for a
-    /// matching response — by `timeout`.
+    /// bounding the report write plus the wait for a matching response by
+    /// `timeout` once this request reaches the transport.
     ///
-    /// On elapse the request's pending entry is removed (concurrent in-flight
-    /// requests are unaffected) and [`ChannelError::Timeout`] is returned; a
-    /// response that still arrives later reaches message listeners as an
-    /// unmatched message.
+    /// On elapse the request's pending entry is removed and
+    /// [`ChannelError::Timeout`] is returned; a response that still arrives
+    /// later reaches message listeners as an unmatched message. Requests on
+    /// one channel are serialized, including when software ids rotate. Queue
+    /// time is deliberately separate from the device-response timeout: a
+    /// healthy request waiting behind one slow transaction must not be
+    /// misreported as a dead HID channel before it reaches the wire. Callers
+    /// that need a whole-operation deadline can bound this future externally.
     ///
     /// [`Self::send`] uses this with [`SEND_RESPONSE_TIMEOUT`], which suits
     /// requests to a device that may be asleep. Requests that should fail
@@ -432,6 +447,14 @@ impl HidppChannel {
         let (dev, feat, func) = msg.header();
         trace!(dev, feat, func, "hidpp request");
 
+        // Keep one complete transaction in flight so two requests with the same HID++ header
+        // cannot consume each other's response and receiver firmware is never
+        // driven concurrently by inventory and live-control maintenance.
+        // The timeout below starts only after this guard is acquired. Counting
+        // queue contention as transport silence made the capture watchdog
+        // retire healthy receiver channels while inventory owned the wire.
+        let _request_guard = self.request_gate.lock().await;
+
         let pending_id = self.pending_message_id.fetch_add(1, Ordering::SeqCst);
         let pending_request = PendingRequest::register(
             pending_id,
@@ -445,7 +468,7 @@ impl HidppChannel {
         let result = {
             let mut request = std::pin::pin!(
                 async move {
-                    self.send_and_forget(msg).await?;
+                    self.write_message_unlocked(msg).await?;
                     pending_request.receive().await
                 }
                 .fuse()
@@ -475,6 +498,11 @@ impl HidppChannel {
             return Err(ChannelError::MessageTypeNotSupported);
         }
 
+        let _request_guard = self.request_gate.lock().await;
+        self.write_message_unlocked(msg).await
+    }
+
+    async fn write_message_unlocked(&self, msg: HidppMessage) -> Result<(), ChannelError> {
         let mut buf = [0u8; LONG_REPORT_LENGTH];
         let len = msg.write_raw(&mut buf);
         self.raw_channel
@@ -487,8 +515,10 @@ impl HidppChannel {
     /// Write one raw HID report through this channel's already-owned transport.
     ///
     /// Reports must contain `1..=64` bytes, including their report ID. The
-    /// operation is bounded by [`SEND_RESPONSE_TIMEOUT`] and returns the exact
-    /// byte count reported by the transport. This is intended for HID++ report
+    /// transport write is bounded by [`SEND_RESPONSE_TIMEOUT`] and returns the
+    /// exact byte count reported by the transport. Queue time behind another
+    /// transaction is not transport time; callers may impose an outer deadline
+    /// when needed. This is intended for HID++ report
     /// widths such as the 64-byte `0x12` lighting frame that [`HidppMessage`]
     /// cannot represent.
     pub async fn write_raw_report(&self, report: &[u8]) -> Result<usize, ChannelError> {
@@ -505,6 +535,7 @@ impl HidppChannel {
             return Err(ChannelError::InvalidRawReportLength(report.len()));
         }
 
+        let _request_guard = self.request_gate.lock().await;
         let mut write = std::pin::pin!(self.raw_channel.write_report(report).fuse());
         select! {
             result = write => result.map_err(ChannelError::Implementation),

--- a/crates/openlogi-hidpp/src/channel/tests.rs
+++ b/crates/openlogi-hidpp/src/channel/tests.rs
@@ -170,7 +170,7 @@ fn cancelled_send_removes_pending_before_a_late_response() {
 }
 
 #[test]
-fn timeout_removes_only_its_own_pending_message() {
+fn timeout_does_not_remove_the_next_queued_request() {
     futures::executor::block_on(async {
         let (raw, handle) = MockRawHidChannel::new();
         let channel = channel_with_reader(raw).await;
@@ -188,8 +188,8 @@ fn timeout_removes_only_its_own_pending_message() {
             move |candidate| *candidate == slow_response,
             Duration::from_secs(1),
         );
-        // Answer the second request only after the first has timed out, so
-        // a removal that took the wrong entry would fail this test.
+        // Answer the queued request only after the active request has timed
+        // out, so timeout cleanup cannot poison the next transaction.
         let respond_late = async {
             futures_timer::Delay::new(Duration::from_millis(100)).await;
             handle.send_incoming(slow_response).await;
@@ -199,6 +199,83 @@ fn timeout_removes_only_its_own_pending_message() {
 
         assert!(matches!(timed_out.unwrap_err(), ChannelError::Timeout));
         assert_eq!(answered.unwrap(), slow_response);
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn one_channel_has_only_one_request_in_flight() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = channel_with_reader(raw).await;
+        let first_response = short_msg(0x20);
+        let second_response = short_msg(0x21);
+
+        let first = channel.send_with_timeout(
+            short_msg(0x10),
+            move |candidate| *candidate == first_response,
+            Duration::from_secs(1),
+        );
+        let second = channel.send_with_timeout(
+            short_msg(0x11),
+            move |candidate| *candidate == second_response,
+            Duration::from_secs(1),
+        );
+        let respond_in_order = async {
+            wait_for_written_report_count(&handle, 1).await;
+            futures_timer::Delay::new(Duration::from_millis(25)).await;
+            assert_eq!(
+                handle.written_reports().len(),
+                1,
+                "a second request reused the channel software id before the first completed"
+            );
+            handle.send_incoming(first_response).await;
+            wait_for_written_report_count(&handle, 2).await;
+            handle.send_incoming(second_response).await;
+        };
+
+        let (first, second, ()) = futures::join!(first, second, respond_in_order);
+
+        assert_eq!(first.unwrap(), first_response);
+        assert_eq!(second.unwrap(), second_response);
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn queued_request_gets_its_full_wire_timeout_after_the_gate() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = channel_with_reader(raw).await;
+        let first_response = short_msg(0x20);
+        let queued_response = short_msg(0x21);
+
+        let first = channel.send_with_timeout(
+            short_msg(0x10),
+            move |candidate| *candidate == first_response,
+            Duration::from_secs(1),
+        );
+        let queued = channel.send_with_timeout(
+            short_msg(0x11),
+            move |candidate| *candidate == queued_response,
+            Duration::from_millis(25),
+        );
+        let finish_first = async {
+            wait_for_written_report_count(&handle, 1).await;
+            // Keep the first transaction active for far longer than the
+            // queued request's own wire timeout. Queueing is not device
+            // silence, so the second request must still reach the transport.
+            futures_timer::Delay::new(Duration::from_millis(100)).await;
+            handle.send_incoming(first_response).await;
+            wait_for_written_report_count(&handle, 2).await;
+            handle.send_incoming(queued_response).await;
+        };
+
+        let (first, queued, ()) = futures::join!(first, queued, finish_first);
+
+        assert_eq!(first.unwrap(), first_response);
+        assert_eq!(queued.unwrap(), queued_response);
+        assert_eq!(handle.written_reports().len(), 2);
         assert_pending_empty(&channel);
     });
 }
@@ -739,6 +816,18 @@ async fn wait_for_atomic_count(count: &AtomicUsize, expected: usize) {
     }
 
     panic!("timed out waiting for atomic count {expected}");
+}
+
+async fn wait_for_written_report_count(handle: &MockRawHidHandle, expected: usize) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(1) {
+        if handle.written_reports().len() >= expected {
+            return;
+        }
+        futures_timer::Delay::new(Duration::from_millis(10)).await;
+    }
+
+    panic!("timed out waiting for written report count {expected}");
 }
 
 fn mock_error() -> Box<dyn Error + Sync + Send> {

--- a/crates/openlogi-hidpp/src/receiver.rs
+++ b/crates/openlogi-hidpp/src/receiver.rs
@@ -77,4 +77,9 @@ pub enum ReceiverError {
     /// Indicates that a HID++1.0 register access resulted in an error.
     #[error("a HID++1.0 error occurred")]
     Protocol(#[from] Hidpp10Error),
+
+    /// Indicates that a receiver slot outside its supported 1-based range was
+    /// requested.
+    #[error("invalid receiver device index {0}; expected 1 through 6")]
+    InvalidDeviceIndex(u8),
 }

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -4,9 +4,13 @@
 //! 2.4 GHz eQuad radio protocol. It uses HID++ 1.0 registers for receiver
 //! control; paired devices speak HID++ 2.0 once addressed via their slot index.
 //!
-//! The register layout for device enumeration (`0xB5/0x5N`, `0xB5/0x6N`) is
-//! identical to Bolt's. The device-kind encoding differs from Bolt at values 5+
-//! (see [`DeviceKind`]).
+//! Device enumeration follows the Unifying-specific `0xB5/0x2N` pairing,
+//! `0xB5/0x3N` extended-pairing, and `0xB5/0x4N` name sub-registers. Unlike
+//! Bolt's `0x5N`/`0x6N` layout, `N=0` addresses receiver slot 1.
+//! These offsets follow [Solaar's reverse-engineered receiver layout], not
+//! the Bolt feature specification.
+//!
+//! [Solaar's reverse-engineered receiver layout]: https://github.com/pwr-Solaar/Solaar/blob/master/lib/logitech_receiver/receiver.py
 
 use std::sync::Arc;
 
@@ -52,19 +56,17 @@ pub enum InfoSubRegister {
     /// slot count).
     ReceiverInfo = 0x03,
 
-    /// Provides information about a specific paired device. The device index
-    /// (4 bits) must be added to this base address to form the actual
-    /// sub-register: `0x50 | (device_index & 0x0f)`.
-    DevicePairingInformation = 0x50,
+    /// Provides information about a specific paired device. Add the zero-based
+    /// slot number: `0x20 + (device_index - 1)`.
+    DevicePairingInformation = 0x20,
 
-    /// Provides the codename of a specific paired device. The device index (4
-    /// bits) must be added: `0x60 | (device_index & 0x0f)`.
-    ///
-    /// NOTE: `0x60` is the *Bolt* base. Wire-verified Unifying receivers store
-    /// names at base `0x40 + (n-1)` instead, so name reads go directly through
-    /// `read_codename_unifying` in `inventory.rs` rather than this constant —
-    /// don't reuse `DeviceCodename` for Unifying name reads.
-    DeviceCodename = 0x60,
+    /// Provides the stable serial number and report types for a paired device.
+    /// Add the zero-based slot number: `0x30 + (device_index - 1)`.
+    DeviceExtendedPairingInformation = 0x30,
+
+    /// Provides the codename of a specific paired device. Add the zero-based
+    /// slot number: `0x40 + (device_index - 1)`.
+    DeviceCodename = 0x40,
 }
 
 /// Implements the Unifying wireless receiver.
@@ -208,28 +210,40 @@ impl Receiver {
         &self,
         device_index: u8,
     ) -> Result<DevicePairingInformation, ReceiverError> {
+        let sub_register =
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, device_index)?;
         let response = self
             .chan
             .read_long_register(
                 RECEIVER_DEVICE_INDEX,
                 Register::ReceiverInfo.into(),
-                [
-                    u8::from(InfoSubRegister::DevicePairingInformation) | (device_index & 0x0f),
-                    0x00,
-                    0x00,
-                ],
+                [sub_register, 0x00, 0x00],
             )
             .await?;
 
-        Ok(DevicePairingInformation {
-            wpid: u16::from_le_bytes([response[2], response[3]]),
-            // Kind is identity-only: an unrecognised nibble folds to
-            // `Unknown` instead of failing the whole pairing-info read.
-            kind: DeviceKind::from(response[1] & 0x0f),
-            encrypted: response[1] & (1 << 5) != 0,
-            online: response[1] & (1 << 6) == 0,
-            unit_id: [response[4], response[5], response[6], response[7]],
-        })
+        Ok(parse_device_pairing_information(&response))
+    }
+
+    /// Retrieves the stable serial number and report types for one paired
+    /// device from the Unifying extended-pairing sub-register.
+    pub async fn get_device_extended_pairing_information(
+        &self,
+        device_index: u8,
+    ) -> Result<DeviceExtendedPairingInformation, ReceiverError> {
+        let sub_register = device_info_sub_register(
+            InfoSubRegister::DeviceExtendedPairingInformation,
+            device_index,
+        )?;
+        let response = self
+            .chan
+            .read_long_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::ReceiverInfo.into(),
+                [sub_register, 0x00, 0x00],
+            )
+            .await?;
+
+        Ok(parse_device_extended_pairing_information(&response))
     }
 
     /// Provides the unique ID of the receiver (serial number).
@@ -308,19 +322,25 @@ pub struct DevicePairingInformation {
     pub wpid: u16,
     /// Device kind reported by the receiver.
     pub kind: DeviceKind,
-    /// Whether the link is encrypted.
-    pub encrypted: bool,
-    /// Whether the device is currently online.
-    pub online: bool,
-    /// Device unit ID.
+}
+
+/// Extended identity retained by a Unifying receiver for one paired device.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct DeviceExtendedPairingInformation {
+    /// Stable device serial number, also exposed by HID++ 2.0 as the unit ID.
     pub unit_id: [u8; 4],
+    /// HID report-type bitmap stored by the receiver.
+    pub report_types: [u8; 4],
+    /// Physical location of the device power switch (low nibble, per HID++
+    /// 1.0).
+    pub power_switch_location: u8,
 }
 
 /// Represents the kind of a device paired to a Unifying receiver.
 ///
-/// The encoding matches Bolt for values 1–4; from 5 onwards Unifying uses a
-/// shifted table (Remote=5, Trackball=6, Touchpad=7) while Bolt reserves those
-/// values and places them at 7–9.
+/// The encoding matches the Unifying HID++ 1.0 pairing and connection tables.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, IntoPrimitive, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
@@ -341,9 +361,36 @@ pub enum DeviceKind {
     /// Remote-control device.
     Remote = 0x05,
     /// Trackball device.
-    Trackball = 0x06,
+    Trackball = 0x08,
     /// Touchpad device.
-    Touchpad = 0x07,
+    Touchpad = 0x09,
+}
+
+fn device_info_sub_register(base: InfoSubRegister, device_index: u8) -> Result<u8, ReceiverError> {
+    let zero_based = device_index
+        .checked_sub(1)
+        .filter(|index| *index < 6)
+        .ok_or(ReceiverError::InvalidDeviceIndex(device_index))?;
+    Ok(u8::from(base) + zero_based)
+}
+
+fn parse_device_pairing_information(response: &[u8; 16]) -> DevicePairingInformation {
+    DevicePairingInformation {
+        wpid: u16::from_be_bytes([response[3], response[4]]),
+        // Kind is identity-only: an unrecognised value folds to `Unknown`
+        // instead of making an otherwise valid occupied slot disappear.
+        kind: DeviceKind::from(response[7] & 0x0f),
+    }
+}
+
+fn parse_device_extended_pairing_information(
+    response: &[u8; 16],
+) -> DeviceExtendedPairingInformation {
+    DeviceExtendedPairingInformation {
+        unit_id: [response[1], response[2], response[3], response[4]],
+        report_types: [response[5], response[6], response[7], response[8]],
+        power_switch_location: response[9] & 0x0f,
+    }
 }
 
 /// Represents a device-connection event fired by the receiver when a paired
@@ -384,11 +431,14 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        DeviceConnection, DeviceKind, DevicePairingInformation, Event, InfoSubRegister, Receiver,
-        Register, decode_notification, update_wireless_notification_flag,
+        DeviceConnection, DeviceKind, Event, InfoSubRegister, Receiver, Register,
+        decode_notification, device_info_sub_register, parse_device_extended_pairing_information,
+        parse_device_pairing_information, update_wireless_notification_flag,
     };
+    use crate::channel::HidppMessage;
     use crate::channel::tests::{MockRawHidChannel, channel_with_reader};
-    use crate::protocol::v10::{Message, MessageHeader, MessageType};
+    use crate::protocol::v10::{Message, MessageHeader};
+    use crate::receiver::ReceiverError;
 
     /// Builds the long notification the receiver broadcasts, with `payload`
     /// laid out exactly as the 17 bytes following the header.
@@ -400,6 +450,20 @@ mod tests {
             },
             payload,
         )
+    }
+
+    fn long_register_response(register_data: [u8; 16]) -> HidppMessage {
+        let mut payload = [0u8; 17];
+        payload[0] = Register::ReceiverInfo.into();
+        payload[1..].copy_from_slice(&register_data);
+        Message::Long(
+            MessageHeader {
+                device_index: super::RECEIVER_DEVICE_INDEX,
+                sub_id: 0x83,
+            },
+            payload,
+        )
+        .into()
     }
 
     #[test]
@@ -453,61 +517,6 @@ mod tests {
     }
 
     #[test]
-    fn pairing_information_reads_encryption_from_bit_5() {
-        // The pairing register carries the same device-info byte as the 0x41
-        // notification, decoded independently — pin its bits too so the two
-        // paths cannot diverge unnoticed.
-        futures::executor::block_on(async {
-            let (raw, handle) = MockRawHidChannel::new();
-            let chan = Arc::new(channel_with_reader(raw).await);
-            let receiver =
-                Receiver::new(chan).expect("the mock's VID/PID routes as a Unifying receiver");
-
-            // First response: bit 5 + bit 6 — encrypted, offline. Second:
-            // bit 4 only (software present), which must not read as
-            // encryption.
-            for status in [0x62, 0x12] {
-                let mut payload = [0u8; 17];
-                payload[0] = Register::ReceiverInfo.into(); // RAP matches on the address echo
-                payload[1] = u8::from(InfoSubRegister::DevicePairingInformation) | 0x02;
-                payload[2] = status;
-                payload[3] = 0x69; // wpid, little-endian
-                payload[4] = 0x40;
-                payload[5..9].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
-                handle.queue_response(
-                    Message::Long(
-                        MessageHeader {
-                            device_index: super::RECEIVER_DEVICE_INDEX,
-                            sub_id: MessageType::GetLongRegister.into(),
-                        },
-                        payload,
-                    )
-                    .into(),
-                );
-            }
-
-            let encrypted_offline = receiver.get_device_pairing_information(2).await.unwrap();
-            assert_eq!(
-                encrypted_offline,
-                DevicePairingInformation {
-                    wpid: 0x4069,
-                    kind: DeviceKind::Mouse,
-                    encrypted: true,
-                    online: false,
-                    unit_id: [0xde, 0xad, 0xbe, 0xef],
-                }
-            );
-
-            let software_present = receiver.get_device_pairing_information(2).await.unwrap();
-            assert!(
-                !software_present.encrypted,
-                "bit 4 is software-present, not encryption"
-            );
-            assert!(software_present.online);
-        });
-    }
-
-    #[test]
     fn bit_6_is_set_when_the_device_is_offline() {
         let mut payload = [0u8; 17];
         payload[1] = 1 << 6;
@@ -534,8 +543,8 @@ mod tests {
         };
 
         assert_eq!(kind(0x05), DeviceKind::Remote);
-        assert_eq!(kind(0x06), DeviceKind::Trackball);
-        assert_eq!(kind(0x07), DeviceKind::Touchpad);
+        assert_eq!(kind(0x08), DeviceKind::Trackball);
+        assert_eq!(kind(0x09), DeviceKind::Touchpad);
     }
 
     #[test]
@@ -579,5 +588,107 @@ mod tests {
                 wpid: 0x4074,
             })
         );
+    }
+
+    #[test]
+    fn unifying_slot_sub_registers_are_zero_based_not_bolt_addresses() {
+        assert_eq!(
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, 1).unwrap(),
+            0x20
+        );
+        assert_eq!(
+            device_info_sub_register(InfoSubRegister::DeviceExtendedPairingInformation, 6).unwrap(),
+            0x35
+        );
+        assert!(matches!(
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, 0),
+            Err(ReceiverError::InvalidDeviceIndex(0))
+        ));
+        assert!(matches!(
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, 7),
+            Err(ReceiverError::InvalidDeviceIndex(7))
+        ));
+    }
+
+    #[test]
+    fn pairing_information_uses_the_unifying_wire_layout() {
+        let mut response = [0u8; 16];
+        response[0] = 0x20;
+        response[3] = 0x40;
+        response[4] = 0x67;
+        response[7] = 0x08;
+
+        let pairing = parse_device_pairing_information(&response);
+
+        assert_eq!(pairing.wpid, 0x4067);
+        assert_eq!(pairing.kind, DeviceKind::Trackball);
+    }
+
+    #[test]
+    fn pairing_kind_ignores_flags_outside_the_low_nibble() {
+        let mut response = [0u8; 16];
+        response[7] = 0xa8;
+
+        assert_eq!(
+            parse_device_pairing_information(&response).kind,
+            DeviceKind::Trackball,
+        );
+    }
+
+    #[test]
+    fn extended_pairing_information_carries_the_stable_unit_id() {
+        let mut response = [0u8; 16];
+        response[0] = 0x30;
+        response[1..=4].copy_from_slice(&[0x29, 0x16, 0xdb, 0xbe]);
+        response[5..=8].copy_from_slice(&[0x01, 0x02, 0x04, 0x08]);
+        response[9] = 0xb3;
+
+        let extended = parse_device_extended_pairing_information(&response);
+
+        assert_eq!(extended.unit_id, [0x29, 0x16, 0xdb, 0xbe]);
+        assert_eq!(extended.report_types, [0x01, 0x02, 0x04, 0x08]);
+        assert_eq!(extended.power_switch_location, 0x03);
+    }
+
+    #[test]
+    fn receiver_reads_unifying_pairing_and_extended_registers_for_slot_one() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = Arc::new(channel_with_reader(raw).await);
+            let receiver = Receiver::new(channel).expect("mock is a known Unifying receiver");
+
+            let mut pairing_response = [0u8; 16];
+            pairing_response[0] = 0x20;
+            pairing_response[3] = 0x40;
+            pairing_response[4] = 0x67;
+            pairing_response[7] = 0x08;
+            handle.queue_response(long_register_response(pairing_response));
+
+            let pairing = receiver
+                .get_device_pairing_information(1)
+                .await
+                .expect("pairing information");
+
+            let mut extended_response = [0u8; 16];
+            extended_response[0] = 0x30;
+            extended_response[1..=4].copy_from_slice(&[0x29, 0x16, 0xdb, 0xbe]);
+            handle.queue_response(long_register_response(extended_response));
+
+            let extended = receiver
+                .get_device_extended_pairing_information(1)
+                .await
+                .expect("extended pairing information");
+
+            assert_eq!(pairing.wpid, 0x4067);
+            assert_eq!(pairing.kind, DeviceKind::Trackball);
+            assert_eq!(extended.unit_id, [0x29, 0x16, 0xdb, 0xbe]);
+            assert_eq!(
+                handle.written_reports(),
+                vec![
+                    vec![0x10, 0xff, 0x83, 0xb5, 0x20, 0x00, 0x00],
+                    vec![0x10, 0xff, 0x83, 0xb5, 0x30, 0x00, 0x00],
+                ]
+            );
+        });
     }
 }

--- a/xtask/src/commands/macos/bundle/embed.rs
+++ b/xtask/src/commands/macos/bundle/embed.rs
@@ -187,6 +187,16 @@ fn agent_launch_plist(channel: Channel) -> Result<plist::Dictionary> {
         plist::Value::String(format!("{nested}/Contents/MacOS/{}", helper.binary)),
     );
     root.insert("KeepAlive".into(), plist::Value::Dictionary(keep_alive));
+    // A supervised successor waits for a legacy or manually launched Agent
+    // to release the singleton. Losing the lock and exiting cleanly here
+    // would leave this service down after the predecessor later crashes.
+    root.insert(
+        "ProgramArguments".into(),
+        plist::Value::Array(vec![
+            plist::Value::String(helper.binary.to_owned()),
+            plist::Value::String("--launchd".into()),
+        ]),
+    );
     Ok(root)
 }
 

--- a/xtask/src/commands/macos/bundle/embed/tests.rs
+++ b/xtask/src/commands/macos/bundle/embed/tests.rs
@@ -119,6 +119,18 @@ fn agent_launch_plist_targets_the_channel_helper_and_keeps_alive() {
                     .as_str()
             )
         );
+        let arguments = content
+            .get("ProgramArguments")
+            .and_then(plist::Value::as_array)
+            .unwrap();
+        assert_eq!(
+            arguments
+                .iter()
+                .map(plist::Value::as_string)
+                .collect::<Vec<_>>(),
+            vec![Some("openlogi-agent"), Some("--launchd")],
+            "the supervised Agent must preserve singleton handoff"
+        );
         let keep_alive = content
             .get("KeepAlive")
             .and_then(plist::Value::as_dictionary)


### PR DESCRIPTION
## Summary

Replace #1024 with the consolidated receiver/Bluetooth and shortcut-recovery fixes, rebased onto `6c0ec1d9` on `master`. The previous PR was closed after follow-up testing exposed agent-registration and intermittent recovery problems.

This addresses related user-visible failures: a mouse appearing offline or twice after changing transports, configured buttons stopping working after a handoff or idle/wake, and helper lifecycle/configuration problems after replacing a local build. The reporter has tested MX Ergo S and Ergo M575, and confirmed the current installation works after the local service/permission recovery described below. Source tests, hardware feedback and remaining upgrade limitations are reported separately; this is not a claim that every macOS/hardware combination is covered.

## Changes

### `openlogi-hidpp`: serialize the real transaction, correct Unifying identity reads

- Serialize the entire request/reply transaction on each channel, including raw writes and send-and-forget traffic. Requests sharing correlation fields must not consume each other's replies. A queued request starts its wire timeout only after acquiring the gate; cancellation removes only its own pending request.
- Read Unifying pairing, extended-pairing and device-name registers with their correct zero-based slot offsets (`0x20`, `0x30`, `0x40`), instead of applying Bolt's layout. Validate slot bounds, decode WPID and the low device-kind nibble, and expose the physical unit ID from extended pairing information.
- The reverse-engineered register layout is explicitly attributed to Solaar; no claim is made that it came from an official Logitech specification.

### `openlogi-hid`: discover the Bluetooth collection actually exposed by Ergo devices

- Accept the Logitech `0xb0xx` Generic Desktop mouse collection as a long-report HID++ fallback, including MX Ergo S and Ergo M575. Ordinary receiver/wired mouse collections remain excluded.
- Prefer the vendor HID++ collection when the same OS node and product expose both. Preference is not global by PID, so another same-model mouse is not hidden merely because the first one has a vendor collection.
- Preserve standalone-driver precedence and Linux receiver-child filtering.

### `openlogi-device`: stable physical identity and channel-scoped probing

- Enumerate Unifying paired-slot identity from receiver registers even while a mouse sleeps or uses Bluetooth; overlay current arrival notifications for liveness. A late arrival with a different WPID cannot mark a replacement slot occupant online.
- Preserve arrival-only enumeration for older receivers without those registers. Unreadable slots with no arrival are not invented as devices, and an absent/all-zero unit ID is never used as a physical cache key.
- Key the Unifying probe cache by physical unit ID rather than receiver slot. Receiver/Bluetooth reconciliation can then use the existing transport-independent identity model, without model-name merging.
- Reuse immutable feature data for a channel generation instead of walking the full feature table every 30 seconds. A replacement channel gets a validation attempt; a failed attempt preserves last-good data rather than dropping the device. Battery readings remain live, and warm-cache adoption restores lifecycle/battery notification indexes.
- Persist physical receiver identities and notification indexes in probe-cache schema 4; discard incompatible cache schemas for a safe cold start. This cache is disposable, not the user's settings.

### `openlogi-agent-core` / `openlogi-device`: recover shortcuts without stale cleanup

- Keep failed firmware-restore tokens scoped to their original physical device **and transport**. An unavailable old receiver route must not block capture through the device's new Bluetooth route (and vice versa).
- Keep the existing restore-before-rearm ordering on the same route. Do not replay old feature indexes into a different transport, underneath a running/draining successor, or into a receiver route reassigned to another mouse.
- Retain each route's cleanup debt for a later safe retry; do not discard it to make a handoff appear successful.
- Remove expired restart deadlines so pending restoration cannot keep the manager's timer permanently ready and busy-spin. Restoration continues to respect device-I/O suspension and receiver leases.

### `openlogi-desktop`: one useful record with correct model metadata

- Resolve offline receiver sightings using the receiver's nonzero physical identity and previously recorded route links. Hydrate their model name, kind and artwork from persisted identity instead of showing a generic chip/incorrect mouse category.
- Suppress never-observed, offline receiver pairings with no persisted device record, avoiding anonymous `Slot N` gallery cards. Known offline devices stay available; online unknown devices remain visible and actionable. This does not unpair or delete anything from the receiver.
- Map MX Ergo S's `SLOT_NAME_CHANGE_POINTER_SPEED` metadata control to `DpiToggle`. Cover the full six-control metadata mapping, including wheel tilt, forward/back, middle click and precision-mode button.

### `openlogi-agent` / `xtask`: supervised recovery and visible-wake gating on macOS

- Mark launchd starts with `--launchd`. If a manually launched or legacy agent already owns the singleton, the supervised successor waits instead of exiting successfully and leaving the service unsupervised after the predecessor fails. Only the lock holder starts the input hook.
- Preserve explicit menu-bar Quit with a one-shot marker and clear stale markers on a new explicit run. Keep existing protocol-version takeover behavior and GUI-owned `SMAppService` registration.
- Use generic workspace wake notifications only to schedule display confirmation. Require two separated visible-display samples before reopening HID; an asleep display keeps I/O suspended during DarkWake. Recover when a screen-wake notification is missed while retaining session-inactive suspension.
- Extend packaging tests to assert the launchd argument and the existing crash-restart/clean-Quit policy.

### `openlogi-desktop` registration: distinguish builds, not only release versions

- Compare both package version and the outer app's `CFBundleVersion` when deciding whether to refresh `SMAppService` registration. A different build of the same release now triggers a refresh attempt instead of being treated as already current; this does not guarantee recovery from every stale macOS service record (see installation notes below).
- Use typed `NSBundle` access; the only manifest change enables its existing Foundation feature. Do not override `RequiresApproval`, change bundle identifiers, or change signing requirements.

### `openlogi-core`: preserve settings from earlier custom builds

- Migrate private-build `device:<identity>` keys and explicit `device_aliases` into the current physical-key/route-link model, including selection and host-switch references.
- Keep conflict-preserving folds and a source backup before saving a migrated configuration, even when the schema version is already current. Aliases without a persisted target are not guessed from model names.
- Keep this one-way import in file loading rather than expanding the strict serialized `Config`/IPC shape. It is compiled only with the `fs` feature; ordinary current configs keep the existing schema and wire contract.

### Existing upstream behavior retained, not reintroduced

The current upstream already provides shared inventory-owned capture channels, transport-independent identity/link configuration, device removal with confirmation, wheel-tilt controls, agent-owned permission reporting and permission-grant relaunch. Those parts were reconciled with the newer architecture rather than copied back from the old GUI branch. No layout redesign, locale changes, dependency-version changes, release tags or installer binaries are included.

## Testing

Validated the final commit `715d3906` on Apple Silicon macOS with Rust 1.98.0:

- Full workspace tests: **1,399 passed, 0 failed**, including all 14 IPC wire-format goldens and locale parity; two pre-existing documentation examples are marked ignored.
- Formatting, strict full-workspace Clippy, and the repository's non-GPUI rustdoc gate: **passed**.
- Windows GNU cross-Clippy proxy, the portable WASM checks, and the Linux ARM64 musl cross-Clippy subset below: **passed**. These are compile/lint checks, not full native Windows/Linux CI or hardware tests.
- Release DMG build, `hdiutil verify`, and packaged launchd plist inspection: **passed**. The final local test bundle is ad-hoc signed and passes deep/strict verification. An earlier unsigned artifact failed installation; the distinction and recovery are documented below. The plist has `--launchd`, the nested agent path, and `KeepAlive.SuccessfulExit = false`.
- `git diff --check` passed. No `Cargo.lock`, dependency-version or GPUI-pin changes.

Exact source-validation commands:

```sh
export RUSTFLAGS='-D warnings'
cargo +1.98.0 fmt --all -- --check
cargo +1.98.0 clippy --workspace --all-targets -- -D warnings
cargo +1.98.0 test --workspace
RUSTDOCFLAGS='-D warnings' cargo +1.98.0 doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent
RUSTUP_TOOLCHAIN=1.98.0 cargo xtask ci clippy-windows wasm
cargo +1.98.0 clippy --target aarch64-unknown-linux-musl \
  -p openlogi-hook -p openlogi-inject -p openlogi-hid -p openlogi-hidpp \
  -p openlogi-core -p openlogi-agent -p openlogi-agent-core \
  -p openlogi-ipc -p openlogi-permissions --all-targets -- -D warnings
git diff --check upstream/master...HEAD
```

Packaging ran separately, without `RUSTFLAGS` or a signing identity:

```sh
RUSTUP_TOOLCHAIN=1.98.0 cargo xtask macos package \
  --output target/release/OpenLogi-pr-review-20260907-arm64.dmg
hdiutil verify target/release/OpenLogi-pr-review-20260907-arm64.dmg
plutil -p target/release/bundle/osx/OpenLogi.app/Contents/Library/LaunchAgents/org.openlogi.agent.service.plist
```

The unsigned build-check artifact was subsequently installed by the reporter and failed SMAppService signature validation. It is not an installable release candidate. It was rebuilt from the same source using the existing inside-out ad-hoc signing pipeline:

```sh
RUSTUP_TOOLCHAIN=1.98.0 cargo xtask macos package --sign-identity=- \
  --output target/release/OpenLogi-local-adhoc-20260907-arm64.dmg
```

The replacement DMG and installed bundle pass signature/integrity checks (`hdiutil verify` and `codesign --verify --deep --strict --verbose=2 /Applications/OpenLogi.app`). Installation still exposed a launch-constraint/stale-BTM service failure: launchd referenced an invalidated background-service record. Targeted service removal followed by the GUI's normal SMAppService registration restored supervised Agent startup, IPC responses and the normal GUI. TCC separately rejected the old Agent permission record because the ad-hoc code requirement had changed. After permission renewal, the reporter confirmed on 2026-09-08 that the current installation works and approved this PR.

No application code changed during that service/permission recovery, and the user's button configuration was preserved. This is a successful local recovery, **not** proof of seamless or unattended upgrades. Stable Developer ID signing/notarization was not available or tested. Release packaging also reports an existing unused-import warning in unchanged `windows/settings/diagnostics.rs`; the strict development-profile Clippy gate above passes.

Regression coverage includes queue wait versus wire timeout, cancellation ownership, per-node Bluetooth fallback preference, Unifying slot/register decoding, stale slot arrivals, warm/replacement channel cache adoption, cross-route restoration debt, device identity/artwork hydration, precision-mode metadata, launchd handoff/quit and visible-wake sequencing, and backup-preserving same-schema config migration. New migration/identity fixtures use synthetic device identifiers.

### Hardware verification and remaining boundaries

- On 2026-09-07, the reporter confirmed validation of both MX Ergo S and Ergo M575 using the installed local fixes and approved resubmission. Earlier testing in this report covered receiver/Bluetooth switching and shortcut behavior.
- On 2026-09-08, the reporter confirmed the final-tip installation works after the service/permission recovery above. The running launchd-supervised Agent serves the installed CLI's `list` through IPC, and that snapshot shows M575 online over Unifying with full model data. A separate exhaustive final-tip retest of every control on both models was not recorded.
- Local logs still contain node probe-retry warnings; their remaining paths have not been characterized by a long-duration soak. A working foreground session is not evidence of zero recovery warnings or unlimited idle stability.
- No claim of original MX Ergo, two simultaneous identical-model mice, exhaustive long-idle/DarkWake soak, Intel macOS or Windows/Linux hardware validation.
- Re-registering a helper cannot repair an arbitrary stale macOS TCC grant or make ad-hoc signatures stable. Input Monitoring and Accessibility still belong to **OpenLogi Agent**, not the GUI; this PR does not bypass user approval or alter the computer's permissions.

### Suggested maintainer hardware check

1. Use MX Ergo S with Bolt, and M575 with Unifying. Bind forward/back and verify the actions; for Ergo S also exercise precision mode and wheel tilt.
2. Switch receiver -> Bluetooth -> receiver repeatedly. Check one record per physical mouse, the active transport/online state, retained model artwork and bindings on both routes.
3. Leave the mouse idle, wake the computer, then test buttons before opening the GUI. Repeat with a disconnect/reconnect and with the other model connected. A maintenance DarkWake should not open HID or wake the display.
4. Rebuild/reinstall the same release with a different bundle build number. Check that the registered agent points to the replacement bundle, only one hook owner runs, explicit Quit stays stopped and a failed predecessor permits supervised recovery.
5. If available, use two same-model mice with distinct unit IDs and reassign a receiver slot; verify identities/configuration and old cleanup stay isolated.

Replaces #1024.

Fixes #366
