### PR TITLE
fix(macos): drive the device-I/O gate from powerd instead of workspace notifications

### DIFF
--- a/.claude/rules/objc-ffi.md
+++ b/.claude/rules/objc-ffi.md
@@ -4,6 +4,7 @@ paths:
   - "crates/openlogi-overlay/src/platform.rs"
   - "crates/openlogi-permissions/**"
   - "crates/openlogi-camera/**"
+  - "crates/openlogi-agent/src/activity_macos.rs"
   - "crates/openlogi-agent/src/tray.rs"
   - "crates/openlogi-agent/src/status_item.rs"
   - "crates/openlogi-agent-core/src/watchers/camera.rs"
@@ -22,8 +23,9 @@ files; **keep this table in sync when you add or move one**:
 
 | File | What it carries |
 |---|---|
+| `openlogi-agent/src/activity_macos.rs` | the device-I/O gate's levels: the `IOPMConnection` powerd subscription (hand-declared SPI, see below) and the `CGSessionCopyCurrentDictionary` console read |
 | `openlogi-agent/src/status_item.rs` | safe `objc2` wrappers over `NSStatusItem` / `NSMenu` / `NSMenuItem` |
-| `openlogi-agent/src/tray.rs` | the menu-bar semantics, `MenuTarget` + `ResumeTarget` (`define_class!`), the Accessory `NSApplication` loop, `NSWorkspace` resume notifications |
+| `openlogi-agent/src/tray.rs` | the menu-bar semantics, `MenuTarget` + `SessionTarget` (`define_class!`), the Accessory `NSApplication` loop, the `NSWorkspace` session (fast-user-switch) notifications |
 | `openlogi-agent-core/src/watchers/camera.rs` | the CoreMediaIO "camera is running" property read |
 | `openlogi-camera/src/capture.rs` | `AVCaptureSession` capture + the `define_class!` frame delegate, and the Camera TCC prompt |
 | `openlogi-camera/src/macos.rs` | `AVCaptureDevice` enumeration (`class!` + `msg_send!`) |
@@ -90,9 +92,11 @@ every 2 s tray refresh under the old `cocoa`/`objc` 0.x path).
   there. Do **not** copy gpui's own `NSThread.isMainThread` + `dispatch2`
   runtime-check idiom; we use the compile-time `MainThreadMarker` guarantee.
 - The tray needs no `static` and no `thread_local`: `run_app_loop` is `-> !`, so
-  the status item, its `MenuTarget` and the `ResumeTarget` are bound as locals
-  that outlive `NSApplication::run()`. They must stay bound — menu items
-  reference their target *weakly*, and the notification center does the same.
+  the status item, its `MenuTarget`, the `SessionTarget` and the powerd
+  `PowerConnection` are bound as locals that outlive `NSApplication::run()`.
+  They must stay bound — menu items reference their target *weakly*, the
+  notification center does the same, and the power callback's `param` points
+  into the connection's own `Arc`.
 - `openlogi-camera`'s frame delegate is deliberately the opposite: an
   `NSObject` subclass with no `thread_kind`, because AVFoundation drives it on
   a background dispatch queue. Its one ivar is the owning session's
@@ -171,6 +175,13 @@ its single user. The current set, all deliberate:
 
 - `openlogi-hook`: `CGEventCopyIOHIDEvent` / `IOHIDEventGetSenderID` —
   undocumented, no bindings anywhere.
