### PR TITLE
fix(agent): avoid capture recovery deadline busy loops

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/capture_session.rs
+++ b/crates/openlogi-agent-core/src/watchers/capture_session.rs
@@ -59,6 +59,25 @@ impl<Restore> CaptureRecovery<Restore> {
     pub(super) fn is_empty(&self) -> bool {
         self.pending_restore.is_none() && self.restart_at.is_none()
     }
+
+    /// Next recovery work that can make progress for this slot. Restart is
+    /// blocked by firmware ownership, so its deadline is not actionable until
+    /// restoration succeeds. Keep the pacing deadline for an early success.
+    pub(super) fn next_deadline(
+        &self,
+        retry_at: impl FnOnce(&Restore) -> Instant,
+    ) -> Option<Instant> {
+        self.pending_restore
+            .as_ref()
+            .map(retry_at)
+            .or(self.restart_at)
+    }
+
+    /// Restoration must finish before a successor can use the hardware, even
+    /// if restart pacing has already elapsed.
+    pub(super) fn blocks_restart(&self, now: Instant) -> bool {
+        self.pending_restore.is_some() || self.restart_at.is_some_and(|deadline| deadline > now)
+    }
 }
 
 /// One manager-owned hardware slot. A session remains in `Running` while it
@@ -323,6 +342,130 @@ mod tests {
             recovery.restart_at,
             Some(restart_at),
             "restore and restart pacing may legitimately coexist"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recovery_failed_restore_waits_instead_of_repeating_expired_restart() {
+        use std::time::Duration;
+
+        let start = Instant::now();
+        let restart_at = start + Duration::from_secs(1);
+        let mut slot = CaptureSlot::running(session());
+        slot.complete(
+            &HidppSessionId::with_epoch("mouse-a", 7),
+            Some(restart_at),
+            Some(restart_at),
+        )
+        .expect("an unexpected completion retains both restore and pacing");
+        assert!(slot.session().is_none());
+        let recovery = slot.recovery_mut().unwrap();
+        assert!(recovery.blocks_restart(start));
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        for _ in 0..3 {
+            assert_eq!(
+                recovery.next_deadline(|retry_at| *retry_at),
+                Some(Instant::now())
+            );
+            // A failed firmware retry returns ownership with a new deadline.
+            let retry_at = Instant::now() + Duration::from_secs(2);
+            recovery.pending_restore = Some(retry_at);
+            assert!(recovery.blocks_restart(Instant::now()));
+            assert_eq!(recovery.restart_at, Some(restart_at));
+            let deadline = recovery.next_deadline(|retry_at| *retry_at).unwrap();
+            assert_eq!(
+                deadline, retry_at,
+                "expired pacing cannot drive another reconciliation"
+            );
+
+            let mut wait = std::pin::pin!(tokio::time::sleep_until(deadline));
+            assert!(futures_lite::future::poll_once(&mut wait).await.is_none());
+
+            // This is the managers' pre-select condition. It must let both
+            // ordinary events and shutdown through after every failed retry.
+            assert!(deadline > Instant::now());
+            let (events, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+            events.send("input").unwrap();
+            tokio::select! {
+                () = &mut wait => panic!("restore retry must not be hot"),
+                event = event_rx.recv() => assert_eq!(event, Some("input")),
+            }
+            let (stop, mut shutdown) = oneshot::channel();
+            stop.send(()).unwrap();
+            tokio::select! {
+                () = &mut wait => panic!("restore retry must not starve shutdown"),
+                result = &mut shutdown => result.unwrap(),
+            }
+            assert_eq!(Instant::now() + Duration::from_secs(2), retry_at);
+            tokio::time::advance(Duration::from_secs(2)).await;
+            wait.await;
+        }
+
+        recovery.pending_restore = None;
+        assert!(
+            !recovery.blocks_restart(Instant::now()),
+            "only successful restoration admits a successor"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recovery_early_restore_keeps_future_restart_pacing() {
+        use std::time::Duration;
+
+        let start = Instant::now();
+        let restart_at = start + Duration::from_secs(5);
+        let mut slot = CaptureSlot::running(session());
+        slot.complete(
+            &HidppSessionId::with_epoch("mouse-a", 7),
+            Some(start + Duration::from_secs(2)),
+            Some(restart_at),
+        )
+        .unwrap();
+        let recovery = slot.recovery_mut().unwrap();
+        assert_eq!(
+            recovery.next_deadline(|retry_at| *retry_at),
+            Some(start + Duration::from_secs(2))
+        );
+
+        // Inventory replacement accelerates the retry before either deadline.
+        tokio::time::advance(Duration::from_millis(500)).await;
+        recovery.pending_restore = Some(Instant::now());
+        assert_eq!(
+            recovery.next_deadline(|retry_at| *retry_at),
+            Some(Instant::now())
+        );
+        recovery.pending_restore = None;
+        assert_eq!(
+            recovery.next_deadline(|retry_at| *retry_at),
+            Some(restart_at)
+        );
+        assert!(recovery.blocks_restart(Instant::now()));
+
+        tokio::time::advance(Duration::from_millis(4499)).await;
+        assert!(recovery.blocks_restart(Instant::now()));
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(!recovery.blocks_restart(Instant::now()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recovery_restore_later_than_restart_is_the_only_actionable_deadline() {
+        use std::time::Duration;
+
+        let now = Instant::now();
+        let recovery = CaptureRecovery {
+            pending_restore: Some(now + Duration::from_secs(3)),
+            restart_at: Some(now + Duration::from_secs(1)),
+        };
+        assert_eq!(
+            recovery.next_deadline(|retry_at| *retry_at),
+            Some(now + Duration::from_secs(3))
+        );
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(recovery.blocks_restart(Instant::now()));
+        assert_eq!(
+            recovery.next_deadline(|retry_at| *retry_at),
+            Some(now + Duration::from_secs(3))
         );
     }
 

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -349,14 +349,7 @@ fn next_deadline(
     slots
         .values()
         .filter_map(GestureSlot::recovery)
-        .flat_map(|recovery| {
-            recovery
-                .pending_restore
-                .as_ref()
-                .map(|pending| pending.retry_at)
-                .into_iter()
-                .chain(recovery.restart_at)
-        })
+        .filter_map(|recovery| recovery.next_deadline(|pending| pending.retry_at))
         .min()
 }
 
@@ -456,10 +449,7 @@ impl GestureManagerState {
             let key = &plan.target.physical_key;
             if self.slots.get(key).is_some_and(|slot| match slot {
                 GestureSlot::Running(_) => true,
-                GestureSlot::Recovering(recovery) => {
-                    recovery.pending_restore.is_some()
-                        || recovery.restart_at.is_some_and(|deadline| deadline > now)
-                }
+                GestureSlot::Recovering(recovery) => recovery.blocks_restart(now),
             }) {
                 continue;
             }

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use openlogi_core::binding::{Action, Binding, ButtonId, GestureDirection};
-use openlogi_core::config::ThumbwheelSensitivity;
+use openlogi_core::config::{ThumbwheelSensitivity, VerticalScrollSensitivity};
 use openlogi_hid::DeviceRoute;
 
 fn route() -> DeviceRoute {
@@ -119,6 +119,90 @@ fn suspended_device_io_disables_retry_deadlines() {
         None,
         "capture retries must stay dormant until visible resume",
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn exclusive_receiver_access_disables_expired_recovery_deadlines() {
+    let access = ReceiverAccess::default();
+    let requests = access.subscribe_requests();
+    let exclusive = access
+        .acquire_exclusive(crate::receiver_access::ExclusiveAccessReason::Pairing)
+        .await;
+    let slots = HashMap::from([(
+        physical_key(),
+        GestureSlot::recovering(None, Some(Instant::now())),
+    )]);
+
+    assert_eq!(next_deadline(*requests.borrow(), true, &slots), None);
+    drop(exclusive);
+    assert_eq!(
+        next_deadline(*requests.borrow(), true, &slots),
+        Some(Instant::now()),
+        "release makes the retry actionable without adding another backoff"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn recovery_manager_waits_for_control_events_and_shutdown_between_retries() {
+    use crate::runtime::scroll::{ScrollPreferences, ScrollRuntime};
+    use futures_lite::future::poll_once;
+
+    for shutdown_requested in [false, true] {
+        let (plans_tx, capture_plans) = watch::channel(Arc::new(vec![plan()]));
+        let capture = CaptureChannel::default();
+        // A missing inventory channel makes the real session task fail without
+        // opening hardware; ordered Done then drives normal restart recovery.
+        let registry = openlogi_hid::ChannelRegistry::default();
+        let access = ReceiverAccess::default();
+        let (_signal, device_io) = openlogi_hid::device_io_channel();
+        let (ring, _ring_rx) = mpsc::unbounded_channel();
+        let mut actions = crate::runtime::ActionRuntime::new(
+            Arc::default(),
+            capture.clone(),
+            registry.clone(),
+            access.clone(),
+            device_io.clone(),
+            ring,
+        )
+        .unwrap();
+        let mut scroll = ScrollRuntime::spawn(Arc::new(ScrollPreferences::new(
+            false,
+            VerticalScrollSensitivity::default(),
+        )))
+        .unwrap();
+        let (shutdown_tx, shutdown) = oneshot::channel();
+        let mut manager = std::pin::pin!(manage(GestureManagerContext {
+            capture_plans,
+            capture_channel: capture,
+            receiver_requests: access.subscribe_requests(),
+            receiver_access: access,
+            channel_registry: registry,
+            device_io,
+            outputs: GestureOutputs::new(actions.dispatcher(), scroll.input(), Arc::default()),
+            shutdown,
+        }));
+
+        for _ in 0..3 {
+            // Poll the actual manager and its detached forwarder/session tasks
+            // through repeated failures. Each poll must return to event wait.
+            for _ in 0..4 {
+                assert!(poll_once(&mut manager).await.is_none());
+                tokio::task::yield_now().await;
+            }
+            tokio::time::advance(RETRY_DELAY).await;
+        }
+        let before_event = Instant::now();
+        if shutdown_requested {
+            shutdown_tx.send(()).unwrap();
+            assert!(matches!(manager.await, ManagerCompletion::Graceful));
+        } else {
+            drop(plans_tx);
+            assert!(matches!(manager.await, ManagerCompletion::Unexpected));
+        }
+        assert_eq!(Instant::now(), before_event);
+        scroll.shutdown();
+        actions.shutdown();
+    }
 }
 
 #[tokio::test]

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -128,16 +128,17 @@ async fn exclusive_receiver_access_disables_expired_recovery_deadlines() {
     let exclusive = access
         .acquire_exclusive(crate::receiver_access::ExclusiveAccessReason::Pairing)
         .await;
+    let restart_at = Instant::now();
     let slots = HashMap::from([(
         physical_key(),
-        GestureSlot::recovering(None, Some(Instant::now())),
+        GestureSlot::recovering(None, Some(restart_at)),
     )]);
 
     assert_eq!(next_deadline(*requests.borrow(), true, &slots), None);
     drop(exclusive);
     assert_eq!(
         next_deadline(*requests.borrow(), true, &slots),
-        Some(Instant::now()),
+        Some(restart_at),
         "release makes the retry actionable without adding another backoff"
     );
 }

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -337,10 +337,7 @@ impl KeyboardManagerState {
         }
         if self.slot.as_ref().is_some_and(|slot| match slot {
             KeyboardSlot::Running(_) => true,
-            KeyboardSlot::Recovering(recovery) => {
-                recovery.pending_restore.is_some()
-                    || recovery.restart_at.is_some_and(|deadline| deadline > now)
-            }
+            KeyboardSlot::Recovering(recovery) => recovery.blocks_restart(now),
         }) {
             return;
         }
@@ -439,13 +436,7 @@ fn next_deadline(
         return None;
     }
     let recovery = slot.and_then(KeyboardSlot::recovery)?;
-    recovery
-        .pending_restore
-        .as_ref()
-        .map(|pending| pending.retry_at)
-        .into_iter()
-        .chain(recovery.restart_at)
-        .min()
+    recovery.next_deadline(|pending| pending.retry_at)
 }
 
 /// Retire the tracked keyboard epoch, preserve its ordered input ownership

--- a/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
@@ -152,13 +152,14 @@ async fn exclusive_receiver_access_disables_expired_recovery_deadlines() {
     let exclusive = access
         .acquire_exclusive(crate::receiver_access::ExclusiveAccessReason::Pairing)
         .await;
-    let slot = KeyboardSlot::recovering(None, Some(tokio::time::Instant::now()));
+    let restart_at = tokio::time::Instant::now();
+    let slot = KeyboardSlot::recovering(None, Some(restart_at));
 
     assert_eq!(next_deadline(*requests.borrow(), true, Some(&slot)), None);
     drop(exclusive);
     assert_eq!(
         next_deadline(*requests.borrow(), true, Some(&slot)),
-        Some(tokio::time::Instant::now()),
+        Some(restart_at),
         "release makes the retry actionable without adding another backoff"
     );
 }

--- a/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard/tests.rs
@@ -144,3 +144,82 @@ fn suspended_device_io_disables_retry_deadlines() {
         "keyboard retries must stay dormant until visible resume",
     );
 }
+
+#[tokio::test(start_paused = true)]
+async fn exclusive_receiver_access_disables_expired_recovery_deadlines() {
+    let access = ReceiverAccess::default();
+    let requests = access.subscribe_requests();
+    let exclusive = access
+        .acquire_exclusive(crate::receiver_access::ExclusiveAccessReason::Pairing)
+        .await;
+    let slot = KeyboardSlot::recovering(None, Some(tokio::time::Instant::now()));
+
+    assert_eq!(next_deadline(*requests.borrow(), true, Some(&slot)), None);
+    drop(exclusive);
+    assert_eq!(
+        next_deadline(*requests.borrow(), true, Some(&slot)),
+        Some(tokio::time::Instant::now()),
+        "release makes the retry actionable without adding another backoff"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn recovery_manager_waits_for_control_events_and_shutdown_between_retries() {
+    use futures_lite::future::poll_once;
+
+    for shutdown_requested in [false, true] {
+        let (spec_tx, spec) = watch::channel(Some(Arc::new(KeyboardSpec {
+            config_key: "keyboard-a".to_owned(),
+            route: target().route,
+            wanted: target().wanted,
+            bindings: dispatch(Action::MissionControl).bindings,
+        })));
+        let capture = CaptureChannel::default();
+        // A missing inventory channel makes the real session task fail without
+        // opening hardware; ordered Done then drives normal restart recovery.
+        let registry = ChannelRegistry::default();
+        let access = ReceiverAccess::default();
+        let (_signal, device_io) = openlogi_hid::device_io_channel();
+        let (ring, _ring_rx) = mpsc::unbounded_channel();
+        let mut actions = crate::runtime::ActionRuntime::new(
+            Arc::default(),
+            capture.clone(),
+            registry.clone(),
+            access.clone(),
+            device_io.clone(),
+            ring,
+        )
+        .unwrap();
+        let (shutdown_tx, shutdown) = oneshot::channel();
+        let mut manager = std::pin::pin!(manage(KeyboardManagerContext {
+            spec,
+            keyboard_channel: capture,
+            receiver_requests: access.subscribe_requests(),
+            receiver_access: access,
+            registry,
+            device_io,
+            dispatcher: actions.dispatcher(),
+            shutdown,
+        }));
+
+        for _ in 0..3 {
+            // Poll the actual manager and its detached forwarder/session tasks
+            // through repeated failures. Each poll must return to event wait.
+            for _ in 0..4 {
+                assert!(poll_once(&mut manager).await.is_none());
+                tokio::task::yield_now().await;
+            }
+            tokio::time::advance(RETRY_DELAY).await;
+        }
+        let before_event = tokio::time::Instant::now();
+        if shutdown_requested {
+            shutdown_tx.send(()).unwrap();
+            assert!(matches!(manager.await, ManagerCompletion::Graceful));
+        } else {
+            drop(spec_tx);
+            assert!(matches!(manager.await, ManagerCompletion::Unexpected));
+        }
+        assert_eq!(tokio::time::Instant::now(), before_event);
+        actions.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary

Prevent gesture and keyboard capture recovery from busy-looping on an expired restart deadline while firmware restoration is still waiting for its next retry. This is a post-merge audit follow-up to #1183; the scheduling defect also existed before that refactor.

An unexpected completion can retain both a restore retry and restart pacing. After a failed restore advances only the retry deadline, taking the minimum keeps returning the expired restart deadline. The manager then reconciles without reaching its event/shutdown `select!`.

## Changes

- `openlogi-agent-core`: make `CaptureRecovery` return the restore retry deadline while restoration is pending, then the retained restart deadline after success. Share the existing restart-eligibility rule with the same recovery owner.
- Preserve restore-before-successor, early-success restart pacing, the minimum across independent gesture slots, exclusive-receiver/device-I/O guards, registry acceleration, ordered drain completion, epoch identity, and the new shutdown paths. No public API, wire type, dependency, or platform-specific changes.
- Add paused-time scheduling regressions and separate production manager-loop event/shutdown coverage.

## Testing

### Red before / green after

- Extracted the existing production `min` and restart-eligibility rules without changing their behavior, then ran `cargo test -p openlogi-agent-core recovery_`: **2 failed, 4 passed**. Both asymmetric-deadline tests returned `start + 1s` instead of the actionable restore retry at `start + 3s`.
- After switching to restore-first scheduling, `cargo test -p openlogi-agent-core watchers::capture_session::tests::recovery_`: **3 passed**. Covers repeated failed-restore scheduling, actual pending timer/event/shutdown waits, a future retry after restart expiry, and an accelerated successful restore that still blocks restart until the original future deadline (including both sides of that boundary).
- `cargo test -p openlogi-agent-core recovery_`: **10 passed** after manager and receiver-guard tests were added.
- `cargo test -p openlogi-agent-core watchers::`: **81 passed**.
- `cargo check -p openlogi-agent-core`: **passed**.

Evidence boundary: the shared scheduling tests drive real `CaptureSlot::complete`, `CaptureRecovery::next_deadline`, and restart eligibility using an `Instant` as the generic restore payload; failed/successful firmware outcomes are supplied by the test. The separate real `manage` loop tests use an empty registry, so they exercise repeated **session-open failures with `pending_restore=None`**, ordered completion, control-channel closure, and graceful shutdown with no virtual-time delay. They are not end-to-end repeated firmware-restoration failures. No unsafe token fabrication or test-only public APIs were added.

### Final pre-push gate

`cargo tree --workspace --target all --invert openlogi-agent-core --prefix none --depth 20` yields exactly `openlogi-agent-core` and `openlogi-agent`. Only the five scoped Rust files changed; no rebase, conflict resolution, or workspace build/validation input changed, so the affected-package tier applies.

All commands below passed on the final tree:

```sh
export RUSTFLAGS='-D warnings'
cargo fmt --all -- --check
cargo clippy -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings
cargo test -p openlogi-agent-core -p openlogi-agent
# Mandatory backstop equivalent: no pre-push hook is installed in this orb.
cargo clippy --workspace --all-targets -- -D warnings
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent
git diff --check
```

Affected-package tests: **273 passed** (237 agent-core, 35 agent, 1 mock-agent); no failures or ignored tests. Full-workspace Clippy and non-GUI rustdoc both exited 0. Clippy's first iteration found one test-only `default_trait_access` lint; it was fixed before rerunning the final gate. Cargo also printed an existing future-incompatibility notice for dependency `proc-macro-error2`, not a current Clippy failure.

The two Copilot test-timing comments were addressed by naming and reusing `restart_at` in both exclusive-receiver tests. The original paused-time sections contained no intervening await, so this is a clarity improvement rather than a timing fix. `RUSTFLAGS='-D warnings' cargo test -p openlogi-agent-core exclusive_receiver_access_disables_expired_recovery_deadlines` passed **2 tests**, and the entire final gate above was rerun successfully before pushing [the follow-up commit](https://github.com/AprilNEA/OpenLogi/commit/18d5798fe23765e54fd4fbb36d16b8eff0d26a82).

Not runtime-tested on hardware. Hardware verification: force an unexpected mouse/keyboard capture termination with firmware still diverted, keep restoration failing past the first restart deadline, then verify low CPU plus responsive input/control events and shutdown initiation. Publish a working replacement channel and verify native restoration precedes rearming; for early restoration, confirm the original restart pacing remains. Shutdown must still wait for firmware ownership to be released, rather than acknowledging prematurely. No hardware CPU, HID-write timing, DarkWake, or end-to-end restoration/shutdown completion claim is made here.

Local host: Linux, Rust 1.98.1. Full-workspace tests and other CI matrix jobs (macOS/Windows, MSRV, typos, cargo-deny, wasm, packaging) were not run locally; the required affected-package tier plus full Clippy/rustdoc backstop above was run.
