### PR TITLE
fix(gui): stop linking SMAppServiceErrorDomain so macOS 13 and 14 can launch

### DIFF
--- a/.claude/rules/objc-ffi.md
+++ b/.claude/rules/objc-ffi.md
@@ -163,6 +163,26 @@ Rules:
 
 [TN3127]: https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements
 
+## Availability: the bindings do not know the deployment floor
+
+The bundles declare macOS 13.0 (`MACOSX_DEPLOYMENT_TARGET` in the release
+workflows, `LSMinimumSystemVersion` in the `Info.plist` templates under
+`openlogi-desktop/bundle/`), but `objc2` generates every symbol a header
+declares regardless of its `API_AVAILABLE(macos(N))`, and Rust has no
+`@available` check. A *function* newer than the floor merely crashes
+when called on an older macOS; an extern *static* — `SMAppServiceErrorDomain`
+is `macos(15.0)` while the rest of `SMAppService` is 13.0 — is bound by dyld
+at load, so the whole binary is refused before `main` (#1279; 0.8.2 and 0.8.3
+would not launch on 13 or 14). CI never runs on the floor release, so nothing
+catches it after the fact.
+
+Before using a generated symbol, read its `API_AVAILABLE` in the SDK header
+(`xcrun --show-sdk-path`). If it is newer than the floor: for a string
+constant, spell the documented value out (the error domain above is the
+literal `"SMAppServiceErrorDomain"` on every release since 13); for a
+function, gate the call on the OS version and resolve it with `dlsym` —
+never import it strongly.
+
 ## Raw `extern` blocks: only where no bindings exist
 
 Typed framework crates are the default; a hand-written `unsafe extern "C"` block
@@ -214,8 +234,8 @@ under a `SAFETY` comment. Where it currently lives on macOS:
 - `desktop/platform/os.rs` — reading AppKit's `NSAppearanceName` statics to set
   `NSApp.appearance`.
 - `desktop/platform/registration/macos.rs` — the `SMAppService` calls (all generated
-  bindings are `unsafe fn`s) and the `SMAppServiceErrorDomain` extern static.
-  Together with `os.rs`, the GUI's entire `unsafe` surface.
+  bindings are `unsafe fn`s). Together with `os.rs`, the GUI's entire `unsafe`
+  surface.
 - `camera/{capture,uvc/iokit}.rs` — the AVFoundation capture FFI and the IOKit
   USB plug-in; `uvc/iokit.rs` deliberately concentrates every `unsafe` of the
   macOS UVC backend so the descriptor parser above it is ordinary safe code.

--- a/.claude/rules/objc-ffi.md
+++ b/.claude/rules/objc-ffi.md
@@ -167,7 +167,7 @@ Rules:
 
 The bundles declare macOS 13.0 (`MACOSX_DEPLOYMENT_TARGET` in the release
 workflows, `LSMinimumSystemVersion` in the `Info.plist` templates under
-`openlogi-desktop/bundle/`), but `objc2` generates every symbol a header
+`crates/openlogi-desktop/bundle/`), but `objc2` generates every symbol a header
 declares regardless of its `API_AVAILABLE(macos(N))`, and Rust has no
 `@available` check. A *function* newer than the floor merely crashes
 when called on an older macOS; an extern *static* — `SMAppServiceErrorDomain`