+- `openlogi-agent/src/activity_macos.rs`: the `IOPMConnection` SPI
+  (`IOPMConnectionCreate` / `SetNotification` / `SetDispatchQueue` /
+  `AcknowledgeEvent` / `Release` / `GetSystemCapabilities`) — exported by IOKit
+  since 10.6 and what `pmset` is built on, but declared only in Apple's
+  open-source `IOKitUser/pwr_mgt.subproj/IOPMLibPrivate.h`, so `objc2-io-kit`
+  cannot generate it. It is the only API that reports a DarkWake → FullWake
+  transition, which is why the gate needs it (see `docs/DECISIONS.md`).
 - `openlogi-camera`: the AVFoundation / CoreMedia / CoreVideo / CoreFoundation
   statics and functions its capture and enumeration paths need
   (`AVMediaTypeVideo`, `CMSampleBufferGetImageBuffer`, the `CVPixelBuffer`
@@ -198,9 +209,12 @@ under a `SAFETY` comment. Where it currently lives on macOS:
 - `agent/status_item.rs` — `NSMenuItem::initWithTitle_action_keyEquivalent` +
   `setTarget:` (raw selector; the target is a *weak* reference, which is why the
   tray keeps `MenuTarget` alive for the app's lifetime).
+- `agent/activity_macos.rs` — the `IOPMConnection` calls, its C callback (the
+  `param` is the gate the `PowerConnection` keeps alive, and `Drop` drains the
+  delivery queue before that `Arc` goes), and the `CGSession` dictionary cast.
 - `agent/tray.rs` — `msg_send![super(this), init]`, the notification-center
-  `addObserver:selector:name:object:`, and the `NSWorkspace*Notification` name
-  statics.
+  `addObserver:selector:name:object:`, and the `NSWorkspaceSession*Notification`
+  name statics.
 - `hook/macos.rs` — the whole tap (Core Graphics / Core Foundation C APIs),
   the `NSWorkspace` activation-observer registration and typed notification
   payload, `AXIsProcessTrusted[WithOptions]` and the two extern statics they

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,7 +5060,6 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.1",
  "dispatch2",
- "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
@@ -5389,8 +5388,10 @@ dependencies = [
  "interprocess",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
+ "objc2-io-kit",
  "opener",
  "openlogi-agent-core",
  "openlogi-core",

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -401,9 +401,9 @@ impl GestureManagerState {
         channels: &SessionChannels,
     ) {
         // Keep existing passive listeners and their firmware ownership intact
-        // while the display/session is asleep. Retiring them here would issue
-        // restoration writes during DarkWake; retries and successors wait for
-        // the user-visible resume instead.
+        // while the host has paused device I/O. Retiring them here would issue
+        // restoration writes during a DarkWake; retries and successors wait
+        // for the full wake instead.
         if !device_io_allowed {
             return;
         }

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -48,8 +48,10 @@ embed-resource = "3.0.9"
 dispatch2 = "0.3.1"
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSRunningApplication", "NSWorkspace"] }
-objc2-core-graphics = { workspace = true, features = ["CGDirectDisplay", "CGDisplayConfiguration", "libc"] }
+objc2-core-foundation = { workspace = true, features = ["CFBase", "CFDictionary", "CFNumber", "CFString"] }
+objc2-core-graphics = { workspace = true, features = ["CGSession"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSData", "NSArray", "NSNotification"] }
+objc2-io-kit = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = "5"

--- a/crates/openlogi-agent/src/activity_macos.rs
+++ b/crates/openlogi-agent/src/activity_macos.rs
@@ -126,6 +126,19 @@ impl ActivityGate {
         self.update(|levels| levels.on_console = on_console);
     }
 
+    /// Record a power transition together with the console level read at
+    /// the same moment, as one gate decision.
+    ///
+    /// Two separate writes would publish twice: a full wake against a stale
+    /// `on_console = true` would open the gate for the instant before the
+    /// fresh read closed it again, and a HID open can start in that instant.
+    pub fn observe(&self, power: PowerState, on_console: bool) {
+        self.update(|levels| {
+            levels.power = power;
+            levels.on_console = on_console;
+        });
+    }
+
     /// Release the launch hold. What the gate does next follows from the
     /// levels alone: a launch into a DarkWake stays closed until powerd
     /// reports the full wake.
@@ -289,10 +302,10 @@ unsafe extern "C" fn on_event(
         ?power,
         "power transition"
     );
-    gate.set_power(power);
-    // The console can move while the machine is dark; the wake is the moment
-    // a dropped session notification would otherwise start to matter.
-    gate.set_on_console(session_is_on_console());
+    // The console can move while the machine is dark, and the wake is the
+    // moment a dropped session notification would start to matter — so read
+    // it now and decide on both levels at once.
+    gate.observe(power, session_is_on_console());
     // SAFETY: `token` identifies this event on `connection`, both handed to
     // this callback by powerd.
     let status = unsafe { ffi::IOPMConnectionAcknowledgeEvent(connection, token) };
@@ -461,6 +474,26 @@ mod tests {
         );
         gate.set_on_console(true);
         assert!(io.allows_io());
+    }
+
+    #[test]
+    fn a_full_wake_into_another_users_console_never_publishes_allowed() {
+        use futures::FutureExt as _;
+
+        let (gate, mut io) = awake_on_console();
+        gate.set_power(PowerState::Sleep);
+        assert_eq!(io.changed().now_or_never(), Some(Some(false)));
+
+        // The console moved while the machine was dark and the session
+        // notification never arrived. The wake must not open the gate even
+        // for an instant: a watch channel keeps a version per publish, so an
+        // Allowed-then-Suspended pair would surface here as a change.
+        gate.observe(PowerState::FullWake, false);
+        assert!(!io.allows_io());
+        assert_eq!(io.changed().now_or_never(), None);
+
+        gate.observe(PowerState::FullWake, true);
+        assert_eq!(io.changed().now_or_never(), Some(Some(true)));
     }
 
     #[test]

--- a/crates/openlogi-agent/src/activity_macos.rs
+++ b/crates/openlogi-agent/src/activity_macos.rs
@@ -1,0 +1,484 @@
+//! The macOS host-activity levels behind the device-I/O gate.
+//!
+//! The gate exists to keep Logitech HID access off while the Mac is asleep or
+//! in a DarkWake: opening a Bluetooth HID device during a maintenance wake is
+//! what promoted an invisible wake into a lit external display (#656). That is
+//! a question about the *system's* power state, and it is answered here from
+//! power management itself rather than from AppKit.
+//!
+//! `NSWorkspace` cannot carry it. Its sleep/wake notifications are edges, the
+//! screen-wake edge is not guaranteed on a lid-close/open cycle (Apple DTS,
+//! developer forums thread 796109), and `NSWorkspaceDidWakeNotification` fires
+//! for a DarkWake as well — so an edge-latched gate had no "the DarkWake is
+//! over" signal and wedged shut whenever a wake notification was dropped
+//! (#1281).
+//!
+//! `IOPMConnection`, the powerd client API `pmset` is built on, reports every
+//! Sleep / DarkWake / FullWake transition as the complete capability set of
+//! the new state, delivered over Mach to a dispatch queue this process owns,
+//! and reads the current set on demand. Every input to the gate is therefore a
+//! level: nothing has to pair, a missed event is corrected by the next, and no
+//! timer is needed. Console ownership (fast user switching) is the other
+//! level; its AppKit edges are forwarded from `tray`, and it is re-read from
+//! CoreGraphics on every power transition.
+//!
+//! The API is exported by IOKit since 10.6 but declared only in Apple's
+//! open-source `IOKitUser/pwr_mgt.subproj/IOPMLibPrivate.h`, hence the
+//! hand-written `extern` block (`.claude/rules/objc-ffi.md`). When the
+//! connection cannot be opened the gate follows the console alone and says so
+//! at error level: a Mac without the SPI gets pre-0.8.2 behaviour — hardware
+//! usable, #656 unprotected — not an agent that can never touch hardware.
+
+#![expect(
+    unsafe_code,
+    reason = "the IOPMConnection SPI has no bindings; its calls, C callback, and the CGSession dictionary cast live here"
+)]
+
+use std::ffi::c_void;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use dispatch2::{DispatchQueue, DispatchQueueAttr, DispatchRetained};
+use objc2_core_foundation::{CFBoolean, CFString, CFType};
+use objc2_core_graphics::CGSessionCopyCurrentDictionary;
+use objc2_io_kit::{IOReturn, kIOReturnSuccess};
+use openlogi_hid::DeviceIoSignal;
+use tracing::{debug, error, info, warn};
+
+/// The system power states that matter to hardware access.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PowerState {
+    /// The CPU is off in this state: sleep or hibernation.
+    Sleep,
+    /// The CPU runs with graphics down: a maintenance or notification wake
+    /// the user cannot see. HID activity here is what #656 is about.
+    DarkWake,
+    /// Graphics are up: a wake the user can see.
+    FullWake,
+}
+
+impl PowerState {
+    /// Classify an `IOPMCapabilityBits` set.
+    ///
+    /// A clear CPU bit is a sleep state and makes the other bits meaningless;
+    /// with it set, the video bit is what separates a DarkWake from the full
+    /// wake `IOPMIsAUserWake` tests for.
+    fn from_capabilities(capabilities: ffi::CapabilityBits) -> Self {
+        if capabilities & ffi::CAPABILITY_CPU == 0 {
+            Self::Sleep
+        } else if capabilities & ffi::CAPABILITY_VIDEO == 0 {
+            Self::DarkWake
+        } else {
+            Self::FullWake
+        }
+    }
+}
+
+/// Everything the gate decides from. Levels only — never an edge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Levels {
+    power: PowerState,
+    /// This login session owns the console; fast user switching moves it.
+    on_console: bool,
+    /// The launch hold, released once both levels above have been read.
+    starting: bool,
+}
+
+impl Levels {
+    fn allows_io(self) -> bool {
+        !self.starting && self.power == PowerState::FullWake && self.on_console
+    }
+}
+
+/// The one transition authority for the device-I/O gate on macOS.
+///
+/// Every writer — the powerd callback, the AppKit session observer, the launch
+/// sequence — sets a level here, and only the resulting [`Levels::allows_io`]
+/// moves the published [`DeviceIoSignal`], so the signal can never drift from
+/// the levels.
+pub struct ActivityGate {
+    signal: DeviceIoSignal,
+    levels: Mutex<Levels>,
+}
+
+impl ActivityGate {
+    /// Close `signal` and hold it closed until [`Self::finish_startup`].
+    pub fn new(signal: DeviceIoSignal) -> Arc<Self> {
+        // `main` closes the gate before spawning the core thread; repeating
+        // the idempotent close keeps the launch hold self-contained.
+        let _ = signal.suspend();
+        Arc::new(Self {
+            signal,
+            levels: Mutex::new(Levels {
+                // Unread until `connect` seeds it; the launch hold covers the
+                // gap, and a launch into a DarkWake must not guess "awake".
+                power: PowerState::Sleep,
+                on_console: false,
+                starting: true,
+            }),
+        })
+    }
+
+    pub fn set_power(&self, power: PowerState) {
+        self.update(|levels| levels.power = power);
+    }
+
+    pub fn set_on_console(&self, on_console: bool) {
+        self.update(|levels| levels.on_console = on_console);
+    }
+
+    /// Release the launch hold. What the gate does next follows from the
+    /// levels alone: a launch into a DarkWake stays closed until powerd
+    /// reports the full wake.
+    pub fn finish_startup(&self) {
+        self.update(|levels| levels.starting = false);
+    }
+
+    fn update(&self, change: impl FnOnce(&mut Levels)) {
+        let mut levels = self.levels.lock().unwrap_or_else(PoisonError::into_inner);
+        let before = *levels;
+        change(&mut levels);
+        let after = *levels;
+        // Published — and logged — under the lock, so two writers cannot
+        // reorder each other's transitions.
+        if after.allows_io() {
+            if self.signal.resume() {
+                info!(power = ?after.power, on_console = after.on_console, "device I/O resumed");
+            }
+        } else if self.signal.suspend() {
+            info!(
+                power = ?after.power,
+                on_console = after.on_console,
+                starting = after.starting,
+                "device I/O paused"
+            );
+        } else if before != after {
+            debug!(
+                ?before,
+                ?after,
+                "host activity level changed; device I/O stays paused"
+            );
+        }
+    }
+}
+
+/// Whether this login session currently owns the console.
+///
+/// `kCGSessionOnConsoleKey` (`CGSession.h`) is the level whose edges
+/// `NSWorkspaceSessionDidBecomeActive` / `…DidResignActive` announce; the
+/// header defines it as `CFSTR("kCGSSessionOnConsoleKey")`, hence the literal.
+/// No session dictionary at all means no GUI session, which is not a state to
+/// resume into either.
+#[must_use]
+pub fn session_is_on_console() -> bool {
+    let Some(session) = CGSessionCopyCurrentDictionary() else {
+        return false;
+    };
+    // SAFETY: `CGSession.h` documents the dictionary as keyed by the
+    // `kCGSession*Key` CFStrings with CoreFoundation values.
+    let session = unsafe { session.cast_unchecked::<CFString, CFType>() };
+    session
+        .get(&CFString::from_static_str("kCGSSessionOnConsoleKey"))
+        .as_deref()
+        .and_then(CFType::downcast_ref::<CFBoolean>)
+        .is_some_and(CFBoolean::value)
+}
+
+/// A live powerd subscription.
+///
+/// `tray::run_app_loop` binds it next to the AppKit loop it never returns
+/// from. The gate it reports to is kept alive by the `Arc` held here, and
+/// [`Drop`] ends delivery before that `Arc` can go, which is what makes the
+/// callback's raw `param` sound.
+pub struct PowerConnection {
+    _gate: Arc<ActivityGate>,
+    queue: DispatchRetained<DispatchQueue>,
+    connection: ffi::Connection,
+}
+
+/// Subscribe `gate` to powerd's Sleep / DarkWake / FullWake transitions and
+/// seed it with the current state.
+///
+/// `None` means the SPI could not be reached. The gate is then told the
+/// system is in a permanent full wake and follows the console alone — the
+/// fail-open degradation the module docs describe.
+pub fn connect(gate: &Arc<ActivityGate>) -> Option<PowerConnection> {
+    match PowerConnection::open(Arc::clone(gate)) {
+        Ok(connection) => Some(connection),
+        Err(status) => {
+            error!(
+                status,
+                "could not subscribe to power management — device I/O will follow the login session only, and a DarkWake will not pause it"
+            );
+            gate.set_power(PowerState::FullWake);
+            None
+        }
+    }
+}
+
+impl PowerConnection {
+    fn open(gate: Arc<ActivityGate>) -> Result<Self, IOReturn> {
+        let mut connection: ffi::Connection = std::ptr::null();
+        let name = CFString::from_static_str("openlogi-agent");
+        // SAFETY: `name` is a live CFString and `connection` a valid
+        // out-pointer; powerd copies the name for its own logging.
+        let status = unsafe {
+            ffi::IOPMConnectionCreate(&name, ffi::SLEEP_WAKE_INTEREST, &raw mut connection)
+        };
+        if status != kIOReturnSuccess || connection.is_null() {
+            return Err(status);
+        }
+        let param = Arc::as_ptr(&gate).cast_mut().cast::<c_void>();
+        // SAFETY: `connection` came from a successful create, `on_event` has
+        // the handler's exact C signature, and `param` points at the gate the
+        // returned `PowerConnection` keeps alive.
+        let status = unsafe { ffi::IOPMConnectionSetNotification(connection, param, on_event) };
+        if status != kIOReturnSuccess {
+            // SAFETY: releasing the connection this function created and has
+            // not yet scheduled for delivery.
+            unsafe { ffi::IOPMConnectionRelease(connection) };
+            return Err(status);
+        }
+        // Seed the level before delivery starts, so the first event can only
+        // move forward from a read state rather than from the launch default.
+        // SAFETY: a plain read of powerd's current capability set.
+        let capabilities = unsafe { ffi::IOPMConnectionGetSystemCapabilities() };
+        gate.set_power(PowerState::from_capabilities(capabilities));
+        let queue = DispatchQueue::new("org.openlogi.agent.power", DispatchQueueAttr::SERIAL);
+        // SAFETY: both handles are live; the queue is retained by the
+        // returned value for as long as the connection can deliver to it.
+        unsafe { ffi::IOPMConnectionSetDispatchQueue(connection, &queue) };
+        Ok(Self {
+            _gate: gate,
+            queue,
+            connection,
+        })
+    }
+}
+
+impl Drop for PowerConnection {
+    fn drop(&mut self) {
+        // SAFETY: the connection was created by `open` and is released
+        // exactly once, here.
+        let status = unsafe { ffi::IOPMConnectionRelease(self.connection) };
+        if status != kIOReturnSuccess {
+            warn!(
+                status,
+                "could not release the power management subscription"
+            );
+        }
+        // A transition already handed to the queue may still be running with
+        // a pointer to the gate; let the serial queue drain before the `Arc`
+        // behind `param` is dropped with the rest of `self`.
+        self.queue.exec_sync(|| {});
+    }
+}
+
+/// powerd's transition callback, on the connection's dispatch queue.
+unsafe extern "C" fn on_event(
+    param: *mut c_void,
+    connection: ffi::Connection,
+    token: ffi::MessageToken,
+    capabilities: ffi::CapabilityBits,
+) {
+    // SAFETY: `param` is the `ActivityGate` behind the `Arc` the
+    // `PowerConnection` holds, alive for the connection's lifetime.
+    let gate = unsafe { &*param.cast::<ActivityGate>() };
+    let power = PowerState::from_capabilities(capabilities);
+    debug!(
+        capabilities = format_args!("{capabilities:#x}"),
+        ?power,
+        "power transition"
+    );
+    gate.set_power(power);
+    // The console can move while the machine is dark; the wake is the moment
+    // a dropped session notification would otherwise start to matter.
+    gate.set_on_console(session_is_on_console());
+    // SAFETY: `token` identifies this event on `connection`, both handed to
+    // this callback by powerd.
+    let status = unsafe { ffi::IOPMConnectionAcknowledgeEvent(connection, token) };
+    if status != kIOReturnSuccess {
+        warn!(
+            status,
+            "could not acknowledge the power transition — power management continues after its timeout"
+        );
+    }
+}
+
+/// The `IOPMConnection` SPI, transcribed from
+/// `IOKitUser/pwr_mgt.subproj/IOPMLibPrivate.h` (IOKitUser-100231).
+mod ffi {
+    use std::ffi::c_void;
+
+    use dispatch2::DispatchQueue;
+    use objc2_core_foundation::CFString;
+    use objc2_io_kit::IOReturn;
+
+    /// `IOPMConnection`: an opaque, powerd-owned handle.
+    #[repr(C)]
+    pub struct OpaqueConnection {
+        _private: [u8; 0],
+    }
+    pub type Connection = *const OpaqueConnection;
+    /// `IOPMCapabilityBits`.
+    pub type CapabilityBits = u32;
+    /// `IOPMConnectionMessageToken`.
+    pub type MessageToken = u32;
+    /// `IOPMEventHandlerType`.
+    pub type EventHandler =
+        unsafe extern "C" fn(*mut c_void, Connection, MessageToken, CapabilityBits);
+
+    /// `kIOPMCapabilityCPU`: clear in every sleep state.
+    pub const CAPABILITY_CPU: CapabilityBits = 0x1;
+    /// `kIOPMCapabilityVideo`: "graphic output to displays are supported".
+    pub const CAPABILITY_VIDEO: CapabilityBits = 0x2;
+    const CAPABILITY_AUDIO: CapabilityBits = 0x4;
+    const CAPABILITY_NETWORK: CapabilityBits = 0x8;
+    const CAPABILITY_DISK: CapabilityBits = 0x10;
+    /// `kIOPMSleepWakeInterest`: "notifications for Sleep, FullWake, and
+    /// DarkWake system events".
+    pub const SLEEP_WAKE_INTEREST: CapabilityBits =
+        CAPABILITY_CPU | CAPABILITY_DISK | CAPABILITY_NETWORK | CAPABILITY_VIDEO | CAPABILITY_AUDIO;
+
+    #[link(name = "IOKit", kind = "framework")]
+    unsafe extern "C" {
+        pub fn IOPMConnectionCreate(
+            name: &CFString,
+            interests: CapabilityBits,
+            connection: *mut Connection,
+        ) -> IOReturn;
+        pub fn IOPMConnectionSetNotification(
+            connection: Connection,
+            param: *mut c_void,
+            handler: EventHandler,
+        ) -> IOReturn;
+        pub fn IOPMConnectionSetDispatchQueue(connection: Connection, queue: &DispatchQueue);
+        pub fn IOPMConnectionAcknowledgeEvent(
+            connection: Connection,
+            token: MessageToken,
+        ) -> IOReturn;
+        pub fn IOPMConnectionRelease(connection: Connection) -> IOReturn;
+        pub fn IOPMConnectionGetSystemCapabilities() -> CapabilityBits;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openlogi_hid::device_io_channel;
+
+    /// `pmset -g log` renders these as `[CDNP]` (DarkWake) and `[CDNVA]`
+    /// (FullWake); the letters are the same bits.
+    const DARK_WAKE: ffi::CapabilityBits = 0x19;
+    const FULL_WAKE: ffi::CapabilityBits = 0x1f;
+
+    #[test]
+    fn capability_bits_classify_by_cpu_then_video() {
+        assert_eq!(PowerState::from_capabilities(0), PowerState::Sleep);
+        assert_eq!(
+            PowerState::from_capabilities(DARK_WAKE),
+            PowerState::DarkWake
+        );
+        assert_eq!(
+            PowerState::from_capabilities(FULL_WAKE),
+            PowerState::FullWake
+        );
+        // Video without CPU is not a state powerd reports; read it as the
+        // sleep the CPU bit says it is.
+        assert_eq!(
+            PowerState::from_capabilities(ffi::CAPABILITY_VIDEO),
+            PowerState::Sleep
+        );
+    }
+
+    fn awake_on_console() -> (Arc<ActivityGate>, openlogi_hid::DeviceIoGate) {
+        let (signal, io) = device_io_channel();
+        let gate = ActivityGate::new(signal);
+        gate.set_power(PowerState::FullWake);
+        gate.set_on_console(true);
+        gate.finish_startup();
+        assert!(io.allows_io());
+        (gate, io)
+    }
+
+    #[test]
+    fn the_launch_hold_outlasts_favourable_levels() {
+        let (signal, io) = device_io_channel();
+        let gate = ActivityGate::new(signal);
+        assert!(!io.allows_io(), "startup must fail closed");
+        gate.set_power(PowerState::FullWake);
+        gate.set_on_console(true);
+        assert!(!io.allows_io(), "levels alone must not release the hold");
+        gate.finish_startup();
+        assert!(io.allows_io());
+    }
+
+    #[test]
+    fn a_launch_into_a_dark_wake_stays_closed_until_the_full_wake() {
+        // The relaunch loop of #952: a watchdog restart during the sleep
+        // transition used to guess "awake" and probe HID behind a dark panel.
+        let (signal, io) = device_io_channel();
+        let gate = ActivityGate::new(signal);
+        gate.set_power(PowerState::DarkWake);
+        gate.set_on_console(true);
+        gate.finish_startup();
+        assert!(!io.allows_io());
+        gate.set_power(PowerState::FullWake);
+        assert!(io.allows_io());
+    }
+
+    #[test]
+    fn a_dark_wake_blip_reopens_on_the_full_wake_alone() {
+        // #1281: a one-second DarkWake at unlock, promoted back to a full wake
+        // by HID activity, with no screen-wake notification ever delivered.
+        let (gate, io) = awake_on_console();
+        gate.set_power(PowerState::DarkWake);
+        assert!(!io.allows_io());
+        gate.set_power(PowerState::FullWake);
+        assert!(io.allows_io());
+    }
+
+    #[test]
+    fn sleep_closes_and_only_a_full_wake_reopens() {
+        let (gate, io) = awake_on_console();
+        gate.set_power(PowerState::Sleep);
+        assert!(!io.allows_io());
+        gate.set_power(PowerState::DarkWake);
+        assert!(!io.allows_io(), "a maintenance wake is not a resume (#656)");
+        gate.set_power(PowerState::FullWake);
+        assert!(io.allows_io());
+    }
+
+    #[test]
+    fn another_users_console_holds_the_gate_through_a_full_wake() {
+        let (gate, io) = awake_on_console();
+        gate.set_on_console(false);
+        assert!(!io.allows_io());
+        gate.set_power(PowerState::Sleep);
+        gate.set_power(PowerState::FullWake);
+        assert!(
+            !io.allows_io(),
+            "a wake into another user's session must not resume"
+        );
+        gate.set_on_console(true);
+        assert!(io.allows_io());
+    }
+
+    #[test]
+    fn the_spi_reports_a_running_cpu_and_accepts_a_subscription() {
+        // Resolves the hand-declared symbols against the host's IOKit and
+        // pins the one fact any running process can assert about itself.
+        // SAFETY: a plain read of powerd's current capability set.
+        let capabilities = unsafe { ffi::IOPMConnectionGetSystemCapabilities() };
+        assert_ne!(
+            capabilities & ffi::CAPABILITY_CPU,
+            0,
+            "a process reading its own capability set is not asleep"
+        );
+        let (signal, _io) = device_io_channel();
+        let gate = ActivityGate::new(signal);
+        assert!(
+            PowerConnection::open(gate).is_ok(),
+            "powerd must accept an unprivileged subscription"
+        );
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -15,6 +15,8 @@
     windows_subsystem = "windows"
 )]
 
+#[cfg(target_os = "macos")]
+mod activity_macos;
 mod autostart;
 mod binary_watch;
 mod lifecycle;
@@ -110,9 +112,8 @@ fn main() {
     #[cfg(target_os = "macos")]
     {
         // Fail closed before the core thread can enumerate or open HID devices.
-        // AppKit releases this startup hold only after its workspace observers
-        // have received the initial session state and Core Graphics has
-        // reported whether the display is already asleep.
+        // The AppKit loop releases this launch hold only after it has read the
+        // login session's console ownership and powerd's current power state.
         let _ = device_io_signal.suspend();
         // Read the menu-bar preference before `config` moves into the core
         // thread; the main thread hosts the tray.

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -1,4 +1,4 @@
-//! The agent's macOS AppKit loop, menu-bar item, and resume notifications.
+//! The agent's macOS AppKit loop, menu-bar item, and login-session observer.
 //!
 //! The always-on agent hosts the menu bar (the GUI is on-demand). The item
 //! carries GUI-directed actions ("Show Main Window", Settings, About, Check for
@@ -10,6 +10,10 @@
 //! launched then URL delivered) and warm reactivation (URL delivered to the
 //! running app).
 //!
+//! The device-I/O gate itself lives in `activity_macos`; this file only
+//! forwards the `NSWorkspace` session edges (fast user switching) to it and
+//! sequences the launch hold around `finishLaunching`.
+//!
 //! macOS-only. AppKit objects are `Retained<T>` (no #99-style leaks); the run
 //! loop owns the main thread for the agent's lifetime.
 
@@ -19,7 +23,7 @@
 )]
 
 use std::cell::RefCell;
-use std::sync::{Mutex, PoisonError};
+use std::sync::Arc;
 
 use dispatch2::DispatchQueue;
 use objc2::rc::Retained;
@@ -28,21 +32,17 @@ use objc2::{
     AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel,
 };
 use objc2_app_kit::NSStatusItem;
-#[cfg(test)]
-use objc2_app_kit::NSWorkspaceDidWakeNotification;
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSImage, NSRunningApplication, NSWorkspace,
-    NSWorkspaceScreensDidSleepNotification, NSWorkspaceScreensDidWakeNotification,
     NSWorkspaceSessionDidBecomeActiveNotification, NSWorkspaceSessionDidResignActiveNotification,
-    NSWorkspaceWillSleepNotification,
 };
-use objc2_core_graphics::{CGDisplayIsAsleep, CGMainDisplayID};
 use objc2_foundation::{NSNotification, NSString};
 use openlogi_core::brand::{self, DeeplinkCommand};
 use openlogi_core::config::AppIcon;
 use openlogi_hid::DeviceIoSignal;
 use tracing::{info, warn};
 
+use crate::activity_macos::{self, ActivityGate};
 use crate::shutdown::{self, ShutdownRequestSender};
 use crate::status_item;
 
@@ -115,103 +115,36 @@ pub fn relocalize() {
     });
 }
 
