### PR TITLE
fix(gui): place Windows actions ring correctly across mixed-DPI monitors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5713,12 +5713,14 @@ dependencies = [
  "openlogi-hook",
  "openlogi-ipc",
  "openlogi-ui",
+ "raw-window-handle",
  "rust-i18n",
  "succession",
  "tarpc",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/openlogi-overlay/Cargo.toml
+++ b/crates/openlogi-overlay/Cargo.toml
@@ -44,5 +44,9 @@ objc2-app-kit = { workspace = true, features = ["NSApplication", "NSResponder", 
 # NSEvent global-monitor handlers are ObjC blocks (click-away dismissal).
 block2 = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+raw-window-handle = "0.6"
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
+
 [lints]
 workspace = true

--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -29,7 +29,8 @@ use tracing_subscriber::EnvFilter;
 use openlogi_core::action_ring::DISPLAY_LIFETIME;
 
 use crate::agent::{Ipc, OverlayCommand, spawn_ipc};
-use crate::ring::{RingView, ring_window_options};
+use crate::platform::RingPlacement;
+use crate::ring::RingView;
 use crate::session::{ClickAwaySession, claim_the_role, spawn_click_away_dismissal};
 
 fn main() -> Result<()> {
@@ -72,15 +73,33 @@ fn main() -> Result<()> {
                     for handle in cx.windows() {
                         let _ = handle.update(cx, |_, window, _| window.remove_window());
                     }
-                    let options = ring_window_options(cx);
+                    let placement = match RingPlacement::capture(cx) {
+                        Ok(placement) => placement,
+                        Err(error) => {
+                            warn!(%error, "could not locate Actions Ring display");
+                            let _ = commands.send(OverlayCommand::Cancel {
+                                session_id: invocation.session_id,
+                            });
+                            return;
+                        }
+                    };
                     let commands = commands.clone();
                     let timeout_commands = commands.clone();
                     let session_id = invocation.session_id;
-                    match cx.open_window(options, |_, cx| {
+                    match cx.open_window(placement.window_options(), |_, cx| {
                         cx.new(|_| RingView::new(invocation, commands, &live_session))
                     }) {
                         Ok(handle) => {
-                            platform::configure_windows();
+                            if let Err(error) = handle
+                                .update(cx, |_, window, _| placement.show(window))
+                                .and_then(std::convert::identity)
+                            {
+                                warn!(%error, "could not position Actions Ring window");
+                                let _ = handle.update(cx, |_, window, _| window.remove_window());
+                                let _ =
+                                    timeout_commands.send(OverlayCommand::Cancel { session_id });
+                                return;
+                            }
                             cx.spawn(async move |cx| {
                                 cx.background_executor().timer(DISPLAY_LIFETIME).await;
                                 if handle

--- a/crates/openlogi-overlay/src/platform.rs
+++ b/crates/openlogi-overlay/src/platform.rs
@@ -1,5 +1,16 @@
 //! Native window policy for the standalone Actions Ring overlay.
 
+#[cfg(not(target_os = "windows"))]
+mod placement;
+// Keep Windows geometry tests runnable on the host; only native.rs needs Win32.
+#[cfg(any(target_os = "windows", test))]
+mod windows;
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) use placement::RingPlacement;
+#[cfg(target_os = "windows")]
+pub(crate) use windows::RingPlacement;
+
 /// Keep the overlay out of the Dock and app switcher.
 #[cfg(target_os = "macos")]
 pub fn configure_application() {
@@ -30,8 +41,8 @@ pub fn configure_windows() {
 #[cfg(not(target_os = "macos"))]
 pub fn configure_application() {}
 
-/// Other GPUI backends need no additional native window configuration here.
-#[cfg(not(target_os = "macos"))]
+/// Linux needs no additional native window configuration here.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub fn configure_windows() {}
 
 /// Owner of the native click-away event monitor; dropping it removes the
@@ -88,6 +99,7 @@ pub fn watch_clicks_outside(_on_mouse_down: impl Fn() + 'static) -> Option<Click
 
 /// One display's global geometry, in the same top-left-origin global point
 /// space that `openlogi_hook::cursor_position()` reports.
+#[cfg(not(target_os = "windows"))]
 pub struct CursorDisplay {
     /// Native display id; on macOS the `CGDirectDisplayID`, numerically equal
     /// to GPUI's `DisplayId` for the same display.
@@ -135,9 +147,9 @@ pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
     })
 }
 
-/// Away from macOS the GPUI display list already carries global origins, so
-/// there is nothing to resolve natively.
-#[cfg(not(target_os = "macos"))]
+/// On Linux the GPUI display list already carries global origins, so there is
+/// nothing to resolve natively.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub fn display_containing(_x: f64, _y: f64) -> Option<CursorDisplay> {
     None
 }

--- a/crates/openlogi-overlay/src/platform/placement.rs
+++ b/crates/openlogi-overlay/src/platform/placement.rs
@@ -1,0 +1,88 @@
+//! GPUI placement on macOS and Linux.
+
+use gpui::{Bounds, DisplayId, Pixels, Point, Size, WindowBounds, WindowOptions, point, px};
+
+use crate::ring::{WINDOW_SIZE, clamp_window_origin, ring_window_options};
+
+/// Captured placement for one invocation, before its window is opened.
+pub(crate) struct RingPlacement {
+    display_id: Option<DisplayId>,
+    bounds: Bounds<Pixels>,
+}
+
+impl RingPlacement {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "native cursor coordinates are screen-sized and exactly usable as GPUI f32 pixels"
+    )]
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "the Windows placement capture is fallible"
+    )]
+    pub(crate) fn capture(cx: &mut gpui::App) -> anyhow::Result<Self> {
+        let cursor = openlogi_hook::cursor_position();
+        let size = Size::new(px(WINDOW_SIZE), px(WINDOW_SIZE));
+        // macOS GPUI bounds are display-relative; translate the global cursor
+        // into the native display's space before clamping.
+        let native_display = cursor
+            .as_ref()
+            .and_then(|cursor| super::display_containing(cursor.x, cursor.y));
+        let (display_id, center, display_bounds) =
+            if let (Some(cursor), Some(display)) = (&cursor, native_display) {
+                (
+                    Some(gpui::DisplayId::from(display.id)),
+                    point(
+                        px((cursor.x - display.origin.0) as f32),
+                        px((cursor.y - display.origin.1) as f32),
+                    ),
+                    Some(Bounds::new(
+                        Point::default(),
+                        Size::new(px(display.size.0 as f32), px(display.size.1 as f32)),
+                    )),
+                )
+            } else {
+                // Linux, or a failed macOS lookup: preserve the GPUI fallback.
+                let cursor_point = cursor
+                    .as_ref()
+                    .map(|cursor| point(px(cursor.x as f32), px(cursor.y as f32)));
+                let display = cursor_point
+                    .and_then(|cursor| {
+                        cx.displays()
+                            .into_iter()
+                            .find(|display| display.bounds().contains(&cursor))
+                    })
+                    .or_else(|| cx.primary_display());
+                let center = cursor_point
+                    .or_else(|| display.as_ref().map(|display| display.bounds().center()))
+                    .unwrap_or_default();
+                let bounds = display.as_ref().map(|display| display.bounds());
+                (display.map(|display| display.id()), center, bounds)
+            };
+        let desired_origin = point(center.x - size.width / 2.0, center.y - size.height / 2.0);
+        let origin = display_bounds.map_or(desired_origin, |display_bounds| {
+            clamp_window_origin(desired_origin, size, display_bounds)
+        });
+        Ok(Self {
+            bounds: Bounds::new(origin, size),
+            display_id,
+        })
+    }
+
+    pub(crate) fn window_options(&self) -> WindowOptions {
+        WindowOptions {
+            window_bounds: Some(WindowBounds::Windowed(self.bounds)),
+            display_id: self.display_id,
+            ..ring_window_options()
+        }
+    }
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        clippy::unused_self,
+        reason = "the Windows implementation consumes the captured geometry and can fail"
+    )]
+    pub(crate) fn show(self, _window: &mut gpui::Window) -> anyhow::Result<()> {
+        super::configure_windows();
+        Ok(())
+    }
+}

--- a/crates/openlogi-overlay/src/platform/windows.rs
+++ b/crates/openlogi-overlay/src/platform/windows.rs
@@ -1,0 +1,130 @@
+//! Windows placement stays in physical virtual-desktop coordinates. GPUI's
+//! per-monitor logical rectangles can overlap at mixed DPI, so neither cursor
+//! monitor selection nor HWND positioning can use logical containment.
+
+use gpui::{Bounds, DevicePixels, DisplayId, Point, WindowOptions, point, size};
+
+use crate::ring::{WINDOW_SIZE, ring_window_options};
+
+#[cfg(target_os = "windows")]
+mod native;
+
+/// One native cursor/monitor snapshot, kept through hidden-window creation.
+pub(crate) struct RingPlacement {
+    display_id: DisplayId,
+    cursor: Point<DevicePixels>,
+    display: Bounds<DevicePixels>,
+}
+
+impl RingPlacement {
+    pub(crate) fn window_options(&self) -> WindowOptions {
+        WindowOptions {
+            display_id: Some(self.display_id),
+            // GPUI initially converts bounds using the default-position HWND's
+            // DPI, not the requested monitor's. Do not show that placement.
+            show: false,
+            ..ring_window_options()
+        }
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "360 DIP scaled by a native display DPI fits in screen-sized i32 pixels"
+    )]
+    fn bounds(&self, dpi: u32) -> Bounds<DevicePixels> {
+        let edge = DevicePixels((f64::from(WINDOW_SIZE) * f64::from(dpi) / 96.0).round() as i32);
+        let half = DevicePixels(edge.0 / 2);
+        let desired = self.cursor - point(half, half);
+        // If the display is smaller than the ring, anchor to its top-left
+        // rather than inverting the clamp range or changing the ring's scale.
+        let max = point(
+            (self.display.right() - edge).max(self.display.left()),
+            (self.display.bottom() - edge).max(self.display.top()),
+        );
+        Bounds::new(desired.clamp(&self.display.origin, &max), size(edge, edge))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn placement(cursor: (i32, i32), rect: (i32, i32, i32, i32)) -> RingPlacement {
+        RingPlacement {
+            display_id: DisplayId::from(42),
+            cursor: point(DevicePixels(cursor.0), DevicePixels(cursor.1)),
+            display: Bounds::new(
+                point(DevicePixels(rect.0), DevicePixels(rect.1)),
+                size(DevicePixels(rect.2 - rect.0), DevicePixels(rect.3 - rect.1)),
+            ),
+        }
+    }
+
+    #[test]
+    fn native_monitor_identity_survives_logical_overlap() {
+        // 100% primary [0,1920), 200% right-hand monitor [1920,4480).
+        // The old DIP point (1000,400) also matched the primary display.
+        let placement = placement((2000, 800), (1920, 0, 4480, 1440));
+        let options = placement.window_options();
+        assert_eq!(options.display_id, Some(DisplayId::from(42)));
+        assert!(
+            !options.show,
+            "no frame may be shown at the default HWND DPI"
+        );
+        let bounds = placement.bounds(192);
+        assert_eq!(bounds.origin, point(DevicePixels(1920), DevicePixels(440)));
+        assert_eq!(bounds.size, size(DevicePixels(720), DevicePixels(720)));
+    }
+
+    #[test]
+    fn physical_center_is_independent_of_monitor_scale_and_global_origin() {
+        for (cursor, rect, dpi, origin, edge) in [
+            ((3000, 850), (1920, 0, 4480, 1440), 192, (2640, 490), 720),
+            ((900, 600), (0, 0, 1920, 1080), 96, (720, 420), 360),
+            // 150% left, 125% above, and 175% below-left with nonzero X/Y.
+            ((-1400, 450), (-2560, -200, 0, 1240), 144, (-1670, 180), 540),
+            ((-300, -700), (-640, -1440, 1920, 0), 120, (-525, -925), 450),
+            (
+                (-1200, 1600),
+                (-1920, 1080, 0, 2520),
+                168,
+                (-1515, 1285),
+                630,
+            ),
+        ] {
+            let bounds = placement(cursor, rect).bounds(dpi);
+            assert_eq!(
+                bounds.origin,
+                point(DevicePixels(origin.0), DevicePixels(origin.1))
+            );
+            assert_eq!(bounds.size, size(DevicePixels(edge), DevicePixels(edge)));
+        }
+    }
+
+    #[test]
+    fn monitor_seams_and_outer_edges_clamp_on_the_selected_side() {
+        for (cursor, rect, dpi, origin) in [
+            ((1919, 600), (0, 0, 1920, 1080), 96, (1560, 420)),
+            ((1920, 600), (1920, 0, 4480, 1440), 192, (1920, 240)),
+            ((4479, 1439), (1920, 0, 4480, 1440), 192, (3760, 720)),
+            ((-1, 600), (-2560, -200, 0, 1240), 144, (-540, 330)),
+            ((0, 600), (0, 0, 1920, 1080), 96, (0, 420)),
+            ((600, -1), (-640, -1440, 1920, 0), 120, (375, -450)),
+            ((600, 0), (0, 0, 1920, 1080), 96, (420, 0)),
+            ((-640, -1440), (-640, -1440, 1920, 0), 120, (-640, -1440)),
+        ] {
+            let bounds = placement(cursor, rect).bounds(dpi);
+            assert_eq!(
+                bounds.origin,
+                point(DevicePixels(origin.0), DevicePixels(origin.1))
+            );
+        }
+    }
+
+    #[test]
+    fn undersized_display_keeps_a_valid_clamp_range() {
+        let bounds = placement((-100, -50), (-200, -100, 0, 0)).bounds(192);
+        assert_eq!(bounds.origin, point(DevicePixels(-200), DevicePixels(-100)));
+        assert_eq!(bounds.size, size(DevicePixels(720), DevicePixels(720)));
+    }
+}

--- a/crates/openlogi-overlay/src/platform/windows/native.rs
+++ b/crates/openlogi-overlay/src/platform/windows/native.rs
@@ -1,0 +1,128 @@
+//! The Win32 boundary: sample once, establish the HWND's target DPI while
+//! hidden, then place and reveal the ring without activating it.
+
+use anyhow::{Context as _, Result, ensure};
+use gpui::{App, Bounds, DevicePixels, DisplayId, Window, point, size};
+use raw_window_handle::{HasWindowHandle as _, RawWindowHandle};
+use windows_sys::Win32::Foundation::{HWND, POINT};
+use windows_sys::Win32::Graphics::Gdi::{
+    GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTOPRIMARY, MONITORINFO,
+    MonitorFromPoint, MonitorFromWindow,
+};
+use windows_sys::Win32::UI::HiDpi::GetDpiForWindow;
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    GetCursorPos, SWP_NOACTIVATE, SWP_NOZORDER, SWP_SHOWWINDOW, SetWindowPos,
+};
+
+use super::RingPlacement;
+
+impl RingPlacement {
+    #[expect(
+        unsafe_code,
+        reason = "read-only Win32 cursor and monitor queries with checked outputs"
+    )]
+    pub(crate) fn capture(_cx: &mut App) -> Result<Self> {
+        let mut cursor = POINT::default();
+        // SAFETY: cursor is writable for the duration of the call. This GPUI
+        // process is PerMonitorV2-aware, so GetCursorPos returns physical pixels.
+        let has_cursor = unsafe { GetCursorPos(&raw mut cursor) } != 0;
+        let monitor = if has_cursor {
+            // SAFETY: POINT is passed by value. Use this same sample for both
+            // selection and positioning, never a second cursor read.
+            unsafe { MonitorFromPoint(cursor, MONITOR_DEFAULTTONEAREST) }
+        } else {
+            // SAFETY: a null HWND plus DEFAULTTOPRIMARY selects the primary.
+            unsafe { MonitorFromWindow(std::ptr::null_mut(), MONITOR_DEFAULTTOPRIMARY) }
+        };
+        let mut info = MONITORINFO {
+            cbSize: u32::try_from(std::mem::size_of::<MONITORINFO>())?,
+            ..MONITORINFO::default()
+        };
+        // SAFETY: monitor is from a native query and info has the required size;
+        // a removed monitor is reported as failure, not used as geometry.
+        if unsafe { GetMonitorInfoW(monitor, &raw mut info) } == 0 {
+            return Err(std::io::Error::last_os_error()).context("query ring monitor bounds");
+        }
+        let rect = info.rcMonitor;
+        let display = Bounds::new(
+            point(DevicePixels(rect.left), DevicePixels(rect.top)),
+            size(
+                DevicePixels(rect.right - rect.left),
+                DevicePixels(rect.bottom - rect.top),
+            ),
+        );
+        Ok(Self {
+            // The pinned GPUI Windows backend uses HMONITOR as DisplayId.
+            display_id: DisplayId::from(monitor as usize as u64),
+            cursor: if has_cursor {
+                point(DevicePixels(cursor.x), DevicePixels(cursor.y))
+            } else {
+                display.center()
+            },
+            display,
+        })
+    }
+
+    #[expect(
+        unsafe_code,
+        reason = "borrow the live GPUI HWND on its owning UI thread"
+    )]
+    pub(crate) fn show(self, window: &mut Window) -> Result<()> {
+        let RawWindowHandle::Win32(handle) = window
+            .window_handle()
+            .map_err(|error| anyhow::anyhow!("get ring HWND: {error}"))?
+            .as_raw()
+        else {
+            anyhow::bail!("ring window has no Win32 handle");
+        };
+        let hwnd = handle.hwnd.get() as HWND;
+        // Bootstrap a tiny hidden window well inside the selected monitor.
+        // SetWindowPos synchronously delivers WM_DPICHANGED; GPUI applies its
+        // suggested rectangle and updates rendering scale before this returns.
+        // Final geometry is applied only AFTER that transition, so the suggested
+        // rectangle cannot move a cursor-centred ring away from its anchor.
+        let anchor = Bounds::new(
+            self.display.center(),
+            size(DevicePixels(1), DevicePixels(1)),
+        );
+        set_bounds(hwnd, anchor, SWP_NOACTIVATE | SWP_NOZORDER)?;
+        // SAFETY: hwnd belongs to the still-borrowed window.
+        let dpi = unsafe { GetDpiForWindow(hwnd) };
+        ensure!(dpi != 0, "could not read ring window DPI");
+        // SAFETY: read-only query on the still-borrowed window.
+        let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+        ensure!(
+            monitor as usize as u64 == u64::from(self.display_id),
+            "ring monitor changed during window creation"
+        );
+        set_bounds(
+            hwnd,
+            self.bounds(dpi),
+            SWP_NOACTIVATE | SWP_NOZORDER | SWP_SHOWWINDOW,
+        )
+    }
+}
+
+#[expect(
+    unsafe_code,
+    reason = "SetWindowPos on a borrowed HWND, with physical screen bounds"
+)]
+fn set_bounds(hwnd: HWND, bounds: Bounds<DevicePixels>, flags: u32) -> Result<()> {
+    // SAFETY: the caller holds the live GPUI window on its owning thread;
+    // NOZORDER makes the null insert-after handle irrelevant.
+    if unsafe {
+        SetWindowPos(
+            hwnd,
+            std::ptr::null_mut(),
+            bounds.origin.x.0,
+            bounds.origin.y.0,
+            bounds.size.width.0,
+            bounds.size.height.0,
+            flags,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error()).context("position Actions Ring window");
+    }
+    Ok(())
+}

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -4,11 +4,12 @@
 //! clamped to the display it came up on, so a ring raised near a screen edge
 //! stays whole instead of being cut off.
 