--- a/crates/openlogi-desktop/src/platform/registration/macos.rs
+++ b/crates/openlogi-desktop/src/platform/registration/macos.rs
@@ -123,7 +123,22 @@ mod backend {
     /// from macOS 15, and a binary that imports that symbol is refused by
     /// dyld on 13 and 14 before `main` runs (#1279). Rust has no availability
     /// checking to catch that, so the constant must never be linked here.
-    pub(super) const ERROR_DOMAIN: &str = "SMAppServiceErrorDomain";
+    const ERROR_DOMAIN: &str = "SMAppServiceErrorDomain";
+
+    /// Recognize `SMAppService` errors without importing its macOS 15-only
+    /// error-domain symbol.
+    pub(super) trait SmAppServiceErrorExt {
+        /// Match both the framework's domain and `expected`: the same small
+        /// integers mean something else as POSIX or OSStatus codes.
+        fn is_sm_app_service_error(&self, expected: core::ffi::c_uint) -> bool;
+    }
+
+    impl SmAppServiceErrorExt for NSError {
+        fn is_sm_app_service_error(&self, expected: core::ffi::c_uint) -> bool {
+            self.domain().to_string() == ERROR_DOMAIN
+                && isize::try_from(expected).is_ok_and(|expected| self.code() == expected)
+        }
+    }
 
     /// The framework handle for the agent service's embedded plist.
     #[expect(unsafe_code, reason = "plain ObjC class method via objc2 bindings")]
@@ -176,20 +191,12 @@ mod backend {
         benign: core::ffi::c_uint,
     ) -> Result<(), String> {
         result.or_else(|error| {
-            let domain = error.domain().to_string();
-            if is_benign(&domain, error.code(), benign) {
+            if error.is_sm_app_service_error(benign) {
                 Ok(())
             } else {
                 Err(error.localizedDescription().to_string())
             }
         })
-    }
-
-    /// Whether an error in `domain` with `code` is the framework's `benign`
-    /// outcome — and only in the framework's domain: the same small integers
-    /// mean something else entirely as POSIX or OSStatus codes.
-    pub(super) fn is_benign(domain: &str, code: isize, benign: core::ffi::c_uint) -> bool {
-        domain == ERROR_DOMAIN && isize::try_from(benign).is_ok_and(|benign| code == benign)
     }
 }
 
@@ -243,26 +250,44 @@ mod tests {
     }
 
     #[test]
-    fn only_the_frameworks_own_already_converged_code_is_forgiven() {
+    fn only_the_frameworks_own_error_domain_and_code_match() {
+        use objc2_foundation::{NSError, NSString};
         use objc2_service_management::{kSMErrorAlreadyRegistered, kSMErrorJobNotFound};
 
-        let already = isize::try_from(kSMErrorAlreadyRegistered).unwrap();
-        assert!(backend::is_benign(
-            backend::ERROR_DOMAIN,
-            already,
-            kSMErrorAlreadyRegistered
-        ));
-        // The other operation's benign code is a real failure for this one.
-        assert!(!backend::is_benign(
-            backend::ERROR_DOMAIN,
-            already,
-            kSMErrorJobNotFound
-        ));
-        // ENOMEM is 12 too; a POSIX error must never read as "already registered".
-        assert!(!backend::is_benign(
-            "NSPOSIXErrorDomain",
-            already,
-            kSMErrorAlreadyRegistered
-        ));
+        use super::backend::SmAppServiceErrorExt;
+
+        for (domain, code, expected, matches) in [
+            (
+                "SMAppServiceErrorDomain",
+                12,
+                kSMErrorAlreadyRegistered,
+                true,
+            ),
+            ("SMAppServiceErrorDomain", 6, kSMErrorJobNotFound, true),
+            // The other operation's benign code is a real failure for this one.
+            ("SMAppServiceErrorDomain", 12, kSMErrorJobNotFound, false),
+            (
+                "SMAppServiceErrorDomain",
+                6,
+                kSMErrorAlreadyRegistered,
+                false,
+            ),
+            // ENOMEM is 12 too; POSIX/OSStatus errors must never match.
+            ("NSPOSIXErrorDomain", 12, kSMErrorAlreadyRegistered, false),
+            ("NSOSStatusErrorDomain", 6, kSMErrorJobNotFound, false),
+            (
+                "SMAppServiceErrorDomain",
+                -1,
+                kSMErrorAlreadyRegistered,
+                false,
+            ),
+        ] {
+            let error = NSError::new(code, &NSString::from_str(domain));
+            assert_eq!(
+                error.is_sm_app_service_error(expected),
+                matches,
+                "domain={domain}, code={code}, expected={expected}"
+            );
+        }
     }
 }

--- a/crates/openlogi-desktop/src/platform/registration/macos.rs
+++ b/crates/openlogi-desktop/src/platform/registration/macos.rs
@@ -116,6 +116,15 @@ mod backend {
 
     use super::{ServiceStatus, agent_service_label};
 
+    /// The domain `SMAppService` reports its errors in.
+    ///
+    /// Spelled out on purpose. The framework has used this string since
+    /// macOS 13 but exports it as the `SMAppServiceErrorDomain` symbol only
+    /// from macOS 15, and a binary that imports that symbol is refused by
+    /// dyld on 13 and 14 before `main` runs (#1279). Rust has no availability
+    /// checking to catch that, so the constant must never be linked here.
+    pub(super) const ERROR_DOMAIN: &str = "SMAppServiceErrorDomain";
+
     /// The framework handle for the agent service's embedded plist.
     #[expect(unsafe_code, reason = "plain ObjC class method via objc2 bindings")]
     fn service() -> Retained<SMAppService> {
@@ -162,25 +171,24 @@ mod backend {
     /// Treat exactly one framework error code — the "already in the desired
     /// state" one for the operation — as success. Matched by the framework's
     /// own constants, never bare ints.
-    #[expect(
-        unsafe_code,
-        reason = "reading a framework-provided immutable static NSString"
-    )]
     fn forgive(
         result: Result<(), Retained<NSError>>,
         benign: core::ffi::c_uint,
     ) -> Result<(), String> {
         result.or_else(|error| {
-            // SAFETY: the extern static is an immutable framework-owned
-            // NSString.
-            let domain_matches =
-                &*error.domain() == unsafe { objc2_service_management::SMAppServiceErrorDomain };
-            if domain_matches && isize::try_from(benign).is_ok_and(|code| error.code() == code) {
+            if is_benign(&error.domain().to_string(), error.code(), benign) {
                 Ok(())
             } else {
                 Err(error.localizedDescription().to_string())
             }
         })
+    }
+
+    /// Whether an error in `domain` with `code` is the framework's `benign`
+    /// outcome — and only in the framework's domain: the same small integers
+    /// mean something else entirely as POSIX or OSStatus codes.
+    pub(super) fn is_benign(domain: &str, code: isize, benign: core::ffi::c_uint) -> bool {
+        domain == ERROR_DOMAIN && isize::try_from(benign).is_ok_and(|benign| code == benign)
     }
 }
 
@@ -231,5 +239,29 @@ mod tests {
         // user's Login Items choice outranks both.
         assert_eq!(ensure_action(ServiceStatus::RequiresApproval, false), None);
         assert_eq!(ensure_action(ServiceStatus::RequiresApproval, true), None);
+    }
+
+    #[test]
+    fn only_the_frameworks_own_already_converged_code_is_forgiven() {
+        use objc2_service_management::{kSMErrorAlreadyRegistered, kSMErrorJobNotFound};
+
+        let already = isize::try_from(kSMErrorAlreadyRegistered).unwrap();
+        assert!(backend::is_benign(
+            backend::ERROR_DOMAIN,
+            already,
+            kSMErrorAlreadyRegistered
+        ));
+        // The other operation's benign code is a real failure for this one.
+        assert!(!backend::is_benign(
+            backend::ERROR_DOMAIN,
+            already,
+            kSMErrorJobNotFound
+        ));
+        // ENOMEM is 12 too; a POSIX error must never read as "already registered".
+        assert!(!backend::is_benign(
+            "NSPOSIXErrorDomain",
+            already,
+            kSMErrorAlreadyRegistered
+        ));
     }
 }

--- a/crates/openlogi-desktop/src/platform/registration/macos.rs
+++ b/crates/openlogi-desktop/src/platform/registration/macos.rs
@@ -176,7 +176,8 @@ mod backend {
         benign: core::ffi::c_uint,
     ) -> Result<(), String> {
         result.or_else(|error| {
-            if is_benign(&error.domain().to_string(), error.code(), benign) {
+            let domain = error.domain().to_string();
+            if is_benign(&domain, error.code(), benign) {
                 Ok(())
             } else {
                 Err(error.localizedDescription().to_string())


### PR DESCRIPTION
## Summary

0.8.2 and 0.8.3 do not launch on macOS 13 or 14: dyld refuses `openlogi-desktop` with `Symbol not found: _SMAppServiceErrorDomain`. The registration backend compared an `SMAppService` error's domain against the framework's `SMAppServiceErrorDomain` extern static, which the SDK marks `API_AVAILABLE(macos(15.0))` while every other `SMAppService` API is 13.0. `objc2-service-management` emits it as a strong data import with no availability guard, and Rust has no `@available` check, so the whole binary is bound — and rejected — before `main`. Only the GUI links ServiceManagement; the agent, overlay, and CLI were never affected. An audit of every framework import in the 0.8.3 bundle against the SDK's availability annotations found no other symbol above the 13.0 floor.

The domain string itself has been `"SMAppServiceErrorDomain"` on every release since Ventura (Apple's own forum reports from December 2022 print it), so the comparison now uses the literal and the symbol is no longer imported. `.claude/rules/objc-ffi.md` records the trap so it is checked before the next generated symbol is used.

## Changes

- **openlogi-desktop**: `platform/registration/macos.rs` — `forgive` compares the error domain against a documented literal through a small `is_benign` predicate; the `unsafe` extern-static read is gone. One test pins that only the framework's own already-converged code, in the framework's own domain, is forgiven.
- **rules**: `.claude/rules/objc-ffi.md` — new "Availability" section; the `unsafe` inventory no longer lists the extern static.

## Testing

macOS 26.4 (Darwin 25.4.0), aarch64:

- `cargo fmt --all -- --check`
- `cargo clippy -p openlogi-desktop --all-targets -- -D warnings`
- `cargo test -p openlogi-desktop` — 202 passed
- `cargo xtask ci typos rustfmt` — PASS
- `nm -um` on the built desktop test binary: no import from ServiceManagement remains (the release 0.8.3 binary had exactly one, `_SMAppServiceErrorDomain`).

Affected-package tier: `openlogi-desktop` is a leaf, so that is the whole set. Not runtime-tested on macOS 13 or 14 (no such machine here): the check is that the 0.8.4 bundle launches on 13.x/14.x, and that `nm -um OpenLogi.app/Contents/MacOS/openlogi-desktop | grep SMAppServiceErrorDomain` prints nothing.

Fixes #1279
Fixes #1188
