### PR TITLE
fix(agent): fence queued pairing discovery after selection

### DIFF
--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -109,13 +109,6 @@ impl SessionOwner {
         }
     }
 
-    fn active_mut(&mut self) -> Option<&mut ActiveSession> {
-        match &mut self.state {
-            SessionState::Active(session) => Some(session),
-            SessionState::Idle | SessionState::Admitting(_) => None,
-        }
-    }
-
     fn end(&mut self, id: SessionId) -> bool {
         if matches!(&self.state, SessionState::Active(session) if session.id == id) {
             self.state = SessionState::Idle;
@@ -199,7 +192,7 @@ impl PairingManager {
     /// Pair with a previously discovered device by address.
     pub fn pair(&self, address: [u8; 6]) -> Result<(), PairingCommandError> {
         with_session_owner(&self.session, |owner| {
-            let Some(session) = owner.active_mut() else {
+            let SessionState::Active(session) = &mut owner.state else {
                 warn!(?address, "pair requested without an active session");
                 return Err(PairingCommandError::NoActiveSession);
             };
@@ -327,9 +320,10 @@ fn apply_session_event(
     observable: &ObservableState,
 ) -> Option<PairingUpdate> {
     with_session_owner(session, |owner| {
-        let active = owner
-            .active_mut()
-            .filter(|active| active.id == event.session)?;
+        let active = match &mut owner.state {
+            SessionState::Active(active) if active.id == event.session => active,
+            _ => return None,
+        };
         let update = match event.event {
             PairingEvent::Searching | PairingEvent::DeviceFound(_)
                 if matches!(active.phase, ActivePhase::Pairing) =>

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -53,7 +53,14 @@ enum SessionState {
 struct ActiveSession {
     id: SessionId,
     devices: DeviceCache,
+    phase: ActivePhase,
     _receiver_lease: ExclusiveReceiverLease,
+}
+
+enum ActivePhase {
+    Discovering,
+    /// A selection was admitted or a passkey received; discovery is closed.
+    Pairing,
 }
 
 impl Default for SessionOwner {
@@ -83,6 +90,7 @@ impl SessionOwner {
         self.state = SessionState::Active(ActiveSession {
             id,
             devices: HashMap::new(),
+            phase: ActivePhase::Discovering,
             _receiver_lease: receiver_lease,
         });
         true
@@ -101,10 +109,10 @@ impl SessionOwner {
         }
     }
 
-    fn active_mut(&mut self, id: SessionId) -> Option<&mut ActiveSession> {
+    fn active_mut(&mut self) -> Option<&mut ActiveSession> {
         match &mut self.state {
-            SessionState::Active(session) if session.id == id => Some(session),
-            SessionState::Idle | SessionState::Admitting(_) | SessionState::Active(_) => None,
+            SessionState::Active(session) => Some(session),
+            SessionState::Idle | SessionState::Admitting(_) => None,
         }
     }
 
@@ -191,7 +199,7 @@ impl PairingManager {
     /// Pair with a previously discovered device by address.
     pub fn pair(&self, address: [u8; 6]) -> Result<(), PairingCommandError> {
         with_session_owner(&self.session, |owner| {
-            let Some(session) = owner.active() else {
+            let Some(session) = owner.active_mut() else {
                 warn!(?address, "pair requested without an active session");
                 return Err(PairingCommandError::NoActiveSession);
             };
@@ -205,6 +213,9 @@ impl PairingManager {
                     device,
                 })
                 .map_err(|_| PairingCommandError::WatcherUnavailable)?;
+            // Fence events already queued by the watcher under the same lock
+            // as event acceptance, and only after the command was sent.
+            session.phase = ActivePhase::Pairing;
             self.observable.set_pairing(Some(PairingPhase::Pairing));
             Ok(())
         })
@@ -316,23 +327,28 @@ fn apply_session_event(
     observable: &ObservableState,
 ) -> Option<PairingUpdate> {
     with_session_owner(session, |owner| {
-        if owner.active().map(|session| session.id) != Some(event.session) {
-            return None;
-        }
+        let active = owner
+            .active_mut()
+            .filter(|active| active.id == event.session)?;
         let update = match event.event {
+            PairingEvent::Searching | PairingEvent::DeviceFound(_)
+                if matches!(active.phase, ActivePhase::Pairing) =>
+            {
+                return None;
+            }
             PairingEvent::Searching => PairingUpdate::Searching,
             PairingEvent::DeviceFound(device) => {
                 let found = FoundDevice {
                     address: device.address,
                     name: device.name.clone(),
                 };
-                owner
-                    .active_mut(event.session)?
-                    .devices
-                    .insert(device.address, device);
+                active.devices.insert(device.address, device);
                 PairingUpdate::DeviceFound(found)
             }
-            PairingEvent::Passkey(method) => PairingUpdate::Passkey(method),
+            PairingEvent::Passkey(method) => {
+                active.phase = ActivePhase::Pairing;
+                PairingUpdate::Passkey(method)
+            }
             PairingEvent::Paired { slot } => PairingUpdate::Paired { slot },
             PairingEvent::Failed(error) => PairingUpdate::Failed(error.into()),
         };

--- a/crates/openlogi-agent/src/pairing/tests.rs
+++ b/crates/openlogi-agent/src/pairing/tests.rs
@@ -154,6 +154,287 @@ fn pair_without_active_session_does_not_publish_pairing() {
 }
 
 #[tokio::test]
+async fn audit_queued_device_found_cannot_revert_selected_phase() {
+    let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+    let manager = manager_with_ctrl(ctrl_tx);
+    let session = start_session(&manager, &mut ctrl_rx).await;
+    let selected = discovered_device();
+    apply_session_event(
+        SessionEvent {
+            session,
+            event: PairingEvent::DeviceFound(selected.clone()),
+        },
+        &manager.session,
+        &manager.observable,
+    );
+    let queued = DiscoveredDevice {
+        address: [6, 5, 4, 3, 2, 1],
+        name: "queued second device".to_string(),
+        ..discovered_device()
+    };
+    let (raw_tx, mut raw_rx) = mpsc::unbounded_channel();
+    raw_tx
+        .send(SessionEvent {
+            session,
+            event: PairingEvent::DeviceFound(queued.clone()),
+        })
+        .unwrap();
+
+    manager.pair(selected.address).unwrap();
+    assert_eq!(
+        manager.observable.snapshot().pairing,
+        Some(PairingPhase::Pairing)
+    );
+    let update = apply_session_event(
+        raw_rx.recv().await.unwrap(),
+        &manager.session,
+        &manager.observable,
+    );
+
+    assert_eq!(
+        manager.observable.snapshot().pairing,
+        Some(PairingPhase::Pairing)
+    );
+    assert!(
+        update.is_none(),
+        "stale discovery must not reach IPC clients"
+    );
+    assert_eq!(
+        manager.pair(queued.address),
+        Err(PairingCommandError::UnknownDevice)
+    );
+    let searching = apply_session_event(
+        SessionEvent {
+            session,
+            event: PairingEvent::Searching,
+        },
+        &manager.session,
+        &manager.observable,
+    );
+    assert!(searching.is_none());
+    assert_eq!(
+        manager.observable.snapshot().pairing,
+        Some(PairingPhase::Pairing)
+    );
+}
+
+#[tokio::test]
+async fn queued_discovery_cannot_revert_passkey() {
+    // Passkeys have always been accepted from the watcher, even without an
+    // explicit agent selection. Both paths must close discovery.
+    for select_first in [false, true] {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+        let session = start_session(&manager, &mut ctrl_rx).await;
+        let device = discovered_device();
+        apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::DeviceFound(device.clone()),
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        let (raw_tx, mut raw_rx) = mpsc::unbounded_channel();
+        for event in [
+            PairingEvent::DeviceFound(DiscoveredDevice {
+                address: [6, 5, 4, 3, 2, 1],
+                ..discovered_device()
+            }),
+            PairingEvent::Searching,
+        ] {
+            raw_tx.send(SessionEvent { session, event }).unwrap();
+        }
+        if select_first {
+            manager.pair(device.address).unwrap();
+        }
+        let method = openlogi_hid::PasskeyMethod::Keyboard("572901".to_string());
+        let update = apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::Passkey(method.clone()),
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        assert!(matches!(update, Some(PairingUpdate::Passkey(value)) if value == method));
+        let expected = Some(PairingPhase::Passkey(method));
+        assert_eq!(manager.observable.snapshot().pairing, expected);
+
+        while let Ok(event) = raw_rx.try_recv() {
+            assert!(apply_session_event(event, &manager.session, &manager.observable).is_none());
+            assert_eq!(manager.observable.snapshot().pairing, expected);
+        }
+        let terminal = apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::Paired { slot: 2 },
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        assert!(matches!(terminal, Some(PairingUpdate::Paired { slot: 2 })));
+        assert_eq!(
+            manager.observable.snapshot().pairing,
+            Some(PairingPhase::Paired { slot: 2 })
+        );
+        assert!(is_idle(&manager));
+        assert!(!manager.shared.receiver_access.exclusive_requested());
+    }
+}
+
+#[tokio::test]
+async fn initial_discovery_keeps_devices_available_for_repeat_selection() {
+    let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+    let manager = manager_with_ctrl(ctrl_tx);
+    let session = start_session(&manager, &mut ctrl_rx).await;
+    let searching = apply_session_event(
+        SessionEvent {
+            session,
+            event: PairingEvent::Searching,
+        },
+        &manager.session,
+        &manager.observable,
+    );
+    assert!(matches!(searching, Some(PairingUpdate::Searching)));
+    assert_eq!(
+        manager.observable.snapshot().pairing,
+        Some(PairingPhase::Searching)
+    );
+    let first = discovered_device();
+    let second = DiscoveredDevice {
+        address: [6, 5, 4, 3, 2, 1],
+        authentication: 1,
+        name: "second keyboard".to_string(),
+        ..discovered_device()
+    };
+    let mut found = Vec::new();
+    for device in [&first, &second] {
+        let expected = FoundDevice {
+            address: device.address,
+            name: device.name.clone(),
+        };
+        let update = apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::DeviceFound(device.clone()),
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        assert!(matches!(update, Some(PairingUpdate::DeviceFound(value)) if value == expected));
+        found.push(expected);
+        assert_eq!(
+            manager.observable.snapshot().pairing,
+            Some(PairingPhase::Found(found.clone()))
+        );
+    }
+    for device in [&first, &second, &first] {
+        manager.pair(device.address).unwrap();
+        let control = ctrl_rx.try_recv().unwrap();
+        assert!(
+            matches!(control, Control::Pair { session: id, device: sent }
+            if id == session && sent.address == device.address
+                && sent.authentication == device.authentication && sent.name == device.name)
+        );
+        assert_eq!(
+            manager.observable.snapshot().pairing,
+            Some(PairingPhase::Pairing)
+        );
+        apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::Passkey(openlogi_hid::PasskeyMethod::Keyboard(
+                    "572901".to_string(),
+                )),
+            },
+            &manager.session,
+            &manager.observable,
+        );
+    }
+    let terminal = apply_session_event(
+        SessionEvent {
+            session,
+            event: PairingEvent::Failed(PairingError::Timeout),
+        },
+        &manager.session,
+        &manager.observable,
+    );
+    assert!(matches!(
+        terminal,
+        Some(PairingUpdate::Failed(PairingFailure::Timeout))
+    ));
+    assert_eq!(
+        manager.observable.snapshot().pairing,
+        Some(PairingPhase::Failed(PairingFailure::Timeout))
+    );
+    assert!(is_idle(&manager));
+    assert!(!manager.shared.receiver_access.exclusive_requested());
+}
+
+#[tokio::test]
+async fn unsuccessful_pair_keeps_discovery_open() {
+    for error in [
+        PairingCommandError::UnknownDevice,
+        PairingCommandError::WatcherUnavailable,
+    ] {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+        let session = start_session(&manager, &mut ctrl_rx).await;
+        let first = discovered_device();
+        let second = DiscoveredDevice {
+            address: [6, 5, 4, 3, 2, 1],
+            ..discovered_device()
+        };
+        apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::DeviceFound(first.clone()),
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        let before = manager.observable.snapshot().pairing;
+        let address = if error == PairingCommandError::WatcherUnavailable {
+            ctrl_rx.close();
+            first.address
+        } else {
+            second.address
+        };
+
+        assert_eq!(manager.pair(address), Err(error));
+        assert_eq!(manager.observable.snapshot().pairing, before);
+        assert!(
+            ctrl_rx.try_recv().is_err(),
+            "failed pair must not send a command"
+        );
+        let update = apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::DeviceFound(second.clone()),
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        assert!(matches!(update, Some(PairingUpdate::DeviceFound(found))
+            if found.address == second.address));
+        assert_eq!(
+            manager.observable.snapshot().pairing,
+            Some(PairingPhase::Found(vec![
+                FoundDevice {
+                    address: first.address,
+                    name: first.name
+                },
+                FoundDevice {
+                    address: second.address,
+                    name: second.name
+                },
+            ]))
+        );
+    }
+}
+
+#[tokio::test]
 async fn start_ignores_overlapping_session_without_clearing_or_sending() {
     let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
     let manager = manager_with_ctrl(ctrl_tx);
@@ -188,6 +469,22 @@ async fn terminal_cleanup_is_exactly_once_and_releases_receiver_lease() {
     let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
     let manager = manager_with_ctrl(ctrl_tx);
     let first = start_session(&manager, &mut ctrl_rx).await;
+    apply_session_event(
+        SessionEvent {
+            session: first,
+            event: PairingEvent::DeviceFound(discovered_device()),
+        },
+        &manager.session,
+        &manager.observable,
+    );
+    manager.pair(discovered_device().address).unwrap();
+    assert!(matches!(ctrl_rx.try_recv().unwrap(), Control::Pair { .. }));
+    manager.cancel().unwrap();
+    assert!(matches!(ctrl_rx.try_recv().unwrap(), Control::Cancel { session } if session == first));
+    assert_eq!(
+        manager.observable.snapshot().pairing,
+        Some(PairingPhase::Pairing)
+    );
     assert!(
         manager
             .shared
@@ -209,6 +506,7 @@ async fn terminal_cleanup_is_exactly_once_and_releases_receiver_lease() {
         Some(PairingUpdate::Failed(PairingFailure::Cancelled))
     ));
     assert!(is_idle(&manager));
+    assert_eq!(manager.observable.snapshot().pairing, None);
     assert!(!manager.shared.receiver_access.exclusive_requested());
     assert!(
         manager
@@ -220,16 +518,26 @@ async fn terminal_cleanup_is_exactly_once_and_releases_receiver_lease() {
 
     let second = start_session(&manager, &mut ctrl_rx).await;
     assert_ne!(second, first);
-    let duplicate = apply_session_event(
-        SessionEvent {
-            session: first,
-            event: PairingEvent::Failed(PairingError::Cancelled),
-        },
-        &manager.session,
-        &manager.observable,
+    for event in [
+        PairingEvent::Failed(PairingError::Cancelled),
+        PairingEvent::DeviceFound(discovered_device()),
+        PairingEvent::Searching,
+        PairingEvent::Passkey(openlogi_hid::PasskeyMethod::Keyboard("572901".to_string())),
+    ] {
+        let stale = apply_session_event(
+            SessionEvent {
+                session: first,
+                event,
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        assert!(stale.is_none());
+    }
+    assert_eq!(
+        manager.pair(discovered_device().address),
+        Err(PairingCommandError::UnknownDevice)
     );
-
-    assert!(duplicate.is_none());
     assert_eq!(
         with_session_owner(&manager.session, |owner| owner
             .active()


### PR DESCRIPTION
## Summary

Prevent discovery already queued in the agent's raw session-event channel from replacing `Pairing` or `Passkey` after a device selection. This follows #1181, which prevents newly emitted discovery at the device layer but cannot fence events already in flight.

## Changes

- `openlogi-agent`: keep discovery admission in the existing `SessionOwner`-locked active session. Close discovery only after `Control::Pair` sends successfully, or when accepting a passkey. Ignore late same-session `Searching` and `DeviceFound` in both the snapshot and IPC update stream.
- Preserve previously admitted devices for repeat selection, passkey acceptance, cancellation, receiver-lease cleanup, and session-ID rejection. Ignore late discovery rather than adding unadvertised devices to the cache.
- Add queued-event regressions and coverage for initial discovery, repeat selection, failed sends/unknown devices, and terminal/session behavior. No public API, wire format, dependency, or platform-specific changes.

## Testing

Linux orb, rustc 1.98.1. Started from freshly fetched `origin/master`; no rebase or conflict resolution. `cargo tree --workspace --target all --invert openlogi-agent` identifies **only `openlogi-agent`** in the affected-package set.

Red before / green after:

```sh
RUSTFLAGS='-D warnings' cargo test -p openlogi-agent --bin openlogi-agent pairing::tests::audit_queued_device_found_cannot_revert_selected_phase -- --exact
```

Before: **FAILED**, actual `Some(Found([queued second device]))`, expected `Some(Pairing)`. After: **1 passed**. This queues a distinct device before selecting the first device, then drains the queued event at the actual agent translation boundary; no hardware required.

Passed on the final tree:

```sh
RUSTFLAGS='-D warnings' cargo test -p openlogi-agent --bin openlogi-agent pairing::tests
# 10 passed

# Affected-package pre-push tier:
export RUSTFLAGS='-D warnings'
cargo fmt --all -- --check
cargo clippy -p openlogi-agent --all-targets -- -D warnings
cargo test -p openlogi-agent
# 39 agent tests + 1 mock-agent test passed

# Pre-push hooks are absent in this orb; ran both backstops manually:
cargo clippy --workspace --all-targets -- -D warnings
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent

git diff --check
```

Full-workspace Clippy exits successfully with an upstream future-incompatibility notice for `proc-macro-error2 2.0.1`.

Not run locally: full-workspace tests, macOS/Windows checks, hardware/UI pairing, typos, cargo-deny, wasm, separate MSRV, shell, and packaging jobs. No changes require those additional local jobs; CI covers its configured matrix.

**Not runtime-tested on hardware.** Hardware check: with two Bolt devices discoverable, select one while discovery is active, confirm it stays on pairing/passkey until success or cancellation, then start a new session and confirm discovery works again. Also smoke-test Unifying automatic pairing, which does not require an explicit device selection.