+#[cfg(any(not(target_os = "windows"), test))]
+use gpui::{Bounds, Pixels, Point, Size, point};
 use gpui::{
-    Bounds, Context, Hsla, InteractiveElement, IntoElement, ParentElement, Pixels, Point, Render,
-    SharedString, Size, StatefulInteractiveElement as _, Styled, Window,
-    WindowBackgroundAppearance, WindowBounds, WindowKind, WindowOptions, div, point,
-    prelude::FluentBuilder as _, px, svg,
+    Context, Hsla, InteractiveElement, IntoElement, ParentElement, Render, SharedString,
+    StatefulInteractiveElement as _, Styled, Window, WindowBackgroundAppearance, WindowKind,
+    WindowOptions, div, prelude::FluentBuilder as _, px, svg,
 };
 use openlogi_core::binding::{Action, ActionRingSlot};
 use openlogi_ipc::ActionRingInvocation;
@@ -18,7 +19,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::agent::OverlayCommand;
-use crate::platform;
 use crate::session::{ClickAwaySession, ShowingRing};
 
 pub(crate) const WINDOW_SIZE: f32 = 360.0;
@@ -225,60 +225,9 @@ impl Render for RingView {
     }
 }
 
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "native cursor coordinates are screen-sized and exactly usable as GPUI f32 pixels"
-)]
-pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
-    let cursor = openlogi_hook::cursor_position();
-    let size = Size::new(px(WINDOW_SIZE), px(WINDOW_SIZE));
-    // GPUI window bounds are display-relative (`display.bounds()` zeroes every
-    // origin) while the hook reports the cursor in global coordinates, so the
-    // cursor's display must be resolved natively and the cursor translated into
-    // that display's space. Feeding the global point straight into the clamp
-    // pins a ring triggered on a secondary display to the primary one's edge.
-    let native_display = cursor
-        .as_ref()
-        .and_then(|cursor| platform::display_containing(cursor.x, cursor.y));
-    let (display_id, center, display_bounds) =
-        if let (Some(cursor), Some(display)) = (&cursor, native_display) {
-            (
-                Some(gpui::DisplayId::from(display.id)),
-                point(
-                    px((cursor.x - display.origin.0) as f32),
-                    px((cursor.y - display.origin.1) as f32),
-                ),
-                Some(Bounds::new(
-                    Point::default(),
-                    Size::new(px(display.size.0 as f32), px(display.size.1 as f32)),
-                )),
-            )
-        } else {
-            // No cursor or no native lookup (non-macOS): GPUI's own display
-            // list, centering on the display when the cursor is unknown.
-            let cursor_point = cursor
-                .as_ref()
-                .map(|cursor| point(px(cursor.x as f32), px(cursor.y as f32)));
-            let display = cursor_point
-                .and_then(|cursor| {
-                    cx.displays()
-                        .into_iter()
-                        .find(|display| display.bounds().contains(&cursor))
-                })
-                .or_else(|| cx.primary_display());
-            let center = cursor_point
-                .or_else(|| display.as_ref().map(|display| display.bounds().center()))
-                .unwrap_or_default();
-            let bounds = display.as_ref().map(|display| display.bounds());
-            (display.map(|display| display.id()), center, bounds)
-        };
-    let desired_origin = point(center.x - size.width / 2.0, center.y - size.height / 2.0);
-    let origin = display_bounds.map_or(desired_origin, |display_bounds| {
-        clamp_window_origin(desired_origin, size, display_bounds)
-    });
-    let bounds = Bounds::new(origin, size);
+/// Appearance shared by the platform-specific placement paths.
+pub(crate) fn ring_window_options() -> WindowOptions {
     WindowOptions {
-        window_bounds: Some(WindowBounds::Windowed(bounds)),
         titlebar: None,
         focus: false,
         show: true,
@@ -286,13 +235,13 @@ pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
         is_movable: false,
         is_resizable: false,
         is_minimizable: false,
-        display_id,
         window_background: WindowBackgroundAppearance::Transparent,
         app_id: Some("openlogi-action-ring".to_string()),
         ..WindowOptions::default()
     }
 }
 
