### PR TITLE
perf(hid): keep a directly connected device's probe across reconnects

### DIFF
--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -871,6 +871,13 @@ impl Enumerator {
             .cloned()
             .collect();
         for key in missing {
+            // A key that names the device memoizes data that stays true while
+            // the device is away, and dropping it is what makes a device that
+            // steps out and back re-answer questions it has already answered.
+            // What it costs to keep is a few hundred bytes per device ever seen.
+            if key.names_the_device() {
+                continue;
+            }
             let misses = self.misses.entry(key.clone()).or_insert(0);
             *misses += 1;
             if *misses > CACHE_MISS_GRACE {

--- a/crates/openlogi-device/src/inventory/cache.rs
+++ b/crates/openlogi-device/src/inventory/cache.rs
@@ -31,11 +31,29 @@ pub(super) enum CacheKey {
     /// two receivers whose serials share a common prefix (e.g. "DA2699E1" and
     /// "DA2604F2" share "DA2").
     UnifyingSlot { receiver_uid: String, slot: u8 },
-    /// Direct (Bluetooth/USB): the OS-assigned HID node id (macOS registry-entry
-    /// id, Linux dev path, Windows interface path). Unique *per node*, so two
-    /// units of the same model never collide, and stable while connected so the
-    /// cache still hits across ticks.
+    /// Direct (Bluetooth/USB) with a serial the backend could read. For a
+    /// Bluetooth device that is its address, which survives both the device
+    /// leaving for another host and the machine rebooting.
+    DirectSerial(String),
+    /// Direct (Bluetooth/USB) with no readable serial: the OS-assigned HID node
+    /// id (macOS registry-entry id, Linux dev path, Windows interface path).
+    /// Unique *per node*, so two units of the same model never collide, but
+    /// only stable while connected.
     Direct(NodeId),
+}
+
+impl CacheKey {
+    /// Whether this key names the device itself rather than where it happened
+    /// to be attached.
+    ///
+    /// The distinction decides how long a memoized probe stays true. An
+    /// identity can never be handed to a different physical device, so what it
+    /// memoizes holds however long that device is away. A pairing slot or an
+    /// OS node id can belong to something else the moment this device leaves,
+    /// so what they memoize is only true while it is still there.
+    pub(super) fn names_the_device(&self) -> bool {
+        matches!(self, Self::Bolt { .. } | Self::DirectSerial(_))
+    }
 }
 
 /// Enumeration ticks a device may be missing before its cache entry is evicted.

--- a/crates/openlogi-device/src/inventory/persist.rs
+++ b/crates/openlogi-device/src/inventory/persist.rs
@@ -7,12 +7,13 @@
 //! fully probed once keeps its identity across restarts, even on transports
 //! where a fresh walk is slow or failing (see `BOLT_SLOT_PROBE`).
 //!
-//! Only Bolt identities are persisted, because only they are keyed on the
-//! device's *own* identity (the pairing-register unit id), which no re-pairing
-//! can silently reassign. A `CacheKey::UnifyingSlot` is `receiver + slot`: a
-//! different device paired into that slot while the agent is down would
-//! inherit the previous occupant's probe on warm start. A `CacheKey::Direct`
-//! is an OS-runtime node id with no cross-boot stability. Loaded entries
+//! Only identity keys are persisted: the Bolt pairing-register unit id, and a
+//! direct device's HID serial (its address, on Bluetooth). Neither can be
+//! silently reassigned to another device. A `CacheKey::UnifyingSlot` is
+//! `receiver + slot`: a different device paired into that slot while the agent
+//! is down would inherit the previous occupant's probe on warm start. A
+//! `CacheKey::Direct` is an OS-runtime node id with no cross-boot
+//! stability. Loaded entries
 //! restart the elapsed refresh window, so the regular self-healing pass
 //! re-walks them on schedule; until (and unless) that walk succeeds, the
 //! persisted data serves exactly like an in-memory cache hit.
@@ -35,7 +36,8 @@ use super::features::{BatteryProbe, ProbedFeatures};
 /// (the cache is a warm-start optimization, not data anyone must keep).
 /// v2 dropped the `UnifyingSlot` key (slot-keyed, so not re-pair-safe).
 /// v3 adds event-capable feature indexes discovered by the immutable walk.
-const SCHEMA_VERSION: u32 = 3;
+/// v4 adds serial-keyed direct devices, which no longer re-walk on reconnect.
+const SCHEMA_VERSION: u32 = 4;
 
 impl ProbeCacheError {
     /// Report why a store could not keep a snapshot.
@@ -90,14 +92,18 @@ struct PersistedEntry {
 }
 
 /// The persistable subset of [`CacheKey`] — Bolt only (see the module docs).
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 enum PersistedKey {
     Bolt { unit_id: [u8; 4] },
+    DirectSerial { serial: String },
 }
 
 fn persistable(key: &CacheKey) -> Option<PersistedKey> {
     match key {
         CacheKey::Bolt { unit_id } => Some(PersistedKey::Bolt { unit_id: *unit_id }),
+        CacheKey::DirectSerial(serial) => Some(PersistedKey::DirectSerial {
+            serial: serial.clone(),
+        }),
         CacheKey::UnifyingSlot { .. } | CacheKey::Direct(_) => None,
     }
 }
@@ -112,6 +118,7 @@ pub(super) fn is_persistable(key: &CacheKey) -> bool {
 fn runtime_key(key: PersistedKey) -> CacheKey {
     match key {
         PersistedKey::Bolt { unit_id } => CacheKey::Bolt { unit_id },
+        PersistedKey::DirectSerial { serial } => CacheKey::DirectSerial(serial),
     }
 }
 

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -483,6 +483,23 @@ pub(super) fn preferred_direct_codename(marketing_name: Option<&str>, os_name: &
 /// case it's neither a receiver nor a direct device we recognise) — healthy
 /// only if that rejection rests on a completed feature walk, so a device
 /// that merely failed to answer is settled as a failed probe instead.
+/// The cache key for a directly connected device.
+///
+/// A serial is preferred wherever the backend reports one, because the node id
+/// lasts only as long as the connection. A Bluetooth device that switches to
+/// another host and comes back arrives under a fresh node, and keying on that
+/// makes it re-walk its entire feature table for data that could not have
+/// changed while it was away.
+pub(super) fn direct_cache_key(info: &NodeInfo) -> CacheKey {
+    info.serial_number
+        .as_deref()
+        .filter(|serial| !serial.is_empty())
+        .map_or_else(
+            || CacheKey::Direct(info.id.clone()),
+            |serial| CacheKey::DirectSerial(serial.to_ascii_lowercase()),
+        )
+}
+
 async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &NodeInfo,
@@ -490,7 +507,7 @@ async fn probe_direct(
     now: Instant,
     subscriptions: Option<&EventSubscriptionHandle>,
 ) -> NodeProbe {
-    let id = CacheKey::Direct(info.id.clone());
+    let id = direct_cache_key(info);
     let cached = cache.get(&id);
     // A direct device is always "present" (its HID node is the candidate), so
     // treat it as online: reuse the cached probe while fresh, otherwise probe.

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -81,15 +81,53 @@ fn cache_dirty_tracks_only_persistable_keys() {
     );
 }
 
+fn direct_node(serial: Option<&str>) -> crate::backend::NodeInfo {
+    crate::backend::NodeInfo {
+        id: crate::backend::NodeId::from("/dev/hidraw3".to_string()),
+        vendor_id: 0x046d,
+        product_id: 0xb378,
+        usage_page: 0xff43,
+        usage_id: 0x0202,
+        name: "MX KEYS S".to_string(),
+        manufacturer: None,
+        serial_number: serial.map(str::to_string),
+    }
+}
+
 #[test]
-fn cache_entry_survives_grace_then_evicts() {
+fn a_direct_device_is_keyed_on_its_serial_when_the_backend_reports_one() {
+    // A Bluetooth device's serial is its address, which is the same after it
+    // has been away on another computer. The node it arrives under is not.
+    assert_eq!(
+        super::probe::direct_cache_key(&direct_node(Some("D9:D2:69:B2:4B:96"))),
+        CacheKey::DirectSerial("d9:d2:69:b2:4b:96".to_string()),
+    );
+}
+
+#[test]
+fn a_direct_device_without_a_serial_falls_back_to_its_node() {
+    // Weaker, but still better than enumeration order, and it is all there is.
+    assert!(matches!(
+        super::probe::direct_cache_key(&direct_node(None)),
+        CacheKey::Direct(_)
+    ));
+    assert!(matches!(
+        super::probe::direct_cache_key(&direct_node(Some(""))),
+        CacheKey::Direct(_)
+    ));
+}
+
+#[test]
+fn a_slot_keyed_entry_survives_the_grace_then_evicts() {
     let mut e = Enumerator::with_backend(ScriptedBackend::new(Vec::new()));
-    let key = CacheKey::Bolt {
-        unit_id: [1, 2, 3, 4],
+    // A slot can belong to a different device the moment this one leaves, so
+    // what it memoizes stops being true once the device is gone for good.
+    let key = CacheKey::UnifyingSlot {
+        receiver_uid: "DA2699E1".to_string(),
+        slot: 1,
     };
     e.cache.insert(key.clone(), cache_entry());
     let nobody = HashSet::new();
-    // Missing for the whole grace window: kept.
     for _ in 0..CACHE_MISS_GRACE {
         e.evict_unseen(&nobody);
         assert!(
@@ -97,12 +135,35 @@ fn cache_entry_survives_grace_then_evicts() {
             "evicted inside the grace window"
         );
     }
-    // One miss past the grace: evicted.
+
     e.evict_unseen(&nobody);
+
     assert!(
         !e.cache.contains_key(&key),
         "should evict past the grace window"
     );
+}
+
+#[test]
+fn an_identity_keyed_entry_is_kept_however_long_the_device_is_away() {
+    let mut e = Enumerator::with_backend(ScriptedBackend::new(Vec::new()));
+    let bolt = CacheKey::Bolt {
+        unit_id: [1, 2, 3, 4],
+    };
+    let direct = CacheKey::DirectSerial("d9:d2:69:b2:4b:96".to_string());
+    e.cache.insert(bolt.clone(), cache_entry());
+    e.cache.insert(direct.clone(), cache_entry());
+    let nobody = HashSet::new();
+
+    // Well past the grace: a keyboard on another computer, a mouse asleep.
+    for _ in 0..(CACHE_MISS_GRACE * 10) {
+        e.evict_unseen(&nobody);
+    }
+
+    // These keys name the device, so nothing else can claim what they memoize,
+    // and keeping it is what lets the device come back without re-answering.
+    assert!(e.cache.contains_key(&bolt));
+    assert!(e.cache.contains_key(&direct));
 }
 
 #[test]


### PR DESCRIPTION
A directly connected device re-walks its entire feature table when it comes back from another computer. On an MX Keys S over Bluetooth that costs about 2.5s, during which the device is enumerated but nothing that needs its feature table can use it yet.

Two things cause it, and both come down to keying a device on where it was attached rather than on what it is.

## The key

`CacheKey::Direct` is the OS node id, and a device that leaves and returns arrives under a fresh one, so every return is a cache miss.

The backend already reports a serial for these devices. On Bluetooth it is the address, which survives both the trip and a reboot:

```
vid=046d pid=b378 serial=Some("d9:d2:69:b2:4b:96")   MX Keys S
vid=046d pid=b042 serial=Some("d1:ec:e1:ac:91:43")   MX Master 4
```

`NodeInfo::identity` already prefers a serial over the node id for exactly this reason, so the cache key does the same now, falling back to the node id only where no serial can be read.

## The eviction

The entry was also dropped while the device was away, past the three-tick grace meant for transient receiver timeouts. A trip to another computer is far longer than that, so the key alone would not have helped.

`CacheKey::names_the_device` makes the existing distinction explicit. An identity key cannot be handed to a different physical device, so what it memoizes stays true however long that device is out, and those entries are kept. A pairing slot or an OS node id can belong to something else the moment the device leaves, so those still evict on the same grace.

This also makes memory agree with disk. Bolt entries were already persisted across restarts while the in-memory cache dropped them after three ticks, which is hard to justify in either direction.

## What this does not do

It does not remove the walk for every reconnect. `is_stale` is `now - probed_at >= REFRESH_INTERVAL`, and a retained entry keeps its original `probed_at`, so a device away for longer than the 30s refresh window still returns to a full walk. What this removes is the walk for a device that steps out and comes back inside that window, which is the common case for host switching, and it is the whole of the gain being claimed here.

Closing the rest means serving the memoized entry immediately and letting the self-heal walk run without blocking it. Immutable data is never wrong, and the refresh exists only to catch something like a firmware update reshuffling the table, so it has no business holding up a device that is already known. That is a change to *when* the refresh happens rather than to what is cached, so it is not folded in here.

Resetting `probed_at` when an entry survives an absence would be one line and is the wrong line: a device that hops every few seconds would then never self-heal at all, and those are exactly the devices this targets.

## Persistence

Persistence follows the same rule rather than naming Bolt alone, so a serial-keyed direct device survives a restart as well. Schema 4; older snapshots are discarded as they were before.

## Testing

- `cargo test`: 1127 pass across the touched crates; clippy and fmt clean
- The eviction test is now two, one per side of the rule: a slot-keyed entry still evicts past the grace, an identity-keyed one is kept however long the device is away
- New tests cover key selection, including the fallback when the backend reports no serial or an empty one

I found this while working on #1145, where the window between a keyboard reconnecting and being usable is long enough for a user to press a key inside it. That case is not the argument for this change, though: every directly connected device pays the same walk on every reconnect today.

I do not have macOS or Windows hardware to measure there. The change is platform-neutral and degrades to the current behaviour wherever a backend reports no serial, but the benefit depends on those backends reporting one.