### PR TITLE
fix(i18n): track the locale catalogs as build inputs

### DIFF
--- a/crates/openlogi-agent/build.rs
+++ b/crates/openlogi-agent/build.rs
@@ -16,6 +16,12 @@ use std::path::PathBuf;
 use std::{env, fs};
 
 fn main() {
+    // `rust_i18n::i18n!` in `main.rs` reads `../openlogi-ui/locales` at macro
+    // expansion time, and Cargo does not track a proc macro's file reads. Without
+    // this, editing a catalog leaves the embedded translations stale until an
+    // unrelated change happens to recompile this crate.
+    println!("cargo:rerun-if-changed=../openlogi-ui/locales");
+
     if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
         return;
     }

--- a/crates/openlogi-desktop/build.rs
+++ b/crates/openlogi-desktop/build.rs
@@ -33,6 +33,12 @@ fn main() {
     println!("cargo:rerun-if-env-changed=OPENLOGI_UPDATE_MANIFEST_URL");
     println!("cargo:rerun-if-env-changed=OPENLOGI_THEMES_DIR");
 
+    // `rust_i18n::i18n!` in `main.rs` reads `../openlogi-ui/locales` at macro
+    // expansion time, and Cargo does not track a proc macro's file reads. Without
+    // this, editing a catalog leaves the embedded translations stale until an
+    // unrelated change happens to recompile this crate.
+    println!("cargo:rerun-if-changed=../openlogi-ui/locales");
+
     embed_windows_resources();
 
     let out = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));

--- a/crates/openlogi-overlay/build.rs
+++ b/crates/openlogi-overlay/build.rs
@@ -17,6 +17,12 @@ use std::path::PathBuf;
 use std::{env, fs};
 
 fn main() {
+    // `rust_i18n::i18n!` in `main.rs` reads `../openlogi-ui/locales` at macro
+    // expansion time, and Cargo does not track a proc macro's file reads. Without
+    // this, editing a catalog leaves the embedded translations stale until an
+    // unrelated change happens to recompile this crate.
+    println!("cargo:rerun-if-changed=../openlogi-ui/locales");
+
     if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
         return;
     }


### PR DESCRIPTION
## Summary

- `rust_i18n::i18n!("../openlogi-ui/locales", …)` reads the catalogs at macro-expansion time, and Cargo does not track a proc macro's file reads. No build script declared them as inputs, so editing a translation did not rebuild the binaries that embed it — the stale catalog stayed compiled in until something unrelated recompiled the crate.
- Worth noting the consequence for the i18n gate: `the_shared_catalog_is_wired_up` in the overlay and agent, which `.claude/rules/i18n.md` names as the check that a catalog is wired up, can pass against a stale catalog. So that gate is not currently load-bearing.

## Changes

- **`openlogi-desktop`, `openlogi-agent`, `openlogi-overlay`** — each `build.rs` now emits `cargo:rerun-if-changed=../openlogi-ui/locales`. In the agent and overlay the directive has to precede the non-Windows early return, or it is never emitted on the platforms that actually build those binaries.

## Testing

Before, on `b6634915`:

```console
$ cargo build -p openlogi-desktop          # warm the build
$ touch crates/openlogi-ui/locales/en.toml
$ cargo build -p openlogi-desktop
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.03s
```

No recompile, so the embedded catalog kept the old strings. After this change the same sequence gives:

```console
   Compiling openlogi-desktop v0.8.3 (/Users/mxie/dev/OpenLogi/crates/openlogi-desktop)
```

Verified the same way for `openlogi-overlay` and `openlogi-agent` — both of which need the pre-guard placement to work off Windows.

Found while building a locale change for #1116: `cargo xtask ci` was green and the bundle built, yet the GUI binary still contained the pre-edit string.

`cargo xtask ci` on macOS/aarch64: **9 passed, 0 failed**. Not run on this host and not claimed green — `shell` (needs shellcheck/shfmt), `tests (linux)` (Linux-only), `cargo-deny` (not installed; no dependency change here).