-struct ActivityTargetIvars {
-    signal: DeviceIoSignal,
-    suspended_by: Mutex<u8>,
+struct SessionTargetIvars {
+    gate: Arc<ActivityGate>,
 }
 
-const SYSTEM_SLEEP: u8 = 1 << 0;
-const SCREEN_SLEEP: u8 = 1 << 1;
-const SESSION_INACTIVE: u8 = 1 << 2;
-const STARTUP: u8 = 1 << 3;
-
 define_class!(
-    // SAFETY: NSObject has no subclassing requirements, and `ActivityTarget`
+    // SAFETY: NSObject has no subclassing requirements, and `SessionTarget`
     // does not implement `Drop`.
     #[unsafe(super(NSObject))]
-    #[ivars = ActivityTargetIvars]
-    #[name = "OpenLogiAgentWorkspaceActivityTarget"]
-    struct ActivityTarget;
+    #[ivars = SessionTargetIvars]
+    #[name = "OpenLogiAgentWorkspaceSessionTarget"]
+    struct SessionTarget;
 
-    impl ActivityTarget {
-        #[unsafe(method(workspaceWillSleep:))]
-        fn workspace_will_sleep(&self, _notification: &NSNotification) {
-            self.suspend_from(SYSTEM_SLEEP);
-        }
-
-        #[unsafe(method(workspaceScreensDidSleep:))]
-        fn workspace_screens_did_sleep(&self, _notification: &NSNotification) {
-            self.suspend_from(SCREEN_SLEEP);
-        }
-
+    impl SessionTarget {
         #[unsafe(method(workspaceSessionDidResignActive:))]
         fn workspace_session_did_resign_active(&self, _notification: &NSNotification) {
-            self.suspend_from(SESSION_INACTIVE);
-        }
-
-        #[unsafe(method(workspaceScreensDidWake:))]
-        fn workspace_screens_did_wake(&self, _notification: &NSNotification) {
-            self.resume_from(SYSTEM_SLEEP | SCREEN_SLEEP);
+            self.ivars().gate.set_on_console(false);
         }
 
         #[unsafe(method(workspaceSessionDidBecomeActive:))]
         fn workspace_session_did_become_active(&self, _notification: &NSNotification) {
-            self.resume_from(SYSTEM_SLEEP | SESSION_INACTIVE);
+            self.ivars().gate.set_on_console(true);
         }
     }
 );
 
-impl ActivityTarget {
-    fn new(signal: DeviceIoSignal) -> Retained<Self> {
-        // `main` closes the gate before spawning the core thread; repeat the
-        // idempotent close here so the target's STARTUP source is self-contained
-        // in tests and any future caller cannot accidentally start open.
-        let _ = signal.suspend();
-        let this = Self::alloc().set_ivars(ActivityTargetIvars {
-            signal,
-            suspended_by: Mutex::new(STARTUP),
-        });
+impl SessionTarget {
+    fn new(gate: Arc<ActivityGate>) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(SessionTargetIvars { gate });
         // SAFETY: `init` initializes our freshly allocated NSObject subclass.
         unsafe { msg_send![super(this), init] }
-    }
-
-    fn finish_startup(&self, display_asleep: bool) {
-        if display_asleep {
-            self.suspend_from(SCREEN_SLEEP);
-        }
-        self.resume_from(STARTUP);
-    }
-
-    fn suspend_from(&self, source: u8) {
-        let changed = {
-            let mut suspended_by = self
-                .ivars()
-                .suspended_by
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let was_allowed = *suspended_by == 0;
-            *suspended_by |= source;
-            was_allowed && self.ivars().signal.suspend()
-        };
-        if changed {
-            info!("display/session suspended — pausing device I/O");
-        }
-    }
-
-    fn resume_from(&self, sources: u8) {
-        let changed = {
-            let mut suspended_by = self
-                .ivars()
-                .suspended_by
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner);
-            let was_suspended = *suspended_by != 0;
-            *suspended_by &= !sources;
-            was_suspended && *suspended_by == 0 && self.ivars().signal.resume()
-        };
-        if changed {
-            info!("display/session resumed — enabling device I/O");
-        }
     }
 }
 
@@ -319,8 +252,8 @@ fn gui_is_running() -> bool {
 /// tokio core still does all the work). The toggle takes effect on the agent's
 /// next launch — a no-restart live toggle would need a main-thread hop from the
 /// IPC reload path (deferred; it can't be verified headlessly).
-/// `device_io_signal` closes the hardware gate while the display/session is
-/// asleep and reopens it only for a user-visible resume.
+/// `device_io_signal` is the hardware gate; it opens only while the Mac is in
+/// a full wake and this login session owns the console (`activity_macos`).
 pub fn run_app_loop(
     show_in_menu_bar: bool,
     app_icon: AppIcon,
@@ -336,18 +269,23 @@ pub fn run_app_loop(
     let app = NSApplication::sharedApplication(mtm);
     app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
 
-    let activity_target = install_activity_observer(device_io_signal);
+    let gate = ActivityGate::new(device_io_signal);
+    let _session = install_session_observer(Arc::clone(&gate));
     // Bind the status item (+ its target/menu) so they outlive `run()` — the
     // menu items only weakly reference the target. `None` when hidden.
     let _tray = show_in_menu_bar.then(|| install_status_item(mtm, app_icon));
 
     // AppKit documents that an app launched into an inactive session receives
     // `NSWorkspaceSessionDidResignActiveNotification` between its will- and
-    // did-finish-launching notifications. Finish that lifecycle while STARTUP
-    // still holds the hardware gate closed, then snapshot display sleep before
-    // permitting the core's initial inventory scan.
+    // did-finish-launching notifications. Finish that lifecycle while the
+    // launch hold still keeps the hardware gate closed, then read both levels
+    // — the console from CoreGraphics, the power state from powerd, which
+    // also starts the transition stream — before releasing the hold. Every
+    // one of those is a level, so the order they land in cannot matter.
     app.finishLaunching();
-    activity_target.finish_startup(CGDisplayIsAsleep(CGMainDisplayID()));
+    let _power = activity_macos::connect(&gate);
+    gate.set_on_console(activity_macos::session_is_on_console());
+    gate.finish_startup();
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
@@ -356,49 +294,24 @@ pub fn run_app_loop(
     shutdown::request_tray_quit(requests.as_ref(), 0);
 }
 
-/// Observe display/session sleep and user-visible resume transitions. Generic
-/// `NSWorkspaceDidWakeNotification` is deliberately not registered: macOS
-/// emits it for maintenance DarkWake, where opening BLE HID is exactly what can
-/// promote an otherwise invisible wake into a full display wake (#656).
-fn install_activity_observer(signal: DeviceIoSignal) -> Retained<ActivityTarget> {
-    let target = ActivityTarget::new(signal);
+/// Forward the login session's console edges to the gate. These are the fast
+/// user switching notifications; sleep and wake are deliberately not observed
+/// here — powerd reports them as levels (`activity_macos`).
+fn install_session_observer(gate: Arc<ActivityGate>) -> Retained<SessionTarget> {
+    let target = SessionTarget::new(gate);
     let workspace = NSWorkspace::sharedWorkspace();
     let center = workspace.notificationCenter();
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
-    let system_sleep = unsafe { NSWorkspaceWillSleepNotification };
-    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
-    let screen_sleep = unsafe { NSWorkspaceScreensDidSleepNotification };
-    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let session_inactive = unsafe { NSWorkspaceSessionDidResignActiveNotification };
     // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
-    let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
-    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
     let session_active = unsafe { NSWorkspaceSessionDidBecomeActiveNotification };
-    // SAFETY: Every selector below has exactly one `NSNotification` argument,
-    // and the caller retains the target for the AppKit loop's lifetime.
+    // SAFETY: Both selectors take exactly one `NSNotification` argument, and
+    // the caller retains the target for the AppKit loop's lifetime.
     unsafe {
-        center.addObserver_selector_name_object(
-            &target,
-            sel!(workspaceWillSleep:),
-            Some(system_sleep),
-            Some(&workspace),
-        );
-        center.addObserver_selector_name_object(
-            &target,
-            sel!(workspaceScreensDidSleep:),
-            Some(screen_sleep),
-            Some(&workspace),
-        );
         center.addObserver_selector_name_object(
             &target,
             sel!(workspaceSessionDidResignActive:),
             Some(session_inactive),
-            Some(&workspace),
-        );
-        center.addObserver_selector_name_object(
-            &target,
-            sel!(workspaceScreensDidWake:),
-            Some(screen_wake),
             Some(&workspace),
         );
         center.addObserver_selector_name_object(
@@ -500,89 +413,34 @@ fn build_menu(mtm: MainThreadMarker, target: &MenuTarget) -> Retained<objc2_app_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::activity_macos::PowerState;
     use openlogi_hid::device_io_channel;
 
-    // Both tests post to the process-wide NSWorkspace notification center.
-    // Keep each observer's entire registration/posting/removal lifetime isolated
-    // so one test's session-inactive event cannot suspend the other test's gate.
-    static WORKSPACE_NOTIFICATIONS: Mutex<()> = Mutex::new(());
-
     #[test]
-    fn overlapping_suspend_sources_all_clear_before_device_io_resumes() {
-        let _notifications = WORKSPACE_NOTIFICATIONS.lock().unwrap();
-        let (signal, gate) = device_io_channel();
-        let target = install_activity_observer(signal);
-        target.finish_startup(false);
+    fn a_session_switch_closes_the_gate_and_the_switch_back_reopens_it() {
+        let (signal, io) = device_io_channel();
+        let gate = ActivityGate::new(signal);
+        let target = install_session_observer(Arc::clone(&gate));
+        gate.set_power(PowerState::FullWake);
+        gate.set_on_console(true);
+        gate.finish_startup();
+        assert!(io.allows_io());
+
         let workspace = NSWorkspace::sharedWorkspace();
         let center = workspace.notificationCenter();
-
-        // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
-        let system_sleep = unsafe { NSWorkspaceWillSleepNotification };
-        // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
-        let screen_sleep = unsafe { NSWorkspaceScreensDidSleepNotification };
-        // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
         let session_inactive = unsafe { NSWorkspaceSessionDidResignActiveNotification };
         // SAFETY: `workspace` is live, matches the registration filter, and
         // notification delivery completes synchronously.
-        unsafe { center.postNotificationName_object(system_sleep, Some(&workspace)) };
-        // SAFETY: `workspace` is live, matches the registration filter, and
-        // notification delivery completes synchronously.
-        unsafe { center.postNotificationName_object(screen_sleep, Some(&workspace)) };
-        // SAFETY: `workspace` is live, matches the registration filter, and
-        // notification delivery completes synchronously.
         unsafe { center.postNotificationName_object(session_inactive, Some(&workspace)) };
-        assert!(!gate.allows_io());
-
-        // `DidWake` is a maintenance/system wake and intentionally has no
-        // observer, so posting it must leave the gate closed.
-        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
-        let darkwake = unsafe { NSWorkspaceDidWakeNotification };
-        // SAFETY: `workspace` is live and notification delivery is synchronous.
-        unsafe { center.postNotificationName_object(darkwake, Some(&workspace)) };
-        assert!(!gate.allows_io());
-
-        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
-        let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
-        // SAFETY: `workspace` is live, matches the registration filter, and
-        // notification delivery completes synchronously.
-        unsafe { center.postNotificationName_object(screen_wake, Some(&workspace)) };
-        assert!(
-            !gate.allows_io(),
-            "screen wake must not override an inactive session",
-        );
+        assert!(!io.allows_io());
 
         // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
         let session_active = unsafe { NSWorkspaceSessionDidBecomeActiveNotification };
         // SAFETY: `workspace` is live, matches the registration filter, and
         // notification delivery completes synchronously.
         unsafe { center.postNotificationName_object(session_active, Some(&workspace)) };
-        assert!(gate.allows_io());
-
-        // SAFETY: This is the same live target registered with `center` above.
-        unsafe { center.removeObserver(&target) };
-    }
-
-    #[test]
-    fn startup_stays_suspended_when_the_display_is_already_asleep() {
-        let _notifications = WORKSPACE_NOTIFICATIONS.lock().unwrap();
-        let (signal, gate) = device_io_channel();
-        let target = install_activity_observer(signal);
-        assert!(!gate.allows_io(), "startup must fail closed");
-
-        target.finish_startup(true);
-        assert!(
-            !gate.allows_io(),
-            "an initially sleeping display must retain the suspension",
-        );
-
-        let workspace = NSWorkspace::sharedWorkspace();
-        let center = workspace.notificationCenter();
-        // SAFETY: AppKit exports the name as an immutable process-lifetime constant.
-        let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
-        // SAFETY: `workspace` is live, matches the registration filter, and
-        // notification delivery completes synchronously.
-        unsafe { center.postNotificationName_object(screen_wake, Some(&workspace)) };
-        assert!(gate.allows_io());
+        assert!(io.allows_io());
 
         // SAFETY: This is the same live target registered with `center` above.
         unsafe { center.removeObserver(&target) };

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4,6 +4,49 @@ Durable "why we did it this way" records that are not obvious from the code.
 Add a dated entry when a non-obvious architectural or dependency decision is
 made or revisited.
 
+## 2026-09: The macOS device-I/O gate follows powerd, through an SPI, and fails open
+
+The gate that keeps HID access off while the Mac is dark (#656) was first built
+on `NSWorkspace` notifications (#1142): `WillSleep` / `ScreensDidSleep` /
+`SessionDidResignActive` closed it, `ScreensDidWake` / `SessionDidBecomeActive`
+reopened it. Those are edges, and macOS does not guarantee the wake edge —
+Apple DTS (developer forums thread 796109) confirms `ScreensDidWake` is skipped
+on some MacBooks for a lid-close/open cycle and that the system may not even
+run the app's run loop to deliver it. One dropped edge paused device I/O until
+the agent was restarted (#1281). The screen-sleep source was never a
+requirement in its own right: it stood in for "not a DarkWake", the state
+AppKit cannot name (`NSWorkspaceDidWakeNotification` fires for both).
+
+The gate now reads the thing it is actually about. `activity_macos` subscribes
+to powerd through `IOPMConnection`, which reports every Sleep / DarkWake /
+FullWake transition as the complete capability set of the new state and reads
+the current set on demand, so every input is a level: nothing pairs, a missed
+event is corrected by the next, no reconciler timer exists. The console level
+(fast user switching) comes from `CGSessionCopyCurrentDictionary`, with the
+AppKit session edges forwarded as hints and the level re-read on every power
+transition. A launch reads both levels before releasing its hold, so a
+watchdog relaunch during a sleep transition no longer guesses "awake" (#952).
+
+Three things decided the API:
+
+- **Only `IOPMConnection` names a DarkWake.** DTS states plainly that the
+  public API does not expose DarkWake at all: `IORegisterForSystemPower`
+  delivers `kIOMessageSystemHasPoweredOn` for a DarkWake as for a full wake,
+  so a gate on it cannot tell the one-second DarkWake blip #1281 was reported
+  with from the full wake that followed it. The undocumented `IOPMrootDomain`
+  "System Capabilities" registry key carries the same level but no events,
+  which is what forced #1283 into polling.
+- **It is an SPI, and that is accepted.** The functions are exported by IOKit
+  since 10.6 and prototyped only in Apple's open-source `IOKitUser`; the
+  shipping `pmset` is built on them. The hand-written `extern` is confined to
+  `activity_macos.rs` and inventoried in `.claude/rules/objc-ffi.md`. OpenLogi
+  is not App Store distributed.
+- **Losing the SPI fails open.** If the subscription cannot be made the gate
+  is told "permanent full wake" and follows the console alone, at error level.
+  That is pre-0.8.2 behaviour (hardware usable, #656 unprotected); failing
+  closed would leave an agent that can never touch hardware, which is the
+  outage #1281 describes.
+
 ## 2026-08: The agent stays one process; a crossing edge gets a wire, not an event layer
 
 The 2026-06 daemon split (#165) put the resident input machinery in


### PR DESCRIPTION
## Summary

The macOS device-I/O gate latched on `NSWorkspace` edges: sleep and screen-sleep notifications closed it, and only `ScreensDidWake` / `SessionDidBecomeActive` reopened it. macOS does not guarantee the wake edge on a lid-close/open cycle (Apple DTS, developer forums thread 796109, also says the system may not run the app's run loop to deliver it), so one dropped edge paused device I/O until the agent was restarted — 66 and 47 minutes in the two reports on #1281.

This replaces the edge latch with levels read from power management itself. `IOPMConnection` (the powerd client API `pmset` is built on) reports every Sleep / DarkWake / FullWake transition as the complete capability set of the new state, delivered to a dispatch queue this process owns, and reads the current set on demand. Nothing has to pair, a missed event is corrected by the next, and there is no reconciler timer. The gate opens only in a full wake while this login session owns the console (`CGSessionCopyCurrentDictionary`, with the AppKit session edges forwarded as hints and the level re-read on every power transition). A launch reads both levels before releasing its hold, so a watchdog relaunch during a sleep transition no longer guesses "awake" from `CGDisplayIsAsleep` (#952). Screen sleep is no longer a suspend source: in #1142 it only stood in for "not a DarkWake", which powerd now names directly, and pre-0.8.2 never gated on it.

The SPI is exported by IOKit since 10.6 but declared only in Apple's open-source `IOKitUser`, so the `extern` block is hand-written and inventoried in `.claude/rules/objc-ffi.md`; the reasoning is recorded in `docs/DECISIONS.md`. If the subscription cannot be made, the gate follows the console alone and logs an error rather than leaving an agent that can never touch hardware.

This re-homes the analysis behind #1283 (the dropped-edge diagnosis, the unsound startup snapshot, the DarkWake-vs-FullWake distinction) onto a level-based source instead of a 2 s reconciler with idle-time heuristics.

## Changes

- **openlogi-agent**
  - New `activity_macos`: `PowerState` classification of `IOPMCapabilityBits`, the `ActivityGate` transition authority (power × console × launch hold → `DeviceIoSignal`), the powerd subscription with acknowledged events and a `Drop` that drains the delivery queue, and the console level read.
  - `tray.rs`: the `ActivityTarget` bitmask is gone; a `SessionTarget` forwards only the fast-user-switch notifications. `run_app_loop` reads both levels after `finishLaunching` and releases the hold.
  - `Cargo.toml`: `objc2-core-foundation` (`CFBase`, `CFDictionary`, `CFNumber`, `CFString`) and `objc2-io-kit` (for `IOReturn`); `objc2-core-graphics` now needs only `CGSession`. Both crates were already in the workspace table; `Cargo.lock` gains the two edges and the gpui pins are unchanged.
- **openlogi-agent-core**: one comment in `watchers/gesture.rs` that described the old screen-sleep source.
- **docs / rules**: `docs/DECISIONS.md` entry for the API choice and the fail-open policy; `.claude/rules/objc-ffi.md` inventory rows for the new file and the SPI.

Log lines to look for: `device I/O paused power=DarkWake on_console=true starting=false` on a maintenance wake, `device I/O resumed power=FullWake on_console=true` on the wake that follows it, and `could not subscribe to power management` if the SPI is unavailable.

## Testing

macOS 26.4 (Darwin 25.4.0), aarch64, `cargo xtask ci`:

- PASS rustfmt, typos, publish closure, shell, clippy, MSRV (cargo check, macos), rustdoc (non-GUI crates), tests (macos, aarch64), cargo-deny, clippy (windows) proxy, wasm (portable crates)
- SKIP tests (linux) — not reproducible on this host. The diff is macOS-gated (`mod activity_macos` and `tray` are `cfg(target_os = "macos")`, the manifest change is in the macOS dependency table), so the Linux and Windows lanes see no source change.

Focused: `cargo test -p openlogi-agent` (34 passed; seven new tests cover the classification, the launch hold, a launch into a DarkWake, the DarkWake blip from #1281, sleep → DarkWake → FullWake, a fast-user-switched console, and an unprivileged powerd subscription against the host's IOKit) and `cargo clippy -p openlogi-agent --all-targets -- -D warnings`.

Not runtime-tested on hardware: no sleep cycle was run on the development machine. To verify: install, close the lid (or `Apple menu > Sleep` with a Bluetooth mouse, the #656 setup), wait for a maintenance wake, open the lid, and check `~/.local/state/openlogi/agent.<date>.log` for the `device I/O paused` / `device I/O resumed` pair with the `power=` field naming the transition. `openlogi list` should report the devices immediately after the wake, with no agent restart.

Fixes #1281
Refs #952