+#[cfg(any(not(target_os = "windows"), test))]
 pub(crate) fn clamp_window_origin(
     desired: Point<Pixels>,
     window_size: Size<Pixels>,


### PR DESCRIPTION
## Summary

Keep Windows Actions Ring monitor selection and placement in physical virtual-desktop coordinates on mixed-DPI multi-monitor setups. Follow-up to #1246, based on the freshly fetched `origin/master` containing that merge; this does not change the hook's cursor-coordinate API or IPC.

The mixed-monitor failure is **source-verified, not reproduced on Windows hardware**. The locked GPUI revision remains unchanged. Two parts of the current path are unsafe to compose:

- GPUI divides each monitor's global physical origin by that monitor's scale. A 100% primary at physical x=[0,1920) and a 200% right monitor at x=[1920,4480) report logical x=[0,1920) and x=[960,2240). The right-monitor cursor (2000,800) becomes (1000,400), so the old first-containing-logical-display lookup can select the primary.
- A correct `display_id` alone is insufficient: GPUI creates the HWND at `CW_USEDEFAULT`, reads `GetDpiForWindow`, then uses that initial HWND scale for `SetWindowPlacement`. It need not be the requested monitor's scale. See the pinned [display geometry](https://github.com/zed-industries/zed/blob/cc053a4a6fa2fd0e8793201ed9099466af1be0b1/crates/gpui_windows/src/display.rs#L37-L79) and [window creation](https://github.com/zed-industries/zed/blob/cc053a4a6fa2fd0e8793201ed9099466af1be0b1/crates/gpui_windows/src/window.rs#L496-L573).

## Changes

- `openlogi-overlay`: sample `GetCursorPos` once, select with `MonitorFromPoint`, and retain that monitor's native ID and physical bounds for the invocation. If the cursor query fails, retain the existing primary-display centering policy.
- `openlogi-overlay`: create the GPUI window hidden, move a small hidden anchor into the selected monitor, and let the synchronous `WM_DPICHANGED` transition complete. Read the HWND's actual DPI, calculate a 360-DIP ring in physical pixels, clamp to the captured display, then position/show without activation. Placement failures remove the hidden window and cancel the session rather than showing a guessed position.
- `openlogi-overlay`: keep macOS/Linux placement behavior in a separate implementation of the same placement lifecycle. No rendering, hook, or wire changes.
- `openlogi-overlay`: four portable regression tests cover retained identity/hidden creation, 100/125/150/175/200% scaling, asymmetric nonzero/negative origins, left/above/below-left displays, both sides of horizontal/vertical seams, outer edges, and an undersized display.
- Dependencies: use already-locked `raw-window-handle` and `windows-sys` on Windows only; no dependency version or GPUI pin changes.

## Testing

All Rust commands below ran with `RUSTFLAGS="-D warnings"` in a Linux x86_64 orb:

- `cargo test -p openlogi-overlay platform::windows` — 4 passed.
- `cargo clippy -p openlogi-overlay --all-targets -- -D warnings` — passed.
- `cargo test -p openlogi-overlay` — 21 passed.
- `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-overlay --all-targets -- -D warnings` — passed, including the native Win32 implementation and test target.
- Full pre-push local gate:
  - `cargo fmt --all -- --check` — passed.
  - `cargo clippy --workspace --all-targets -- -D warnings` — passed.
  - `cargo test --workspace` — 1407 passed, 0 failed; 2 existing ignored HID++/derive doctests.
  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent` — passed.
- `cargo xtask ci clippy-windows cargo-deny` — 2 passed, 0 failed, 0 skipped. The Windows proxy is a subset, not the native Windows workspace CI job; the overlay was additionally cross-linted directly above.
- `typos --config .config/typos.toml crates/openlogi-overlay` and `git diff --check` — passed. Commit and pre-push hooks ran without bypasses, including full-workspace Clippy and non-GUI rustdoc at push.
- Linux runtime smoke: a temporary harness loaded the actual `RingView` and placement modules under Xvfb/Mesa, with Openbox/picom also tried. At cursor (800,600), GPUI bounds were (620,420), 360×360; at cursor (1599,1199), bounds were (1240,840), 360×360 on a 1600×1200 display. Both coordinate assertions passed. **Visual verification was inconclusive:** captured windows were blank, including an unchanged `origin/master` baseline in the same harness. No screenshot is presented as proof of rendering. The harness is not included in the patch.

Not runtime-tested on hardware. No Windows or macOS graphical host was available. Native Windows workspace CI, macOS checks, and Windows mixed-DPI rendering/activation behavior have not been verified locally. The unrelated MSRV, wasm, and Linux-musl cross jobs were not run; Linux cfg was checked natively by the full workspace gate.

### Maintainer Windows verification

1. Build all three binaries from this branch (`cargo build --release -p openlogi-desktop -p openlogi-agent -p openlogi-overlay`), quit older instances/helpers, and run the rebuilt app with an Actions Ring binding on a Logitech device.
2. Use a 1920×1080 100% primary with a 2560×1440 200% display to its right. Keep the foreground app on the primary and make the **first** ring invocation on the secondary. Away from edges, the ring must center on the cursor at 720×720 physical pixels. For example, cursor (3000,850) should yield origin (2640,490). At cursor (2000,800), expect the left-edge clamp to origin (1920,440), not a jump to the primary.
3. Invoke immediately on both sides of the seam (x=1919/1920), at outer corners, and away from edges. Repeat while alternating monitors. Confirm no flash at a primary/default-screen position, no focus steal, and that hover, click activation, cancellation, and timeout still work.
4. Reverse the DPI arrangement (200% primary, 100% secondary), then try 125%/150%/175% combinations. Put the secondary left of and above the primary, including non-aligned top/left edges and negative X/Y. Check both sides of x=0 and y=0 seams.
5. Rearrange displays or change scaling between invocations and reopen the ring. Each invocation must use the new monitor geometry and scale; no overlay restart should be needed.

Refs #1027; follow-up to #1246.
