### PR TITLE
test(gui): cover camera preview lifecycle

### DIFF
--- a/crates/openlogi-desktop/src/features/camera/preview.rs
+++ b/crates/openlogi-desktop/src/features/camera/preview.rs
@@ -29,10 +29,16 @@ use gpui::{
 use gpui_base::Button as BaseButton;
 use gpui_component::v_flex;
 use image::{Frame as ImageFrame, RgbaImage};
-use openlogi_camera::{CameraAuthorization, CameraStream, Frame};
+use openlogi_camera::{CameraAuthorization, Frame};
 
 use crate::state::{AppState, StateEvent};
 use crate::ui::theme::{self, Palette, Typography as _};
+
+mod capture;
+use capture::{Capture, PreviewStream, SystemCapture};
+
+#[cfg(test)]
+mod tests;
 
 const PREVIEW_W: f32 = 480.;
 const PREVIEW_H: f32 = 270.; // 16:9
@@ -40,6 +46,7 @@ const PREVIEW_H: f32 = 270.; // 16:9
 /// Live preview view. Holds the capture stream + its texture only while the
 /// parent points it at a camera via [`Self::set_target`].
 pub struct CameraPreview {
+    capture: Box<dyn Capture>,
     lifecycle: PreviewLifecycle,
     current_image: Option<Arc<RenderImage>>,
     _permission_obs: Subscription,
@@ -54,7 +61,7 @@ enum PreviewLifecycle {
     AwaitingAccess(String),
     Streaming {
         target: String,
-        stream: CameraStream,
+        stream: Box<dyn PreviewStream>,
         last_generation: u64,
         /// Dropping the streaming state cancels its frame-rate repaint pump.
         _repaint_task: Task<()>,
@@ -74,19 +81,24 @@ impl PreviewLifecycle {
 
 impl CameraPreview {
     pub fn new(cx: &mut Context<Self>) -> Self {
+        Self::with_capture(Box::new(SystemCapture), cx)
+    }
+
+    fn with_capture(capture: Box<dyn Capture>, cx: &mut Context<Self>) -> Self {
         let permission_obs = cx.subscribe(
             &AppState::global(cx),
             |preview, _, event: &StateEvent, cx| {
                 if !matches!(event, StateEvent::CameraPermissionChanged) {
                     return;
                 }
-                if openlogi_camera::camera_access_granted() {
+                if preview.capture.access_granted() {
                     preview.start_deferred_stream(cx);
                 }
                 cx.notify();
             },
         );
         Self {
+            capture,
             lifecycle: PreviewLifecycle::Stopped,
             current_image: None,
             _permission_obs: permission_obs,
@@ -100,7 +112,7 @@ impl CameraPreview {
     /// permission starts as soon as access is granted.
     pub fn set_target(&mut self, target: Option<String>, cx: &mut Context<Self>) {
         if target.as_deref() == self.lifecycle.target() {
-            if openlogi_camera::camera_access_granted() && self.start_deferred_stream(cx) {
+            if self.capture.access_granted() && self.start_deferred_stream(cx) {
                 cx.notify();
             }
             return;
@@ -119,7 +131,7 @@ impl CameraPreview {
         };
         // Only open the camera when access is already granted, so selecting it
         // never blocks the UI thread on the permission dialog.
-        if openlogi_camera::camera_access_granted() {
+        if self.capture.access_granted() {
             self.start_stream(target, cx);
         } else {
             self.lifecycle = PreviewLifecycle::AwaitingAccess(target);
@@ -138,7 +150,7 @@ impl CameraPreview {
     }
 
     fn start_stream(&mut self, target: String, cx: &mut Context<Self>) {
-        let Ok(stream) = openlogi_camera::start_stream(&target) else {
+        let Ok(stream) = self.capture.start_stream(&target) else {
             self.lifecycle = PreviewLifecycle::StartFailed(target);
             return;
         };
@@ -181,7 +193,7 @@ impl CameraPreview {
 impl Render for CameraPreview {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
-        let granted = openlogi_camera::camera_access_granted();
+        let granted = self.capture.access_granted();
 
         // Rebuild the texture only when a new frame arrived; free the old one.
         if let PreviewLifecycle::Streaming {

--- a/crates/openlogi-desktop/src/features/camera/preview/capture.rs
+++ b/crates/openlogi-desktop/src/features/camera/preview/capture.rs
@@ -1,0 +1,39 @@
+//! The preview's hardware boundary. Tests substitute capture resources, not
+//! the view's lifecycle, permission subscription, texture handling or tasks.
+
+use std::sync::Arc;
+
+use openlogi_camera::{CameraStream, CaptureError, Frame};
+
+pub(super) trait Capture {
+    fn access_granted(&self) -> bool;
+    fn start_stream(&self, target: &str) -> Result<Box<dyn PreviewStream>, CaptureError>;
+}
+
+pub(super) trait PreviewStream {
+    fn frame_generation(&self) -> u64;
+    fn take_frame(&self) -> Option<Arc<Frame>>;
+}
+
+pub(super) struct SystemCapture;
+
+impl Capture for SystemCapture {
+    fn access_granted(&self) -> bool {
+        openlogi_camera::camera_access_granted()
+    }
+
+    fn start_stream(&self, target: &str) -> Result<Box<dyn PreviewStream>, CaptureError> {
+        openlogi_camera::start_stream(target)
+            .map(|stream| Box::new(stream) as Box<dyn PreviewStream>)
+    }
+}
+
+impl PreviewStream for CameraStream {
+    fn frame_generation(&self) -> u64 {
+        self.frame_generation()
+    }
+
+    fn take_frame(&self) -> Option<Arc<Frame>> {
+        self.take_frame()
+    }
+}

--- a/crates/openlogi-desktop/src/features/camera/preview/tests.rs
+++ b/crates/openlogi-desktop/src/features/camera/preview/tests.rs
@@ -1,0 +1,367 @@
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use gpui::{AppContext as _, Entity, TestAppContext, VisualTestContext, point, size};
+use openlogi_camera::CaptureError;
+use openlogi_core::config::Config;
+
+use super::*;
+use crate::services::assets::AssetResolver;
+use crate::state::ConfigPersistence;
+
+#[derive(Default)]
+struct FakeCapture {
+    granted: Cell<bool>,
+    failure: RefCell<Option<CaptureError>>,
+    events: Rc<RefCell<Vec<String>>>,
+    frames: RefCell<Vec<Rc<Frames>>>,
+}
+
+impl Capture for Rc<FakeCapture> {
+    fn access_granted(&self) -> bool {
+        self.granted.get()
+    }
+
+    fn start_stream(&self, target: &str) -> Result<Box<dyn PreviewStream>, CaptureError> {
+        self.events.borrow_mut().push(format!("open {target}"));
+        if let Some(error) = self.failure.borrow().clone() {
+            return Err(error);
+        }
+        let frames = Rc::new(Frames::default());
+        self.frames.borrow_mut().push(frames.clone());
+        Ok(Box::new(FakeStream {
+            frames,
+            target: target.to_owned(),
+            events: self.events.clone(),
+        }))
+    }
+}
+
+#[derive(Default)]
+struct Frames {
+    latest: RefCell<Option<Arc<Frame>>>,
+    generation: Cell<u64>,
+    polls: Cell<usize>,
+    takes: Cell<usize>,
+}
+
+impl Frames {
+    fn publish(&self, bgra: Vec<u8>) {
+        *self.latest.borrow_mut() = Some(Arc::new(Frame {
+            width: 2,
+            height: 1,
+            bgra,
+        }));
+        self.generation.set(self.generation.get() + 1);
+    }
+}
+
+struct FakeStream {
+    frames: Rc<Frames>,
+    target: String,
+    events: Rc<RefCell<Vec<String>>>,
+}
+
+impl PreviewStream for FakeStream {
+    fn frame_generation(&self) -> u64 {
+        self.frames.polls.set(self.frames.polls.get() + 1);
+        self.frames.generation.get()
+    }
+
+    fn take_frame(&self) -> Option<Arc<Frame>> {
+        self.frames.takes.set(self.frames.takes.get() + 1);
+        self.frames.latest.borrow_mut().take()
+    }
+}
+
+impl Drop for FakeStream {
+    fn drop(&mut self) {
+        self.events
+            .borrow_mut()
+            .push(format!("drop {}", self.target));
+    }
+}
+
+fn preview(cx: &mut TestAppContext) -> (Entity<CameraPreview>, Rc<FakeCapture>) {
+    cx.update(gpui_component::init);
+    cx.update(|cx| {
+        let cache = AssetResolver::new();
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let state = cx.new(|_| {
+            AppState::with_runtime(
+                Config::ephemeral(),
+                &[],
+                &[],
+                &cache,
+                &[],
+                ConfigPersistence::MemoryOnly,
+                commands,
+            )
+        });
+        AppState::set_global(state, cx);
+    });
+    let capture = Rc::new(FakeCapture::default());
+    let view = cx.new(|cx| CameraPreview::with_capture(Box::new(capture.clone()), cx));
+    (view, capture)
+}
+
+fn permission_event(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        AppState::global(cx).update(cx, |_, cx| cx.emit(StateEvent::CameraPermissionChanged));
+    });
+}
+
+fn tick(cx: &mut TestAppContext) {
+    cx.run_until_parked();
+    cx.executor().advance_clock(Duration::from_millis(16));
+    cx.run_until_parked();
+}
+
+fn draw(view: &Entity<CameraPreview>, cx: &mut VisualTestContext) {
+    cx.draw(
+        point(px(0.), px(0.)),
+        size(px(PREVIEW_W), px(PREVIEW_H)),
+        |_, _| view.clone().into_any_element(),
+    );
+}
+
+#[gpui::test]
+fn permission_event_starts_the_waiting_target_exactly_once(cx: &mut TestAppContext) {
+    let (view, capture) = preview(cx);
+    view.update(cx, |view, cx| {
+        view.set_target(Some("a".into()), cx);
+        view.set_target(Some("a".into()), cx);
+        assert!(matches!(&view.lifecycle, PreviewLifecycle::AwaitingAccess(id) if id == "a"));
+    });
+    permission_event(cx);
+    assert!(capture.events.borrow().is_empty());
+
+    capture.granted.set(true);
+    permission_event(cx);
+    assert_eq!(
+        *capture.events.borrow(),
+        ["open a"],
+        "the event must start capture before another render"
+    );
+    permission_event(cx);
+    view.update(cx, |view, cx| {
+        view.set_target(Some("a".into()), cx);
+        assert!(
+            matches!(&view.lifecycle, PreviewLifecycle::Streaming { target, .. } if target == "a")
+        );
+    });
+    assert_eq!(*capture.events.borrow(), ["open a"]);
+}
+
+#[gpui::test]
+fn permission_on_render_starts_only_the_current_waiting_target(cx: &mut TestAppContext) {
+    let (view, capture) = preview(cx);
+    view.update(cx, |view, cx| {
+        view.set_target(Some("superseded".into()), cx);
+        view.set_target(Some("current".into()), cx);
+    });
+    capture.granted.set(true);
+    view.update(cx, |view, cx| {
+        view.set_target(Some("current".into()), cx);
+        view.set_target(Some("current".into()), cx);
+    });
+    permission_event(cx);
+    assert_eq!(*capture.events.borrow(), ["open current"]);
+}
+
+#[gpui::test]
+fn stopping_while_waiting_does_not_open_after_a_late_grant(cx: &mut TestAppContext) {
+    let (view, capture) = preview(cx);
+    view.update(cx, |view, cx| {
+        view.set_target(Some("a".into()), cx);
+        view.set_target(None, cx);
+    });
+    capture.granted.set(true);
+    permission_event(cx);
+    view.update(cx, |view, cx| {
+        view.set_target(None, cx);
+        assert!(matches!(view.lifecycle, PreviewLifecycle::Stopped));
+    });
+    assert!(capture.events.borrow().is_empty());
+}
+
+#[gpui::test]
+fn failed_start_does_not_retry_on_same_target_renders_or_permission_events(
+    cx: &mut TestAppContext,
+) {
+    let (view, capture) = preview(cx);
+    capture.granted.set(true);
+    *capture.failure.borrow_mut() = Some(CaptureError::Setup("test failure".into()));
+    view.update(cx, |view, cx| {
+        view.set_target(Some("a".into()), cx);
+        assert!(matches!(&view.lifecycle, PreviewLifecycle::StartFailed(id) if id == "a"));
+        for _ in 0..3 {
+            view.set_target(Some("a".into()), cx);
+        }
+    });
+    permission_event(cx);
+    assert_eq!(*capture.events.borrow(), ["open a"]);
+
+    // Reselecting after leaving is a new attempt. This contract says nothing
+    // about a future explicit retry action/timer: repeated renders aren't one.
+    *capture.failure.borrow_mut() = None;
+    view.update(cx, |view, cx| {
+        view.set_target(None, cx);
+        view.set_target(Some("a".into()), cx);
+        assert!(matches!(view.lifecycle, PreviewLifecycle::Streaming { .. }));
+    });
+    assert_eq!(*capture.events.borrow(), ["open a", "open a"]);
+}
+
+#[gpui::test]
+fn switching_stopping_and_dropping_release_streams_and_cancel_repaint_pumps(
+    cx: &mut TestAppContext,
+) {
+    let (view, capture) = preview(cx);
+    capture.granted.set(true);
+    view.update(cx, |view, cx| view.set_target(Some("a".into()), cx));
+    tick(cx);
+    assert_eq!(capture.frames.borrow()[0].polls.get(), 1);
+
+    view.update(cx, |view, cx| view.set_target(Some("b".into()), cx));
+    assert_eq!(*capture.events.borrow(), ["open a", "drop a", "open b"]);
+    tick(cx);
+    // A detached old task would poll the replacement stream too.
+    assert_eq!(capture.frames.borrow()[0].polls.get(), 1);
+    assert_eq!(capture.frames.borrow()[1].polls.get(), 1);
+
+    view.update(cx, |view, cx| view.set_target(None, cx));
+    assert_eq!(
+        *capture.events.borrow(),
+        ["open a", "drop a", "open b", "drop b"]
+    );
+    tick(cx);
+    view.update(cx, |view, cx| view.set_target(Some("c".into()), cx));
+    tick(cx);
+    assert_eq!(capture.frames.borrow()[1].polls.get(), 1);
+    assert_eq!(capture.frames.borrow()[2].polls.get(), 1);
+
+    let weak = view.downgrade();
+    drop(view);
+    cx.update(|_| {}); // Flush GPUI's deferred entity release.
+    cx.run_until_parked();
+    tick(cx);
+    assert!(
+        weak.upgrade().is_none(),
+        "the repaint task must not retain its view"
+    );
+    assert_eq!(capture.frames.borrow()[2].polls.get(), 1);
+    assert_eq!(
+        *capture.events.borrow(),
+        ["open a", "drop a", "open b", "drop b", "open c", "drop c"]
+    );
+}
+
+#[gpui::test]
+fn repaint_notifies_only_for_an_unrendered_generation(cx: &mut TestAppContext) {
+    let (view, capture) = preview(cx);
+    capture.granted.set(true);
+    view.update(cx, |view, cx| view.set_target(Some("a".into()), cx));
+    let notifies = Rc::new(Cell::new(0));
+    let _observer = cx.update(|cx| {
+        cx.observe(&view, {
+            let notifies = notifies.clone();
+            move |_, _| notifies.set(notifies.get() + 1)
+        })
+    });
+    tick(cx);
+    assert_eq!(notifies.get(), 0);
+
+    capture.frames.borrow()[0].publish(vec![1, 2, 3, 255, 4, 5, 6, 255]);
+    tick(cx);
+    assert_eq!(notifies.get(), 1);
+    let cx = cx.add_empty_window();
+    draw(&view, cx);
+    tick(cx);
+    assert_eq!(
+        notifies.get(),
+        1,
+        "rendering consumes the pending generation"
+    );
+}
+
+#[gpui::test]
+fn textures_follow_frame_generation_and_are_released_without_another_render(
+    cx: &mut TestAppContext,
+) {
+    let (view, capture) = preview(cx);
+    capture.granted.set(true);
+    view.update(cx, |view, cx| view.set_target(Some("a".into()), cx));
+    let frames = capture.frames.borrow()[0].clone();
+    let cx = cx.add_empty_window();
+    draw(&view, cx);
+    assert_eq!(frames.takes.get(), 0);
+
+    let first_pixels = vec![10, 20, 30, 255, 40, 50, 60, 128];
+    frames.publish(first_pixels.clone());
+    draw(&view, cx);
+    let first = view.read_with(cx, |view, _| view.current_image.clone().unwrap());
+    assert_eq!(first.as_bytes(0).unwrap(), first_pixels);
+    assert!(cx.update(|window, _| window.has_image_atlas_entry(&first)));
+    draw(&view, cx);
+    assert_eq!(
+        frames.takes.get(),
+        1,
+        "unchanged generations reuse the texture"
+    );
+    view.read_with(cx, |view, _| {
+        assert_eq!(view.current_image.as_ref().unwrap().id, first.id);
+    });
+
+    frames.publish(vec![1; 8]);
+    let latest_pixels = vec![90, 80, 70, 255, 60, 50, 40, 255];
+    frames.publish(latest_pixels.clone());
+    draw(&view, cx);
+    let latest = view.read_with(cx, |view, _| {
+        assert!(matches!(
+            &view.lifecycle,
+            PreviewLifecycle::Streaming {
+                last_generation: 3,
+                ..
+            }
+        ));
+        view.current_image.clone().unwrap()
+    });
+    assert_eq!(latest.as_bytes(0).unwrap(), latest_pixels);
+    assert_ne!(latest.id, first.id);
+    assert!(!cx.update(|window, _| window.has_image_atlas_entry(&first)));
+    assert!(cx.update(|window, _| window.has_image_atlas_entry(&latest)));
+
+    frames.publish(vec![0; 3]); // A malformed frame must not replace the last good texture.
+    draw(&view, cx);
+    view.read_with(cx, |view, _| {
+        assert!(matches!(
+            &view.lifecycle,
+            PreviewLifecycle::Streaming {
+                last_generation: 3,
+                ..
+            }
+        ));
+        assert_eq!(view.current_image.as_ref().unwrap().id, latest.id);
+    });
+
+    view.update(cx, |view, cx| {
+        view.set_target(Some("b".into()), cx);
+        assert!(view.current_image.is_none());
+        assert!(matches!(
+            &view.lifecycle,
+            PreviewLifecycle::Streaming {
+                last_generation: 0,
+                ..
+            }
+        ));
+    });
+    assert!(!cx.update(|window, _| window.has_image_atlas_entry(&latest)));
+    capture.frames.borrow()[1].publish(vec![7; 8]);
+    draw(&view, cx);
+    let replacement = view.read_with(cx, |view, _| view.current_image.clone().unwrap());
+    assert!(cx.update(|window, _| window.has_image_atlas_entry(&replacement)));
+    view.update(cx, |view, cx| view.set_target(None, cx));
+    assert!(!cx.update(|window, _| window.has_image_atlas_entry(&replacement)));
+    view.read_with(cx, |view, _| assert!(view.current_image.is_none()));
+}

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -109,8 +109,11 @@ pub(crate) enum StateEvent {
     CameraChanged,
     /// Host camera-permission status may have changed.
     #[cfg_attr(
-        not(target_os = "macos"),
-        expect(dead_code, reason = "camera consent polling is macOS-only")
+        not(any(target_os = "macos", test)),
+        expect(
+            dead_code,
+            reason = "camera consent polling is macOS-only outside tests"
+        )
     )]
     CameraPermissionChanged,
     /// Per-device preferences outside the feature-specific events changed.


### PR DESCRIPTION
## Summary

Add direct, hardware-free coverage of the production `CameraPreview` lifecycle introduced in #1182. The existing camera-filtered desktop tests did not exercise this view.

This is independent of #1069 / #1019: no capture-backend changes, startup-error UI, retry timer, shared capture, or format-selection changes.

## Changes

- **openlogi-desktop:** inject only the private capture boundary. Production still delegates to `openlogi_camera`; tests substitute permission status and RAII streams while exercising the real `set_target`, permission subscription, repaint task, render, and GPUI texture teardown.
- Seven GPUI tests cover deferred permission starts through events and renders, superseded/stopped targets, same-target failed-start idempotence, stream drop ordering, cancellation of the old repaint pump, generation-based repaint/texture reuse, malformed-frame retention, and texture-atlas removal without another render.
- Scope `CameraPermissionChanged`'s existing non-macOS dead-code expectation to non-test builds, since these tests emit that event on Linux too. No event or wire-contract change.
- No manifest, locale, or Cargo.lock changes; GPUI pins are preserved.

## Testing

Linux orb, Rust 1.98.0. Rust commands below used `RUSTFLAGS="-D warnings"`.

- `cargo tree --workspace --target all --invert openlogi-desktop --locked --prefix none` — affected package set is only `openlogi-desktop`; affected-package local gate applies (fresh branch from fetched `origin/master`, no rebase or build-input changes).
- `cargo fmt --all -- --check` — pass.
- `cargo test -p openlogi-desktop features::camera::preview --locked` — 7 passed.
- `cargo test -p openlogi-desktop --locked` — 200 passed, including the new lifecycle and existing i18n tests.
- `cargo clippy -p openlogi-desktop --all-targets --locked -- -D warnings` — pass after fixing a test semicolon lint.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — pass on the final tree.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent --locked` — pass. Workspace Clippy + this command are the required pre-push-hook equivalent; this orb has no installed pre-push hook.
- `cargo xtask ci clippy-windows` — 1 passed, 0 failed, 0 skipped. This is the ring-free Windows cross-lint proxy, **not** the Windows desktop build/test lane. The changed `state.rs` cfg attribute was also hand-audited against `origin/master`; it changes test lint scope only.

Mutation checks, all deliberately reverted before the final gate:

- Detach the repaint task → resource test fails with 2 successor-stream polls instead of 1.
- Drop only the image Arc instead of calling GPUI `drop_image` → texture test fails because the atlas entry survives retargeting.
- Retry `StartFailed` from the same-target/deferred path → idempotence test fails with 5 opens instead of 1. The test does not prohibit a future explicit retry timer/action.

GPUI tests execute the real renderer and assert independent asymmetric BGRA pixels, image identities, and atlas insertion/removal. They are **not** real-GPU screenshots or hardware verification. No visible UI behavior changed, so no screenshot is attached. Windows desktop/macOS tests were not run locally; CI owns those platform lanes. The dependency `proc-macro-error2` emits an existing future-incompatibility notice.

Not runtime-tested on hardware. Maintainer smoke check: open a camera preview, grant Camera permission when requested, leave/re-enter the tab, switch cameras, and confirm live frames and camera release/LED behavior. Startup-error/busy-camera validation belongs to #1069.

Follow-up to #1182; does not close #1019.