### PR TITLE
fix(hid): make dedicated MX Master 4 gestures consistent

### DIFF
--- a/crates/openlogi-core/src/binding/swipe.rs
+++ b/crates/openlogi-core/src/binding/swipe.rs
@@ -15,8 +15,8 @@ pub const GESTURE_SWIPE_THRESHOLD: i32 = 50;
 pub const GESTURE_SWIPE_DEADZONE: i32 = 40;
 /// Minimum time a gesture button must be held before its travel can commit to a
 /// swipe. Distinguishes a deliberate hold-and-swipe from a quick click whose
-/// cursor happened to be moving. Shared by both gesture paths (the HID++ thumb
-/// pad and the OS-hook Middle/Back/Forward).
+/// cursor happened to be moving. Applies to ordinary buttons used for gestures;
+/// dedicated gesture controls use distance alone for immediate recognition.
 pub const GESTURE_HOLD_FOR_SWIPE: std::time::Duration = std::time::Duration::from_millis(160);
 
 /// Classify the *running* raw-XY travel of a held gesture button into a
@@ -69,14 +69,13 @@ pub fn detect_swipe(dx: i32, dy: i32) -> Option<GestureDirection> {
 /// dedicated gesture button (`openlogi-hid`'s `0x1b04` raw-XY divert) and the OS-hook
 /// Middle/Back/Forward buttons (`openlogi-agent-core`'s CGEventTap). A gesture
 /// button's hold accumulates travel; the instant the dominant axis commits a
-/// direction — after the button has been held [`GESTURE_HOLD_FOR_SWIPE`], so a
-/// quick click whose cursor drifted doesn't count — [`Self::accumulate`] returns
-/// that direction exactly once, like Logitech Options+. A hold that never
+/// direction — after the hold gate for ordinary buttons, or immediately for
+/// dedicated gesture controls — [`Self::accumulate`] returns
+/// that direction exactly once. A hold that never
 /// commits is a plain click, reported by [`Self::end`].
 ///
-/// The two paths differ only in *what identifies the held control* (a
-/// [`ButtonId`](super::ButtonId) for the OS hook, a diverted CID for the HID++ gesture control), so each owns
-/// that and embeds this for the shared travel logic. Keeping the logic in one
+/// Capture layers identify the held control and select its timing policy,
+/// then embed this state machine for the shared travel logic. Keeping it in one
 /// place is deliberate: the two copies it replaced had already drifted apart
 /// (one resolved a swipe only on release), which mis-fired the click.
 #[derive(Debug, Default)]
@@ -84,6 +83,8 @@ pub struct SwipeAccumulator {
     /// When the current hold began, or `None` when not holding. Gates a
     /// deliberate swipe against a quick click whose cursor happened to move.
     held_since: Option<Instant>,
+    /// Minimum duration for this hold, selected by the physical control type.
+    min_hold: std::time::Duration,
     /// Accumulated raw-XY travel since the hold began (saturating, so an
     /// arbitrarily long hold can never overflow).
     dx: i32,
@@ -96,7 +97,18 @@ pub struct SwipeAccumulator {
 impl SwipeAccumulator {
     /// Begin a fresh hold, resetting the travel accumulator and commit state.
     pub fn begin(&mut self) {
+        self.begin_with_min_hold(GESTURE_HOLD_FOR_SWIPE);
+    }
+
+    /// Begin a dedicated gesture-control hold. Distance and direction gates
+    /// still apply, but a deliberate swipe need not wait for a click-drift timer.
+    pub fn begin_dedicated(&mut self) {
+        self.begin_with_min_hold(std::time::Duration::ZERO);
+    }
+
+    fn begin_with_min_hold(&mut self, min_hold: std::time::Duration) {
         self.held_since = Some(Instant::now());
+        self.min_hold = min_hold;
         self.dx = 0;
         self.dy = 0;
         self.fired = false;
@@ -111,7 +123,7 @@ impl SwipeAccumulator {
 
     /// Feed a pointer-move / raw-XY delta into the current hold. Returns
     /// `Some(direction)` exactly once per hold — the instant travel commits, and
-    /// only after the hold passes [`GESTURE_HOLD_FOR_SWIPE`] — and `None` while
+    /// only after the selected hold gate passes — and `None` while
     /// still too short, already committed, or not holding.
     pub fn accumulate(&mut self, dx: i32, dy: i32) -> Option<GestureDirection> {
         if self.fired || self.held_since.is_none() {
@@ -121,7 +133,7 @@ impl SwipeAccumulator {
         self.dy = self.dy.saturating_add(dy);
         let held_long_enough = self
             .held_since
-            .is_some_and(|t| t.elapsed() >= GESTURE_HOLD_FOR_SWIPE);
+            .is_some_and(|t| t.elapsed() >= self.min_hold);
         if held_long_enough && let Some(dir) = detect_swipe(self.dx, self.dy) {
             self.fired = true;
             return Some(dir);
@@ -211,6 +223,45 @@ mod tests {
     }
 
     // ── SwipeAccumulator (the shared mid-swipe state machine) ─────────────────
+
+    #[test]
+    fn dedicated_swipe_commits_first_direction_without_waiting() {
+        let mut acc = SwipeAccumulator::default();
+        acc.begin_dedicated();
+        assert_eq!(acc.accumulate(-60, 0), Some(GestureDirection::Left));
+        // Recovery motion during the same press must never reverse the action.
+        assert_eq!(acc.accumulate(200, 0), None);
+        assert!(!acc.end());
+        acc.begin_dedicated();
+        assert_eq!(acc.accumulate(60, 0), Some(GestureDirection::Right));
+    }
+
+    #[test]
+    fn dedicated_hold_preserves_distance_diagonal_and_click_checks() {
+        let mut acc = SwipeAccumulator::default();
+        acc.begin_dedicated();
+        assert_eq!(acc.accumulate(2, -1), None);
+        assert!(acc.end(), "small drift remains a click");
+        acc.begin_dedicated();
+        assert_eq!(acc.accumulate(60, 60), None);
+        assert!(acc.end(), "a diagonal must not commit a direction");
+        acc.begin_dedicated();
+        assert_eq!(acc.accumulate(-24, 0), None);
+        assert_eq!(acc.accumulate(-24, 0), None);
+        assert_eq!(acc.accumulate(-2, 0), Some(GestureDirection::Left));
+    }
+
+    #[test]
+    fn ordinary_begin_restores_hold_gate_after_dedicated_hold() {
+        let mut acc = SwipeAccumulator::default();
+        acc.begin_dedicated();
+        assert_eq!(acc.accumulate(60, 0), Some(GestureDirection::Right));
+        acc.end();
+        acc.begin();
+        assert_eq!(acc.accumulate(-60, 0), None);
+        acc.backdate_hold_for_test();
+        assert_eq!(acc.accumulate(0, 0), Some(GestureDirection::Left));
+    }
 
     #[test]
     fn accumulator_commits_a_direction_once_after_the_hold_gate() {

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -124,7 +124,11 @@ enum HoldState {
 /// Begin a hold for `cid`, its swipe accumulator started fresh.
 fn begin_hold(cid: u16, button: ButtonId, overlap: bool, skip_first_raw_xy: bool) -> HoldState {
     let mut swipe = SwipeAccumulator::default();
-    swipe.begin();
+    if button.is_hidpp_gesture_source() {
+        swipe.begin_dedicated();
+    } else {
+        swipe.begin();
+    }
     HoldState::Holding {
         cid,
         button,
@@ -1051,7 +1055,7 @@ fn handle_raw_xy(
         return;
     }
     // Commit the instant a clean direction emerges (mid-swipe, once per hold);
-    // the accumulator gates on hold duration internally and drops travel that
+    // the accumulator applies the control's timing policy and drops travel that
     // arrives outside a hold.
     if let Some(direction) = swipe.accumulate(i32::from(dx), i32::from(dy)) {
         debug!(?direction, %button, "gesture committed");

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -114,9 +114,8 @@ enum HoldState {
         /// A second armed source is held alongside the holder. Overlap motion
         /// could belong to either control — dropped until the overlap ends.
         overlap: bool,
-        /// The hold's next raw-XY sample must be dropped: the haptic panel's
-        /// first sample after contact is an absolute position jump, not a
-        /// delta (see [`reprog_controls::HAPTIC_PANEL_CID`]).
+        /// Drop the hold's first report when the device's control table
+        /// identifies a source with a stale initial raw-XY sample.
         skip_first_raw_xy: bool,
     },
 }
@@ -138,15 +137,45 @@ fn begin_hold(cid: u16, button: ButtonId, overlap: bool, skip_first_raw_xy: bool
     }
 }
 
+/// Hardware-specific first-report handling, derived from the live control table.
+#[derive(Clone, Copy, Default)]
+enum FirstRawXyPolicy {
+    #[default]
+    PanelOnly,
+    /// MX Master 4 exposes the vendor-specific haptic panel. Hardware traces
+    /// show stale initial travel on its dedicated gesture button as well.
+    HapticDevice,
+}
+
+impl FirstRawXyPolicy {
+    fn from_control_ids(cids: impl IntoIterator<Item = u16>) -> Self {
+        if cids
+            .into_iter()
+            .any(|cid| cid == reprog_controls::HAPTIC_PANEL_CID)
+        {
+            Self::HapticDevice
+        } else {
+            Self::PanelOnly
+        }
+    }
+
+    fn skips(self, cid: u16) -> bool {
+        cid == reprog_controls::HAPTIC_PANEL_CID
+            || (matches!(self, Self::HapticDevice) && cid == reprog_controls::GESTURE_BUTTON_CID)
+    }
+}
+
 /// Movement + button state accumulated across messages. Lives behind a `Mutex`
 /// because the channel's read thread invokes the listener by shared reference.
 #[derive(Default)]
 struct CaptureAccum {
+    /// Device policy retained when capture state is reset after a reconnect.
+    first_raw_xy_policy: FirstRawXyPolicy,
     /// The hold owning raw-XY motion, if any (see [`HoldState`]).
     hold: HoldState,
     /// The armed gesture sources held in the last event, for edge detection:
     /// a source not previously held that becomes the holder is a fresh touch
-    /// (the haptic panel's first sample is then a contact jump to discard).
+    /// (a source covered by the device policy then drops its initial sample).
     gestures_down: Vec<u16>,
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
@@ -314,7 +343,7 @@ async fn run_capture_session_on(
         *slot = Some(shared.clone());
     }
 
-    let accum = Arc::new(Mutex::new(CaptureAccum::default()));
+    let accum = Arc::new(Mutex::new(armed.capture_accum()));
     let reprog_index = armed.reprog.as_ref().map(ReprogControlsV4::feature_index);
     let gesture_cids = armed.gesture_cids.clone();
     let gesture_button_set = armed.gesture_button_cids.clone();
@@ -470,6 +499,8 @@ fn thumbwheel_input(
 /// to the firmware on teardown.
 #[derive(Default)]
 struct ArmedControls {
+    /// Initial-report quirk discovered from the complete device control table.
+    first_raw_xy_policy: FirstRawXyPolicy,
     /// `0x1b04` accessor, present when the device exposes it.
     reprog: Option<ReprogControlsV4>,
     /// The gesture-source CIDs diverted with raw-XY reporting: the
@@ -510,6 +541,13 @@ impl ArmedThumbwheel {
 }
 
 impl ArmedControls {
+    fn capture_accum(&self) -> CaptureAccum {
+        CaptureAccum {
+            first_raw_xy_policy: self.first_raw_xy_policy,
+            ..CaptureAccum::default()
+        }
+    }
+
     /// Build the one-time polarity fact learned while arming the thumb wheel.
     fn thumbwheel_direction(&self) -> Option<CapturedInput> {
         let positive_is_forward = self
@@ -662,7 +700,7 @@ async fn monitor_capture(
                 };
                 info!(?broadcast, "device reconnected — re-arming control capture");
                 *context.accum.lock().unwrap_or_else(PoisonError::into_inner) =
-                    CaptureAccum::default();
+                    context.armed.capture_accum();
                 context.armed.rearm(&device_io).await;
             }
             generation = context.activity.changed_after(activity_generation) => {
@@ -755,6 +793,8 @@ async fn arm_controls_into(
     {
         let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
         let controls = enumerate_controls(&rc).await?;
+        armed.first_raw_xy_policy =
+            FirstRawXyPolicy::from_control_ids(controls.iter().map(|control| control.cid));
         // Register an accessor before the first divert, so a failure on any
         // divert (including the first) can become a restore capability.
         armed.reprog = Some(rc.clone());
@@ -966,7 +1006,7 @@ fn handle_reprog_with_gesture_buttons(
                     }
                     // ...and the first still-held source begins (or takes
                     // over) the hold. A source not down in the previous event
-                    // is a fresh touch, so the panel's contact-jump discard
+                    // is a fresh touch, so the device's first-report discard
                     // applies; one that was already held has had its jump
                     // dropped during the overlap.
                     match held.first() {
@@ -974,8 +1014,7 @@ fn handle_reprog_with_gesture_buttons(
                             cid,
                             button,
                             held.len() > 1,
-                            cid == reprog_controls::HAPTIC_PANEL_CID
-                                && !acc.gestures_down.contains(&cid),
+                            acc.first_raw_xy_policy.skips(cid) && !acc.gestures_down.contains(&cid),
                         ),
                         None => HoldState::Idle,
                     }
@@ -1048,7 +1087,7 @@ fn handle_raw_xy(
     if *overlap {
         return;
     }
-    // The haptic panel's first sample after contact is a position jump;
+    // A stale first sample can carry pre-press travel or a contact jump;
     // summing it would commit a bogus direction instantly.
     if *skip_first_raw_xy {
         *skip_first_raw_xy = false;

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -703,11 +703,113 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
 }
 
 #[test]
+fn haptic_device_dedicated_button_ignores_stale_first_motion() {
+    // Two leftward holds captured on an MX Master 4: the first packet carries
+    // rightward travel from before the press, followed by actual left motion.
+    let armed = ArmedControls {
+        first_raw_xy_policy: FirstRawXyPolicy::from_control_ids(BOTH.iter().copied()),
+        ..ArmedControls::default()
+    };
+    for samples in [
+        vec![(2041, -74), (-21, -5), (-21, -4), (-25, -4)],
+        vec![(252, 34), (-37, -4), (-23, -2)],
+    ] {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        // This factory is also used after reconnect: each fresh capture must
+        // retain the hardware policy while discarding the previous hold.
+        let mut acc = armed.capture_accum();
+        handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
+        for (dx, dy) in samples {
+            handle_reprog(
+                &mut acc,
+                RawControlEvent::RawXy { dx, dy },
+                GESTURE,
+                &[],
+                &[],
+                &tx,
+            );
+        }
+        assert_eq!(
+            next_gesture(&mut rx),
+            Ok(CapturedInput::Gesture(
+                ButtonId::GestureButton,
+                GestureDirection::Left,
+            ))
+        );
+        assert!(next_gesture(&mut rx).is_err(), "one action per hold");
+    }
+}
+
+#[test]
+fn haptic_device_dedicated_takeover_only_discards_on_a_fresh_press() {
+    for overlaps in [false, true] {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut acc = ArmedControls {
+            first_raw_xy_policy: FirstRawXyPolicy::from_control_ids(BOTH.iter().copied()),
+            ..ArmedControls::default()
+        }
+        .capture_accum();
+        handle_reprog(&mut acc, panel_press(), BOTH, &[], &[], &tx);
+        if overlaps {
+            handle_reprog(&mut acc, both_press(), BOTH, &[], &[], &tx);
+            handle_reprog(
+                &mut acc,
+                RawControlEvent::RawXy { dx: 2041, dy: -74 },
+                BOTH,
+                &[],
+                &[],
+                &tx,
+            );
+        }
+        handle_reprog(&mut acc, press(), BOTH, &[], &[], &tx);
+        assert_eq!(
+            next_gesture(&mut rx),
+            Ok(CapturedInput::Gesture(
+                ButtonId::HapticPanel,
+                GestureDirection::Click
+            ))
+        );
+        if !overlaps {
+            handle_reprog(
+                &mut acc,
+                RawControlEvent::RawXy { dx: 2041, dy: -74 },
+                BOTH,
+                &[],
+                &[],
+                &tx,
+            );
+            assert!(
+                next_gesture(&mut rx).is_err(),
+                "fresh press drops stale sample"
+            );
+        }
+        handle_reprog(
+            &mut acc,
+            RawControlEvent::RawXy { dx: -120, dy: -5 },
+            BOTH,
+            &[],
+            &[],
+            &tx,
+        );
+        assert_eq!(
+            next_gesture(&mut rx),
+            Ok(CapturedInput::Gesture(
+                ButtonId::GestureButton,
+                GestureDirection::Left
+            ))
+        );
+    }
+}
+
+#[test]
 fn the_dedicated_buttons_first_sample_is_not_discarded() {
-    // The discard is a panel quirk: the dedicated button's raw-XY stream is
-    // relative from the first sample, which must keep committing as-is.
+    // Devices without a haptic panel keep their first dedicated-button delta.
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let mut acc = CaptureAccum::default();
+    let mut acc = ArmedControls {
+        first_raw_xy_policy: FirstRawXyPolicy::from_control_ids(GESTURE.iter().copied()),
+        ..ArmedControls::default()
+    }
+    .capture_accum();
 
     handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
     acc.backdate_hold_for_test();

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -453,7 +453,7 @@ fn a_same_report_swap_to_the_panel_still_discards_its_contact_jump() {
 }
 
 #[test]
-fn quick_tap_is_a_click_even_while_the_cursor_moves() {
+fn dedicated_quick_swipe_is_not_misclassified_as_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
@@ -472,12 +472,12 @@ fn quick_tap_is_a_click_even_while_the_cursor_moves() {
         next_gesture(&mut rx),
         Ok(CapturedInput::Gesture(
             ButtonId::GestureButton,
-            GestureDirection::Click
+            GestureDirection::Right
         ))
     );
     assert!(
         next_gesture(&mut rx).is_err(),
-        "a quick tap emits exactly one click"
+        "a quick swipe emits exactly one direction, without a release click"
     );
 }
 
@@ -579,6 +579,89 @@ fn a_quick_panel_tap_is_a_click() {
 }
 
 #[test]
+fn dedicated_swipe_commits_immediately_and_ignores_opposite_recovery() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: -120, dy: 5 },
+        GESTURE,
+        &[],
+        &[],
+        &tx,
+    );
+    assert_eq!(
+        next_gesture(&mut rx),
+        Ok(CapturedInput::Gesture(
+            ButtonId::GestureButton,
+            GestureDirection::Left,
+        )),
+        "a deliberate dedicated-button swipe must not wait 160 ms"
+    );
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 300, dy: 0 },
+        GESTURE,
+        &[],
+        &[],
+        &tx,
+    );
+    handle_reprog(&mut acc, release(), GESTURE, &[], &[], &tx);
+    assert!(
+        next_gesture(&mut rx).is_err(),
+        "recovery and release must not emit another action"
+    );
+}
+
+#[test]
+fn side_button_raw_xy_still_waits_for_the_hold_gate() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let cid = 0x0056;
+    let buttons = [(cid, ButtonId::Forward)];
+    handle_reprog_with_gesture_buttons(
+        &mut acc,
+        RawControlEvent::DivertedButtons([cid, 0, 0, 0]),
+        &[],
+        &[],
+        &buttons,
+        &[],
+        &tx,
+    );
+    handle_reprog_with_gesture_buttons(
+        &mut acc,
+        RawControlEvent::RawXy { dx: -120, dy: 5 },
+        &[],
+        &[],
+        &buttons,
+        &[],
+        &tx,
+    );
+    assert!(
+        next_gesture(&mut rx).is_err(),
+        "ordinary buttons retain click-drift protection"
+    );
+    acc.backdate_hold_for_test();
+    handle_reprog_with_gesture_buttons(
+        &mut acc,
+        RawControlEvent::RawXy { dx: -1, dy: 0 },
+        &[],
+        &[],
+        &buttons,
+        &[],
+        &tx,
+    );
+    assert_eq!(
+        next_gesture(&mut rx),
+        Ok(CapturedInput::Gesture(
+            ButtonId::Forward,
+            GestureDirection::Left,
+        ))
+    );
+}
+
+#[test]
 fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
     // Real-hardware probe finding: the panel's first raw-XY sample after
     // contact is a large position jump (up to thousands of units), not a
@@ -587,7 +670,6 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
     let mut acc = CaptureAccum::default();
 
     handle_reprog(&mut acc, panel_press(), PANEL, &[], &[], &tx);
-    acc.backdate_hold_for_test();
     // The contact jump — leftward, far past every threshold.
     handle_reprog(
         &mut acc,


### PR DESCRIPTION
## Summary

Fix inconsistent dedicated-button gestures observed on an MX Master 4 connected through a Bolt receiver on macOS. Quick swipes could miss the 160 ms hold gate, and some leftward swipes were interpreted as rightward because of an anomalous first raw-XY report.

In five physical leftward gestures, the existing recognizer produced three Left and two Right actions. The two incorrect sequences started with `(2041, -74)` and `(252, 34)`, followed by leftward motion. Discarding the first report made all five captured sequences classify as Left. The firmware origin of that initial report is not established.

## Changes

- **core:** let dedicated GestureButton/HapticPanel swipes commit once the existing distance and diagonal thresholds are met, without the ordinary-button hold delay. Keep one action per hold and retain the 160 ms gate for ordinary buttons.
- **device:** extend first-report suppression to GestureButton on devices whose live control table includes HapticPanel. Preserve the policy after reconnect and keep first-report behavior unchanged on devices without that panel.
- **tests:** cover fast swipes, opposite recovery motion, the two captured failure sequences, overlapping controls, and ordinary-button behavior.

## Testing

- `cargo fmt --all -- --check` and `git diff --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace` — 1,373 passed, 0 failed, 2 ignored
- `RUSTFLAGS='-D warnings' cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown`
- `RUSTFLAGS='-D warnings' RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- Built and installed a locally signed macOS Dev bundle. The mouse owner confirmed that gestures work after this fix. The stale Accessibility grant caused by rebuilding the ad-hoc-signed agent was reset and reauthorized before hardware validation.

Hardware retest: bind Left/Right to PreviousDesktop/NextDesktop, perform repeated short swipes in both directions, and check behavior at the first/last desktop. Release the button before repositioning the mouse. Other mouse models and Linux/Windows have not been hardware-tested.
