### PR TITLE
test(agent): cover native and browser side-button profiles

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -320,35 +320,112 @@ mod tests {
     }
 
     #[test]
-    fn thumb_button_bound_to_a_browser_action_is_diverted() {
-        // BrowserBack used to be the default action for Back, so choosing it
-        // in the GUI matched the default and the button was never diverted.
-        let mut cfg = Config::default();
-        cfg.set_binding(
-            "2b023",
-            ButtonId::Back,
-            Binding::Single(Action::BrowserBack),
-        );
+    fn thumb_button_capture_distinguishes_native_and_browser_actions() {
+        for (button, native, browser) in [
+            (ButtonId::Back, Action::MouseBack, Action::BrowserBack),
+            (
+                ButtonId::Forward,
+                Action::MouseForward,
+                Action::BrowserForward,
+            ),
+        ] {
+            for (stored, expected_action, diverted) in [
+                (None, native.clone(), false),
+                (Some(native.clone()), native, false),
+                (Some(browser.clone()), browser, true),
+            ] {
+                let mut cfg = Config::default();
+                if let Some(action) = stored {
+                    cfg.set_binding("2b023", button, Binding::Single(action));
+                }
 
-        let plan = plan_for_device(&cfg, "2b023", route(), None, 0, true);
-        assert!(
-            plan.target
-                .spec
-                .divert_buttons
-                .iter()
-                .any(|&(_, button)| button == ButtonId::Back),
-            "a thumb button bound to a browser action must be diverted: {:?}",
-            plan.target.spec.divert_buttons
-        );
-        assert!(
-            !plan
-                .target
-                .spec
-                .divert_buttons
-                .iter()
-                .any(|&(_, button)| button == ButtonId::Forward),
-            "the untouched forward button must keep its native button 5"
-        );
+                let plan = plan_for_device(&cfg, "2b023", route(), None, 0, true);
+                assert_eq!(
+                    plan.dispatch.bindings.get(&button),
+                    Some(&Binding::Single(expected_action)),
+                    "{button:?} must resolve unset bindings to native clicks"
+                );
+                // Several model-specific CIDs can map to the same side button.
+                for side in [ButtonId::Back, ButtonId::Forward] {
+                    assert_eq!(
+                        plan.target
+                            .spec
+                            .divert_buttons
+                            .iter()
+                            .any(|&(_, captured)| captured == side),
+                        diverted && side == button,
+                        "only an explicitly browser-bound {button:?} should be diverted"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn thumb_button_capture_follows_per_app_overrides_and_inheritance() {
+        for (cid, button, native, browser) in [
+            (
+                0x0053,
+                ButtonId::Back,
+                Action::MouseBack,
+                Action::BrowserBack,
+            ),
+            (
+                0x0056,
+                ButtonId::Forward,
+                Action::MouseForward,
+                Action::BrowserForward,
+            ),
+        ] {
+            for (global, overridden, global_diverted) in [
+                (native.clone(), browser.clone(), false),
+                (browser, native, true),
+            ] {
+                let mut cfg = Config::default();
+                cfg.set_binding("2b023", button, Binding::Single(global.clone()));
+                cfg.set_per_app_binding(
+                    "2b023",
+                    "com.apple.Safari",
+                    button,
+                    Some(overridden.clone()),
+                );
+
+                for (app, expected_action, diverted) in [
+                    (None, &global, global_diverted),
+                    (Some("com.apple.Safari"), &overridden, !global_diverted),
+                    (Some("com.example.Other"), &global, global_diverted),
+                ] {
+                    let plan = plan_for_device(&cfg, "2b023", route(), app, 0, true);
+                    assert_eq!(
+                        plan.dispatch.bindings.get(&button),
+                        Some(&Binding::Single(expected_action.clone())),
+                        "{button:?} dispatch must resolve the profile for {app:?}"
+                    );
+                    assert_eq!(
+                        plan.target.spec.divert_buttons.contains(&(cid, button)),
+                        diverted,
+                        "{button:?} capture must follow its effective binding for {app:?}"
+                    );
+                }
+
+                cfg.set_per_app_binding("2b023", "com.apple.Safari", button, None);
+                let inherited =
+                    plan_for_device(&cfg, "2b023", route(), Some("com.apple.Safari"), 0, true);
+                assert_eq!(
+                    inherited.dispatch.bindings.get(&button),
+                    Some(&Binding::Single(global))
+                );
+                assert_eq!(
+                    inherited
+                        .target
+                        .spec
+                        .divert_buttons
+                        .contains(&(cid, button)),
+                    global_diverted,
+                    "clearing {button:?}'s app override must restore global capture"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -231,6 +231,18 @@ mod tests {
         )
     }
 
+    /// Whether `plan` diverts `button` at all. The plan filters the divert
+    /// list per button, so every CID a button maps to is in or out together;
+    /// which CIDs those are is the device layer's table, not this crate's
+    /// concern.
+    fn diverts(plan: &DeviceCapturePlan, button: ButtonId) -> bool {
+        plan.target
+            .spec
+            .divert_buttons
+            .iter()
+            .any(|&(_, diverted)| diverted == button)
+    }
+
     #[test]
     fn both_hidpp_sources_gesture_when_both_are_in_gesture_mode() {
         // On MX Master 4 the dedicated button and the haptic panel can gesture
@@ -345,14 +357,9 @@ mod tests {
                     Some(&Binding::Single(expected_action)),
                     "{button:?} must resolve unset bindings to native clicks"
                 );
-                // Several model-specific CIDs can map to the same side button.
                 for side in [ButtonId::Back, ButtonId::Forward] {
                     assert_eq!(
-                        plan.target
-                            .spec
-                            .divert_buttons
-                            .iter()
-                            .any(|&(_, captured)| captured == side),
+                        diverts(&plan, side),
                         diverted && side == button,
                         "only an explicitly browser-bound {button:?} should be diverted"
                     );
@@ -363,15 +370,9 @@ mod tests {
 
     #[test]
     fn thumb_button_capture_follows_per_app_overrides_and_inheritance() {
-        for (cid, button, native, browser) in [
+        for (button, native, browser) in [
+            (ButtonId::Back, Action::MouseBack, Action::BrowserBack),
             (
-                0x0053,
-                ButtonId::Back,
-                Action::MouseBack,
-                Action::BrowserBack,
-            ),
-            (
-                0x0056,
                 ButtonId::Forward,
                 Action::MouseForward,
                 Action::BrowserForward,
@@ -402,7 +403,7 @@ mod tests {
                         "{button:?} dispatch must resolve the profile for {app:?}"
                     );
                     assert_eq!(
-                        plan.target.spec.divert_buttons.contains(&(cid, button)),
+                        diverts(&plan, button),
                         diverted,
                         "{button:?} capture must follow its effective binding for {app:?}"
                     );
@@ -416,11 +417,7 @@ mod tests {
                     Some(&Binding::Single(global))
                 );
                 assert_eq!(
-                    inherited
-                        .target
-                        .spec
-                        .divert_buttons
-                        .contains(&(cid, button)),
+                    diverts(&inherited, button),
                     global_diverted,
                     "clearing {button:?}'s app override must restore global capture"
                 );

--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -112,12 +112,10 @@ impl ActionExecutor {
                 );
                 return;
             }
-            // BrowserBack/BrowserForward fall through to the keyboard shortcut
-            // (Cmd+[ / Cmd+]) here — for Chrome and other apps that respond to
-            // it, and as the HID++ gesture watcher's own fallback when its
-            // AXPress attempt (Safari) fails. On devices where one physical
-            // press is visible through both capture paths, debounce the shared
-            // action so the browser navigates only once.
+            // Browser navigation uses platform input synthesis, not a native
+            // mouse click. If one physical press is visible through both
+            // capture paths, debounce the shared action so the browser
+            // navigates only once.
             Action::BrowserBack | Action::BrowserForward => {
                 if browser_nav_debounce_ok(action) {
                     openlogi_inject::execute(action);

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -48,9 +48,9 @@ pub fn default_binding(button: ButtonId) -> Action {
             reason = "see the left tilt above — same control pair, mirrored direction"
         )]
         ButtonId::WheelTiltRight => Action::HorizontalScrollRight,
-        // Seeding this as BrowserBack made it unreachable: picking BrowserBack
-        // in the GUI matched the default, so capture_plan never diverted the
-        // button and the action never fired.
+        // Preserve native side-button events unless explicitly rebound.
+        // BrowserBack/BrowserForward are dispatched navigation actions: using
+        // them as seeds would make the capture plan skip their HID++ diversion.
         ButtonId::Back => Action::MouseBack,
         ButtonId::Forward => Action::MouseForward,
         ButtonId::DpiToggle => Action::CycleDpiPresets,

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -97,10 +97,8 @@ fn combo(shortcut: Shortcut) -> KeyCombo {
         Shortcut::SelectAll => "Cmd+A",
         Shortcut::Find => "Cmd+F",
         Shortcut::Save => "Cmd+S",
-        // Cmd+[ / Cmd+] for Chrome and other apps. Safari is handled
-        // upstream via ax_navigate_browser() with the PID captured at press
-        // time — by the time execute() is called the AX path has already
-        // run, so this is the fallback for non-Safari browsers only.
+        // Browser navigation uses keyboard shortcuts here, including for
+        // Safari. The AX helper is not called by this dispatch path.
         Shortcut::BrowserBack => "Cmd+[",
         Shortcut::BrowserForward => "Cmd+]",
         Shortcut::NewTab => "Cmd+T",


### PR DESCRIPTION
## Summary

Follow up on #1225 with regression coverage for both Back and Forward, native defaults, and per-app capture decisions. No runtime behavior, defaults, configuration schema, or IPC wire types change.

The native defaults introduced by #1225 preserve mouse-button events; they do not enable Safari navigation automatically. Explicit `BrowserBack` / `BrowserForward` bindings request dispatched navigation instead. Existing explicit browser bindings remain intact.

## Changes

- `openlogi-agent-core`: cover both side buttons with unset, explicitly native, and explicitly browser-navigation bindings; assert the other side stays native.
- `openlogi-agent-core`: cover native-to-browser and browser-to-native app overrides, another foreground app, and inheritance after clearing an override. Check both the capture target and the resolved dispatch action.
- `openlogi-core`: explain why native defaults must differ from dispatched browser actions without claiming the OS hook could never handle the old defaults.
- `openlogi-agent-core` / `openlogi-inject`: remove stale comments claiming Safari already passes through the AX navigation helper. The current dispatch path uses platform input synthesis; Safari AX targeting and focus timing remain separate work in #1082.

## Testing

All commands ran on Linux. The full gate used `RUSTFLAGS="-D warnings"`.

```sh
cargo test -p openlogi-agent-core thumb_button_capture --locked
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --workspace --locked
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent --locked
cargo xtask ci wasm
```

- Full workspace tests: 1,426 passed, 0 failed, 2 existing ignored doctests.
- Mutation check: temporarily restoring only Forward's old `BrowserForward` default made `cargo test -p openlogi-agent-core thumb_button_capture_distinguishes_native_and_browser_actions --locked` fail with `BrowserForward != MouseForward`. The mutation was removed before the full gate.
- macOS source changes are comments only and were manually checked against the base. macOS and Windows builds/runtime tests were not run locally; neither were the other CI jobs outside the commands listed above.
- Not runtime-tested on hardware. This PR tests capture-plan semantics, not successful navigation in Safari or other applications.

Hardware verification for the behavior established by #1225:

1. Check both Back and Forward with no explicit binding and with `MouseBack` / `MouseForward`: OpenLogi should leave their native events intact, without promising navigation in applications that do not support those events.
2. Bind each side to `BrowserBack` / `BrowserForward`, then check that the agent captures and dispatches the corresponding action once per press. Verify browser behavior separately in Safari and a Chromium-based browser.
3. Exercise per-app profiles in both directions: native globally with browser navigation in one app, then browser navigation globally with native actions in that app. Switch apps and clear the override to verify inheritance.

Related: #1082, #736, #1118, #23, #354. No additional issue closures are claimed by this follow-up.
