### PR TITLE
fix(gui): rebuild the agent's launchd registration when its job is gone

### DIFF
--- a/crates/openlogi-desktop/src/platform/registration.rs
+++ b/crates/openlogi-desktop/src/platform/registration.rs
@@ -22,7 +22,7 @@ use macos as platform;
 use unsupported as platform;
 
 #[cfg(target_os = "macos")]
-pub use macos::agent_service_label;
+pub use macos::{agent_service_label, reregister_missing_job};
 
 /// Where the agent service stands with launchd, mirroring
 /// `SMAppServiceStatus` plus a "not this platform" arm.

--- a/crates/openlogi-desktop/src/platform/registration/macos.rs
+++ b/crates/openlogi-desktop/src/platform/registration/macos.rs
@@ -24,30 +24,66 @@ pub(super) fn status() -> ServiceStatus {
 enum EnsureAction {
     /// The service is absent — register it.
     Register,
-    /// The service is registered but a different executable registered it —
-    /// unregister-then-register, the dance Apple requires after an update.
+    /// The service is registered but the registration cannot be used as it
+    /// stands — unregister-then-register, the dance Apple requires after an
+    /// update and the only way to rebuild a job launchd has dropped.
     Reregister,
 }
 
-/// The pure convergence rule behind [`ensure_registered`] (which is what the
-/// tests below pin down).
+/// What launchd itself last said about the job, which is the one fact
+/// [`ServiceStatus`] cannot carry: `SMAppService` reads the Background Task
+/// Management record, not the launchd domain, and the two can disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LaunchdJob {
+    /// Nothing observed — the ordinary convergence call.
+    Unobserved,
+    /// Something removed the job (a `launchctl bootout` / `unload`, from a
+    /// cleanup tool or by hand) while the record survived it.
+    Missing,
+}
+
+/// The pure convergence rule behind [`ensure_registered`] and
+/// [`reregister_missing_job`] (which is what the tests below pin down).
 ///
 /// - Absent (`NotRegistered`) → register. `NotFound` also attempts it, so a
 ///   broken bundle surfaces an informative framework error instead of
 ///   silence.
 /// - `Enabled` with a stale version marker → re-register.
+/// - `Enabled` with no job left in launchd → re-register: registering again
+///   returns `kSMErrorAlreadyRegistered` against the surviving record and
+///   submits nothing, so the dance is what puts a startable job back.
 /// - `RequiresApproval` → nothing, ever: the user's System Settings choice
