### PR TITLE
fix(cli): replace the stale receiver note with a Linux udev hint

### DIFF
--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -133,8 +133,8 @@ fn print_empty_notes(status: Option<&AgentStatus>) {
                  permission: System Settings → Privacy & Security → Input Monitoring."
             );
             println!(
-                "  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548); other \
-                 receivers (Unifying) aren't surfaced yet."
+                "  - On Linux, HID++ access needs OpenLogi's udev rules (shipped by the \
+                 packages; for a source build see docs/INSTALL-linux.md)."
             );
         }
     }


### PR DESCRIPTION
## Summary

`openlogi list` still prints "hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548); other receivers (Unifying) aren't surfaced yet." when nothing is found. That is no longer true — Unifying, Nano and Lightspeed receivers are enumerated — and it is also what users paste into issues (e.g. #1305, #367). On Linux the usual cause of an empty list is missing hidraw access, so the note now points there.

## Changes

- `openlogi-cli`: replace the stale receiver note in `list.rs` with a Linux udev-rules hint pointing to `docs/INSTALL-linux.md`.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p openlogi-cli --all-targets -- -D warnings`
- `cargo test -p openlogi-cli -p openlogi` (94 passed)
- Hit on real hardware: without the udev rules, `openlogi list` on Arch Linux showed the old note while every HID++ open failed with `Permission denied`; after installing `70-openlogi.rules` the Unifying receiver and its MX Ergo enumerate.