-///   outranks the update path too.
-fn ensure_action(status: ServiceStatus, stale: bool) -> Option<EnsureAction> {
+///   outranks the update and repair paths too.
+fn ensure_action(status: ServiceStatus, stale: bool, job: LaunchdJob) -> Option<EnsureAction> {
     match status {
         ServiceStatus::NotRegistered | ServiceStatus::NotFound => Some(EnsureAction::Register),
-        ServiceStatus::Enabled if stale => Some(EnsureAction::Reregister),
+        ServiceStatus::Enabled if stale || job == LaunchdJob::Missing => {
+            Some(EnsureAction::Reregister)
+        }
         ServiceStatus::Enabled | ServiceStatus::RequiresApproval => None,
     }
 }
 
 pub(super) fn ensure_registered() -> Result<(), String> {
-    match ensure_action(backend::status(), registration_is_stale()) {
+    converge(LaunchdJob::Unobserved)
+}
+
+/// Rebuild a registration whose launchd job is gone: the service still reports
+/// [`ServiceStatus::Enabled`], so nothing else here would touch it, yet every
+/// `launchctl kickstart` answers "Could not find service" and the agent can
+/// never be started again.
+///
+/// # Errors
+///
+/// The framework's error description, as for [`ensure_registered`].
+pub fn reregister_missing_job() -> Result<(), String> {
+    converge(LaunchdJob::Missing)
+}
+
+/// Apply [`ensure_action`] and record the version that registered, so the next
+/// update is recognised as stale.
+fn converge(job: LaunchdJob) -> Result<(), String> {
+    match ensure_action(backend::status(), registration_is_stale(), job) {
         Some(EnsureAction::Register) => {
             backend::register()?;
             tracing::info!("registered the agent service with launchd");
@@ -55,7 +91,14 @@ pub(super) fn ensure_registered() -> Result<(), String> {
         Some(EnsureAction::Reregister) => {
             backend::unregister()?;
             backend::register()?;
-            tracing::info!("re-registered the agent service (executable changed)");
+            match job {
+                LaunchdJob::Missing => {
+                    tracing::info!("re-registered the agent service (launchd had no job for it)");
+                }
+                LaunchdJob::Unobserved => {
+                    tracing::info!("re-registered the agent service (executable changed)");
+                }
+            }
         }
         None => return Ok(()),
     }
@@ -191,13 +234,19 @@ mod tests {
     #[test]
     fn an_absent_service_is_registered() {
         assert_eq!(
-            ensure_action(ServiceStatus::NotRegistered, false),
+            ensure_action(ServiceStatus::NotRegistered, false, LaunchdJob::Unobserved),
             Some(EnsureAction::Register)
         );
         // A fresh install has no marker, which reads as stale — that must
         // still be a plain register, not an unregister dance.
         assert_eq!(
-            ensure_action(ServiceStatus::NotRegistered, true),
+            ensure_action(ServiceStatus::NotRegistered, true, LaunchdJob::Unobserved),
+            Some(EnsureAction::Register)
+        );
+        // Nothing to unregister when the record is gone too, however the
+        // caller learned that launchd has no job.
+        assert_eq!(
+            ensure_action(ServiceStatus::NotRegistered, false, LaunchdJob::Missing),
             Some(EnsureAction::Register)
         );
     }
@@ -207,29 +256,63 @@ mod tests {
         // NotFound means a broken or bare bundle; attempting the register
         // surfaces an informative framework error instead of silence.
         assert_eq!(
-            ensure_action(ServiceStatus::NotFound, false),
+            ensure_action(ServiceStatus::NotFound, false, LaunchdJob::Unobserved),
             Some(EnsureAction::Register)
         );
     }
 
     #[test]
     fn a_current_registration_is_left_alone() {
-        assert_eq!(ensure_action(ServiceStatus::Enabled, false), None);
+        assert_eq!(
+            ensure_action(ServiceStatus::Enabled, false, LaunchdJob::Unobserved),
+            None
+        );
     }
 
     #[test]
     fn an_update_reregisters() {
         assert_eq!(
-            ensure_action(ServiceStatus::Enabled, true),
+            ensure_action(ServiceStatus::Enabled, true, LaunchdJob::Unobserved),
+            Some(EnsureAction::Reregister)
+        );
+    }
+
+    #[test]
+    fn a_job_launchd_lost_is_reregistered() {
+        // The record outlived its launchd job (a `bootout` / `unload` from a
+        // cleanup tool or by hand). The version marker is current, so nothing
+        // else here would act — and registering again would return
+        // `kSMErrorAlreadyRegistered` without submitting a job, leaving every
+        // kickstart to answer "Could not find service".
+        assert_eq!(
+            ensure_action(ServiceStatus::Enabled, false, LaunchdJob::Missing),
             Some(EnsureAction::Reregister)
         );
     }
 
     #[test]
     fn a_system_settings_disable_is_never_overridden() {
-        // Not on a normal launch, and not by the update path either: the
-        // user's Login Items choice outranks both.
-        assert_eq!(ensure_action(ServiceStatus::RequiresApproval, false), None);
-        assert_eq!(ensure_action(ServiceStatus::RequiresApproval, true), None);
+        // Not on a normal launch, not by the update path, and not by the
+        // repair either: the user's Login Items choice outranks all three.
+        assert_eq!(
+            ensure_action(
+                ServiceStatus::RequiresApproval,
+                false,
+                LaunchdJob::Unobserved
+            ),
+            None
+        );
+        assert_eq!(
+            ensure_action(
+                ServiceStatus::RequiresApproval,
+                true,
+                LaunchdJob::Unobserved
+            ),
+            None
+        );
+        assert_eq!(
+            ensure_action(ServiceStatus::RequiresApproval, false, LaunchdJob::Missing),
+            None
+        );
     }
 }

--- a/crates/openlogi-desktop/src/services/ipc/launch.rs
+++ b/crates/openlogi-desktop/src/services/ipc/launch.rs
@@ -2,11 +2,11 @@
 //!
 //! On macOS production is supervised-only: `launchctl kickstart` the
 //! registered service, register it on demand when absent (registration *is*
-//! the supervised start), and stop there — a login item the user switched
-//! off stays off, and a bundle whose registration fails needs its install
-//! fixed, not an unmanaged shadow agent. Only dev profiles (which never
-//! register) fall through to the direct launch (`open -g -n` / `disclaim`),
-//! which elsewhere is the only path.
+//! the supervised start), rebuild a registration launchd has no job for, and
+//! stop there — a login item the user switched off stays off, and a bundle
+//! whose registration fails needs its install fixed, not an unmanaged shadow
+//! agent. Only dev profiles (which never register) fall through to the direct
+//! launch (`open -g -n` / `disclaim`), which elsewhere is the only path.
 
 use std::path::PathBuf;
 
@@ -38,7 +38,8 @@ pub(super) fn spawn_agent() {
     // supervised rungs below; direct launch is reserved for dev profiles.
     #[cfg(target_os = "macos")]
     {
-        if kickstart_registered_agent() {
+        let kickstart = kickstart_registered_agent();
+        if kickstart == Kickstart::Started {
             return;
         }
         // Second rung: on a fresh install this reflex outruns the
@@ -47,9 +48,19 @@ pub(super) fn spawn_agent() {
         // profiles never register implicitly (a login item into `target/`
         // goes stale).
         if !openlogi_core::paths::is_dev_profile() {
-            match crate::platform::registration::ensure_registered() {
+            // A record whose job launchd no longer has still reports
+            // `Enabled`, so plain convergence would leave it alone and every
+            // kickstart from here on answers "Could not find service" — the
+            // agent would stay down for the rest of the session. Say what
+            // launchctl saw so the registration can rebuild the job.
+            let registered = if kickstart == Kickstart::NoSuchJob {
+                crate::platform::registration::reregister_missing_job()
+            } else {
+                crate::platform::registration::ensure_registered()
+            };
+            match registered {
                 Ok(()) => {
-                    if kickstart_registered_agent() {
+                    if kickstart_registered_agent() == Kickstart::Started {
                         return;
                     }
                 }
@@ -112,19 +123,38 @@ fn launch_agent(path: &std::path::Path) -> std::io::Result<()> {
     disclaim::Command::new(path).spawn().map(|_| ())
 }
 
-/// `launchctl kickstart` the agent's registered launchd service. Returns
-/// whether the start was handed to launchd — `false` (not registered, user
-/// switched it off in Login Items, or launchctl itself failed) lets the caller
-/// try registration before deciding whether its profile permits direct launch.
+/// What `launchctl kickstart` made of the agent's registered launchd service.
 #[cfg(target_os = "macos")]
-fn kickstart_registered_agent() -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kickstart {
+    /// launchd took the start request.
+    Started,
+    /// launchd has no job under that label — the registration record
+    /// `SMAppService` reads outlived the job itself, so only re-registering
+    /// can produce something startable again.
+    NoSuchJob,
+    /// Nothing to kickstart (not registered, or the user switched it off in
+    /// Login Items), or launchctl itself failed.
+    Unavailable,
+}
+
+/// `launchctl`'s exit status for "Could not find service": the label is not in
+/// the domain at all, as opposed to a job that exists and refused to start.
+#[cfg(target_os = "macos")]
+const LAUNCHCTL_SERVICE_NOT_FOUND: i32 = 113;
+
+/// `launchctl kickstart` the agent's registered launchd service. Anything but
+/// [`Kickstart::Started`] lets the caller converge the registration before
+/// deciding whether its profile permits direct launch.
+#[cfg(target_os = "macos")]
+fn kickstart_registered_agent() -> Kickstart {
     use crate::platform::registration;
 
     if registration::status() != registration::ServiceStatus::Enabled {
-        return false;
+        return Kickstart::Unavailable;
     }
     let Some(uid) = current_uid() else {
-        return false;
+        return Kickstart::Unavailable;
     };
     let target = format!("gui/{uid}/{}", registration::agent_service_label());
     match std::process::Command::new("/bin/launchctl")
@@ -134,7 +164,7 @@ fn kickstart_registered_agent() -> bool {
     {
         Ok(out) if out.status.success() => {
             info!(%target, "agent not running — kickstarted the registered service");
-            true
+            Kickstart::Started
         }
         Ok(out) => {
             warn!(
@@ -143,12 +173,24 @@ fn kickstart_registered_agent() -> bool {
                 stderr = %String::from_utf8_lossy(&out.stderr).trim(),
                 "launchctl kickstart failed"
             );
-            false
+            failed_kickstart(out.status.code())
         }
         Err(e) => {
             warn!(error = %e, "could not run launchctl");
-            false
+            Kickstart::Unavailable
         }
+    }
+}
+
+/// Read a failed `launchctl kickstart` exit code: only "could not find
+/// service" says the job is gone rather than unstartable, and only that
+/// warrants rebuilding the registration.
+#[cfg(target_os = "macos")]
+fn failed_kickstart(code: Option<i32>) -> Kickstart {
+    if code == Some(LAUNCHCTL_SERVICE_NOT_FOUND) {
+        Kickstart::NoSuchJob
+    } else {
+        Kickstart::Unavailable
     }
 }
 
@@ -210,6 +252,21 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn only_a_missing_service_asks_for_a_new_registration() {
+        // 113 is launchctl's "Could not find service": the label is not in the
+        // domain, which the registration can repair. Every other failure is a
+        // job that exists and did not start — re-registering would restart a
+        // working service for nothing.
+        assert_eq!(
+            failed_kickstart(Some(LAUNCHCTL_SERVICE_NOT_FOUND)),
+            Kickstart::NoSuchJob
+        );
+        assert_eq!(failed_kickstart(Some(1)), Kickstart::Unavailable);
+        // Killed by a signal: no exit code at all.
+        assert_eq!(failed_kickstart(None), Kickstart::Unavailable);
+    }
 
     #[test]
     fn helper_bundle_resolves_only_the_packaged_layout() {


### PR DESCRIPTION
## Summary

On macOS the GUI can never bring the agent back once something removes its
launchd job (`launchctl bootout` / `unload` — a cleanup tool, an uninstaller
sweep, or a manual restart attempt): `SMAppService` reads the Background Task
Management record and still reports `Enabled`, while the launchd domain has no
job, so `launchctl kickstart` answers exit 113 "Could not find service"
forever. `ensure_registered()` is keyed on the record — `Enabled` + a current
version marker means "nothing to do" — so the second rung of `spawn_agent`
converges on the state that is already broken, and the reflex repeats the same
two failed kickstarts every 30 s for the rest of the session. A relaunch does
not help, and neither does a reboot: login start reads the same record.

For the user this shows up as settings that save but never apply, behind the
fail-closed notice "saved, but the agent is not running, so it has not been
applied yet".

The record is the wrong authority for "can this be started". `launchctl` is the
only caller that learns the job is gone, so this passes that fact into the
registration rule, which then runs the unregister-then-register dance it
already owns — plain `register` returns `kSMErrorAlreadyRegistered` against the
surviving record and submits no job, so the dance is what rebuilds one.

## Changes

- `crates/openlogi-desktop/src/services/ipc/launch.rs`
  - `kickstart_registered_agent` returns a `Kickstart` outcome instead of a
    bool, so "launchd has no such job" (exit 113) is distinguishable from "not
    eligible" and "the job exists and did not start".
  - `spawn_agent`'s supervised second rung calls the new repair for
    `NoSuchJob` and keeps plain convergence for everything else.
  - New test pins the exit-code reading: only 113 asks for a new
    registration; other codes and a signal death do not.
- `crates/openlogi-desktop/src/platform/registration/macos.rs`
  - `ensure_action` takes what launchd last said about the job
    (`LaunchdJob::{Unobserved, Missing}`); `Enabled` + `Missing` re-registers.
    `RequiresApproval` still wins over the repair, as it does over the update
    path.
  - `ensure_registered()` and the new `reregister_missing_job()` are the two
    intent-named entry points over one `converge` body; the re-register log
    line now names which of the two reasons it acted on.
  - Tests extended for the new dimension, plus one for the repair case.
- `crates/openlogi-desktop/src/platform/registration.rs`: re-export the
  macOS-only repair next to `agent_service_label`. The cross-platform facade
  (and the `unsupported` stub) is unchanged — no other platform has a launchd
  job to lose.

The GUI startup path (`runtime.rs`) needs no equivalent change: with the agent
down the IPC client is already unreachable at launch, so the spawn reflex runs
this same path within a second of the window opening.

## Testing

```
cargo fmt --all -- --check
cargo clippy -p openlogi-desktop --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test -p openlogi-desktop
```

`openlogi-desktop` is the whole affected package set (no workspace package
depends on it).

Not runtime-tested on hardware: the patched rungs are production-profile only
(`is_dev_profile()` short-circuits them), so a dev bundle cannot exercise them.
What *was* verified on the affected machine (macOS 26.6.2 arm64, 0.8.3): the failure state reproduces exactly as described — kickstart
113 twice per attempt and `status=Enabled` in the "leaving it down" warning —
and forcing the same `EnsureAction::Reregister` this PR now reaches (by
deleting `~/.local/share/openlogi/registration-version` so the marker reads
stale) put the launchd job back and the agent, hook, tray and overlay came up
within seconds.

To reproduce and check the fix on a packaged build:

```sh
launchctl bootout "gui/$(id -u)/org.openlogi.agent.service"   # agent exits, job removed
launchctl print "gui/$(id -u)/org.openlogi.agent.service"     # "Could not find service"
# before: the GUI loops on kickstart 113 and the agent never returns
# after:  the GUI re-registers once and the agent comes back within a kickstart cycle
```

Cross-platform lanes not run: every new item is inside an existing
`#[cfg(target_os = "macos")]` block and no shared signature changed, but
Windows/Linux clippy were not executed locally (no devenv on this host).

Fixes #1302