### PR TITLE
feat(core): seed Finder/Safari navigation profiles for pointing devices

### DIFF
--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -41,6 +41,7 @@ use crate::binding::{
     Action, ActionRingConfig, ActionRingIcon, ActionRingSlot, Binding, ButtonId, GestureDirection,
     RingAction, default_binding, default_binding_for, default_gesture_binding,
 };
+use crate::device::DeviceKind;
 use crate::device_order::PhysicalDeviceKey;
 use crate::hid::Dpi;
 #[cfg(feature = "fs")]
@@ -48,6 +49,13 @@ use settings::GestureOwner;
 /// The schema version the current build produces. Bumped whenever the
 /// persisted shape or enum vocabulary changes; readers inspect this value
 /// before consuming the rest of the file.
+///
+/// v8 seeds macOS per-app navigation profiles (Finder, Safari → ⌘[ / ⌘]) for
+/// pointing devices, once: neither app ever navigated on mouse buttons 4/5,
+/// so the Back/Forward defaults are silently dead there without the overlay
+/// (see `seed_navigation_profiles`). The version gate is what makes the
+/// seed one-shot — a v8 file whose profile was deleted or reshaped is the
+/// user's state, not a missing default.
 ///
 /// v7 aligns the thumb-wheel scroll defaults with its normalised physical
 /// direction. Pre-v7 explicit default pairs are migrated in device and
@@ -91,7 +99,46 @@ use settings::GestureOwner;
 /// next save; [`Config::load_from_path`] accepts supported versions `1` through
 /// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
 /// silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 7;
+pub const SCHEMA_VERSION: u32 = 8;
+
+/// macOS applications that never navigate on mouse buttons 4/5 but do honor
+/// their Go/History key equivalents — the pair Logi Options+ also ships
+/// per-app overrides for. Seeded by [`seed_navigation_profiles`].
+#[cfg(target_os = "macos")]
+const SEEDED_NAVIGATION_APPS: [&str; 2] = ["com.apple.finder", "com.apple.Safari"];
+
+/// Seed the built-in per-app navigation profiles for a pointing device.
+///
+/// Finder and Safari ignore the synthetic (and native) mouse button 4/5
+/// events the Back/Forward defaults produce, so without an overlay those
+/// buttons are silently dead there; `BrowserBack`/`BrowserForward` (⌘[ / ⌘])
+/// is what both apps actually honor. An app is seeded only when it has no
+/// per-app entry at all: a profile the user shaped — or deleted, via the
+/// callers' one-shot discipline — is never touched. Callers are the first
+/// identity record for a device ([`Config::set_device_identity`]) and the
+/// pre-v8 load migration; nothing re-runs on plain loads or refreshes.
+#[cfg(target_os = "macos")]
+fn seed_navigation_profiles(device: &mut DeviceConfig, kind: DeviceKind) {
+    if !matches!(kind, DeviceKind::Mouse | DeviceKind::Trackball) {
+        return;
+    }
+    for app in SEEDED_NAVIGATION_APPS {
+        device
+            .per_app_bindings
+            .entry(app.to_string())
+            .or_insert_with(|| {
+                BTreeMap::from([
+                    (ButtonId::Back, Action::BrowserBack),
+                    (ButtonId::Forward, Action::BrowserForward),
+                ])
+            });
+    }
+}
+
+/// Buttons 4/5 navigate natively in the stock file managers and browsers on
+/// Linux and Windows, so there is nothing to seed off macOS.
+#[cfg(not(target_os = "macos"))]
+fn seed_navigation_profiles(_device: &mut DeviceConfig, _kind: DeviceKind) {}
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -583,6 +630,20 @@ impl Config {
         }
     }
 
+    /// Seed the built-in navigation profiles for every device whose recorded
+    /// identity marks it a pointing device — the pre-v8 half of
+    /// [`seed_navigation_profiles`]'s one-shot discipline. Devices without a
+    /// recorded identity are skipped, not lost: their first online sighting
+    /// routes through [`Self::set_device_identity`], which seeds then.
+    #[cfg(feature = "fs")]
+    fn seed_recorded_navigation_profiles(&mut self) {
+        for device in self.devices.values_mut() {
+            if let Some(kind) = device.identity.as_ref().map(|identity| identity.kind) {
+                seed_navigation_profiles(device, kind);
+            }
+        }
+    }
+
     /// Resolve the effective binding map for `device_key`, overlaying the
     /// per-app entry for `bundle_id` (if any) on top of the global per-device
     /// `bindings`. A per-app override replaces the whole button with a
@@ -779,11 +840,18 @@ impl Config {
 
     /// Record (or refresh) the identity captured for `device_key` while it was
     /// online, creating the device entry if needed.
+    ///
+    /// The first record for an entry — the moment a device's kind becomes
+    /// known — also seeds the built-in per-app navigation profiles (see
+    /// `seed_navigation_profiles`). A refresh never re-seeds: the entry
+    /// already carries an identity, so a profile the user deleted stays
+    /// deleted.
     pub fn set_device_identity(&mut self, device_key: &str, identity: DeviceIdentity) {
-        self.devices
-            .entry(device_key.to_string())
-            .or_default()
-            .identity = Some(identity.without_unit_identifiers());
+        let device = self.devices.entry(device_key.to_string()).or_default();
+        if device.identity.is_none() {
+            seed_navigation_profiles(device, identity.kind);
+        }
+        device.identity = Some(identity.without_unit_identifiers());
     }
 
     /// Drop everything recorded for `device_key` — identity, custom name, and

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -278,6 +278,12 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
     if header.schema_version <= 6 {
         config.migrate_thumbwheel_native_direction();
     }
+    // Pre-v8 pointing devices never received the built-in Finder/Safari
+    // navigation profiles. The version gate keeps this one-shot: on a v8
+    // file a missing profile is the user's deletion, not a gap to refill.
+    if header.schema_version <= 7 {
+        config.seed_recorded_navigation_profiles();
+    }
     config.repair_duplicate_routes();
     config.schema_version = SCHEMA_VERSION;
     Ok((config, header.schema_version))

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -2260,3 +2260,217 @@ fn an_unknown_route_gets_the_device_value() {
         Some(Dpi::new(1600))
     );
 }
+
+#[cfg(target_os = "macos")]
+mod navigation_seed {
+    //! Finder/Safari never navigate on mouse buttons 4/5, so pointing devices
+    //! are seeded with per-app ⌘[ / ⌘] profiles — once, so a deleted or
+    //! customized profile is the user's to keep.
+
+    use super::*;
+    use crate::device::{Capabilities, DeviceKind};
+
+    fn identity(kind: DeviceKind) -> DeviceIdentity {
+        DeviceIdentity {
+            display_name: "Test Device".to_string(),
+            model_info: None,
+            codename: None,
+            kind,
+            capabilities: Capabilities::default(),
+            light_capabilities: None,
+            driver_id: None,
+            registry_model_id: None,
+        }
+    }
+
+    fn seeded_pair() -> std::collections::BTreeMap<ButtonId, Action> {
+        std::collections::BTreeMap::from([
+            (ButtonId::Back, Action::BrowserBack),
+            (ButtonId::Forward, Action::BrowserForward),
+        ])
+    }
+
+    #[test]
+    fn first_mouse_identity_seeds_finder_and_safari_profiles() {
+        let mut cfg = Config::default();
+        cfg.set_device_identity("serial:test", identity(DeviceKind::Mouse));
+
+        let device = &cfg.devices["serial:test"];
+        assert_eq!(
+            device.per_app_bindings.get("com.apple.finder"),
+            Some(&seeded_pair())
+        );
+        assert_eq!(
+            device.per_app_bindings.get("com.apple.Safari"),
+            Some(&seeded_pair())
+        );
+    }
+
+    #[test]
+    fn trackball_identity_is_seeded_too() {
+        let mut cfg = Config::default();
+        cfg.set_device_identity("serial:test", identity(DeviceKind::Trackball));
+        assert!(
+            cfg.devices["serial:test"]
+                .per_app_bindings
+                .contains_key("com.apple.finder")
+        );
+    }
+
+    #[test]
+    fn keyboard_identity_seeds_no_navigation_profiles() {
+        let mut cfg = Config::default();
+        cfg.set_device_identity("serial:test", identity(DeviceKind::Keyboard));
+        assert!(cfg.devices["serial:test"].per_app_bindings.is_empty());
+    }
+
+    #[test]
+    fn identity_refresh_does_not_reseed_a_removed_profile() {
+        let mut cfg = Config::default();
+        cfg.set_device_identity("serial:test", identity(DeviceKind::Mouse));
+        // The user deletes the Finder profile (removing every override prunes
+        // the app key, matching the GUI's remove-profile flow).
+        cfg.set_per_app_binding("serial:test", "com.apple.finder", ButtonId::Back, None);
+        cfg.set_per_app_binding("serial:test", "com.apple.finder", ButtonId::Forward, None);
+        assert!(
+            !cfg.devices["serial:test"]
+                .per_app_bindings
+                .contains_key("com.apple.finder"),
+            "precondition: the profile is gone"
+        );
+
+        // The next online sighting refreshes the identity.
+        cfg.set_device_identity("serial:test", identity(DeviceKind::Mouse));
+
+        assert!(
+            !cfg.devices["serial:test"]
+                .per_app_bindings
+                .contains_key("com.apple.finder"),
+            "an identity refresh must not resurrect a deleted profile"
+        );
+    }
+
+    #[test]
+    fn seed_keeps_a_preexisting_app_profile_verbatim() {
+        let mut cfg = Config::default();
+        cfg.set_per_app_binding(
+            "serial:test",
+            "com.apple.finder",
+            ButtonId::Back,
+            Some(Action::Undo),
+        );
+
+        cfg.set_device_identity("serial:test", identity(DeviceKind::Mouse));
+
+        let device = &cfg.devices["serial:test"];
+        assert_eq!(
+            device.per_app_bindings["com.apple.finder"],
+            std::collections::BTreeMap::from([(ButtonId::Back, Action::Undo)]),
+            "a profile the user already shaped is not touched"
+        );
+        assert_eq!(
+            device.per_app_bindings.get("com.apple.Safari"),
+            Some(&seeded_pair()),
+            "absent apps are still seeded"
+        );
+    }
+
+    const V7_MOUSE: &str = "\
+schema_version = 7
+
+[devices.\"serial:test\".identity]
+display_name = \"MX Master 3S\"
+kind = \"mouse\"
+
+[devices.\"serial:test\".identity.capabilities]
+buttons = true
+pointer = true
+lighting = false
+scroll_inversion = true
+hires_wheel = true
+thumbwheel = true
+haptic_feedback = false
+haptic_panel = false
+";
+
+    fn load(body: &str) -> Config {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, body).expect("write");
+        Config::load_from_path(&path).expect("load")
+    }
+
+    #[test]
+    fn pre_v8_mouse_config_gains_navigation_profiles_on_load() {
+        let cfg = load(V7_MOUSE);
+        let device = &cfg.devices["serial:test"];
+        assert_eq!(
+            device.per_app_bindings.get("com.apple.finder"),
+            Some(&seeded_pair())
+        );
+        assert_eq!(
+            device.per_app_bindings.get("com.apple.Safari"),
+            Some(&seeded_pair())
+        );
+        assert_eq!(cfg.schema_version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn pre_v8_migration_keeps_an_existing_finder_profile_verbatim() {
+        let body = format!(
+            "{V7_MOUSE}
+[devices.\"serial:test\".per_app_bindings.\"com.apple.finder\"]
+Back = {{ CustomShortcut = \"Cmd+[\" }}
+"
+        );
+        let cfg = load(&body);
+        let device = &cfg.devices["serial:test"];
+        let finder = &device.per_app_bindings["com.apple.finder"];
+        assert_eq!(finder.len(), 1, "the shaped profile is not extended");
+        assert!(
+            matches!(finder.get(&ButtonId::Back), Some(Action::CustomShortcut(_))),
+            "the user's action survives"
+        );
+        assert_eq!(
+            device.per_app_bindings.get("com.apple.Safari"),
+            Some(&seeded_pair()),
+            "apps without a profile are still seeded"
+        );
+    }
+
+    #[test]
+    fn pre_v8_migration_skips_identityless_and_keyboard_devices() {
+        let body = "\
+schema_version = 7
+
+[devices.\"serial:mystery\"]
+custom_name = \"No identity yet\"
+
+[devices.\"serial:kbd\".identity]
+display_name = \"MX Keys\"
+kind = \"keyboard\"
+
+[devices.\"serial:kbd\".identity.capabilities]
+buttons = false
+pointer = false
+lighting = false
+scroll_inversion = false
+hires_wheel = false
+thumbwheel = false
+haptic_feedback = false
+haptic_panel = false
+";
+        let cfg = load(body);
+        assert!(cfg.devices["serial:mystery"].per_app_bindings.is_empty());
+        assert!(cfg.devices["serial:kbd"].per_app_bindings.is_empty());
+    }
+
+    #[test]
+    fn a_v8_config_without_navigation_profiles_stays_unseeded() {
+        let cfg = load(&V7_MOUSE.replace("schema_version = 7", "schema_version = 8"));
+        assert!(
+            cfg.devices["serial:test"].per_app_bindings.is_empty(),
+            "the seed is a one-shot migration, not a load-time default"
+        );
+    }
+}

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -817,15 +817,34 @@ fn state_editing(app: &str) -> AppState {
     state
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn a_sighted_mouse_carries_the_seeded_navigation_profiles() {
+    // The runtime records the online mouse's identity from the inventory,
+    // which is the trigger that seeds the built-in Finder/Safari profiles.
+    let state = state_with_a_known_mouse();
+    let finder = state
+        .config
+        .per_app_overrides(KNOWN_MOUSE_KEY, "com.apple.finder")
+        .expect("the first sighting seeds Finder");
+    assert_eq!(finder.get(&ButtonId::Back), Some(&Action::BrowserBack));
+    assert_eq!(
+        finder.get(&ButtonId::Forward),
+        Some(&Action::BrowserForward)
+    );
+}
+
 #[test]
 fn a_binding_committed_in_a_per_app_profile_leaves_the_global_one_alone() {
-    let mut state = state_editing("com.apple.Safari");
+    // Not a seeded id: mouse devices ship Finder/Safari profiles by default,
+    // and this test needs a profile born from the commit alone.
+    let mut state = state_editing("com.example.Browser");
     state.commit_binding(ButtonId::Back, Action::Undo);
 
     assert_eq!(
         state
             .config
-            .per_app_overrides(KNOWN_MOUSE_KEY, "com.apple.Safari"),
+            .per_app_overrides(KNOWN_MOUSE_KEY, "com.example.Browser"),
         Some(&BTreeMap::from([(ButtonId::Back, Action::Undo)]))
     );
     assert!(
@@ -887,10 +906,11 @@ fn an_action_ring_icon_edit_targets_the_open_application_layout() {
 
 #[test]
 fn removing_an_action_ring_profile_leaves_button_overrides_untouched() {
+    // Not a seeded id — see above.
     let mut state = state_with_a_known_mouse();
-    state.set_editing_app(Some("com.apple.Safari".into()));
+    state.set_editing_app(Some("com.example.Browser".into()));
     state.commit_binding(ButtonId::Back, Action::Undo);
-    state.set_editing_action_ring_app(Some("com.apple.Safari".into()));
+    state.set_editing_action_ring_app(Some("com.example.Browser".into()));
     state.commit_action_ring_slot(ActionRingSlot::Top, Some(ring_action(Action::NewTab)));
 
     state.remove_editing_action_ring_profile();
@@ -900,21 +920,22 @@ fn removing_an_action_ring_profile_leaves_button_overrides_untouched() {
     assert_eq!(
         state
             .config
-            .per_app_overrides(KNOWN_MOUSE_KEY, "com.apple.Safari"),
+            .per_app_overrides(KNOWN_MOUSE_KEY, "com.example.Browser"),
         Some(&BTreeMap::from([(ButtonId::Back, Action::Undo)]))
     );
     assert_eq!(
         state.editing_app(),
-        Some("com.apple.Safari"),
+        Some("com.example.Browser"),
         "the Buttons editor keeps its independent scope"
     );
 }
 
 #[test]
 fn clearing_an_override_falls_back_to_the_global_binding() {
+    // Not a seeded id — see above.
     let mut state = state_with_a_known_mouse();
     state.commit_binding(ButtonId::Back, Action::Copy);
-    state.set_editing_app(Some("com.apple.Safari".into()));
+    state.set_editing_app(Some("com.example.Browser".into()));
     state.commit_binding(ButtonId::Back, Action::Undo);
     assert_eq!(
         state.button_bindings().get(&ButtonId::Back),
@@ -931,7 +952,7 @@ fn clearing_an_override_falls_back_to_the_global_binding() {
     assert!(
         state
             .config
-            .per_app_overrides(KNOWN_MOUSE_KEY, "com.apple.Safari")
+            .per_app_overrides(KNOWN_MOUSE_KEY, "com.example.Browser")
             .is_none(),
         "an emptied profile is pruned, not left behind"
     );
@@ -939,9 +960,10 @@ fn clearing_an_override_falls_back_to_the_global_binding() {
 
 #[test]
 fn clearing_a_thumbwheel_override_drops_both_directions() {
+    // Not a seeded id — see above.
     let mut state = state_with_a_known_mouse();
     state.commit_thumbwheel_preset(ThumbwheelPreset::Volume);
-    state.set_editing_app(Some("com.apple.Safari".into()));
+    state.set_editing_app(Some("com.example.Browser".into()));
     state.commit_thumbwheel_preset(ThumbwheelPreset::CycleDpi);
 
     state.clear_app_thumbwheel();
@@ -957,7 +979,7 @@ fn clearing_a_thumbwheel_override_drops_both_directions() {
     assert!(
         state
             .config
-            .per_app_overrides(KNOWN_MOUSE_KEY, "com.apple.Safari")
+            .per_app_overrides(KNOWN_MOUSE_KEY, "com.example.Browser")
             .is_none(),
         "both halves must be cleared so the empty profile is pruned"
     );
@@ -1069,11 +1091,12 @@ fn invalid_device_selection_preserves_the_valid_current_device() {
 
 #[test]
 fn the_active_profile_is_the_default_until_the_app_in_front_is_overridden() {
+    // Not a seeded id: Safari in front would resolve its built-in profile.
     let mut state = state_with_a_known_mouse();
-    let safari = app("com.apple.Safari", "Safari");
+    let editor = app("com.example.Editor", "Editor");
     state.set_foreground(ForegroundApps {
-        current: Some(safari.clone()),
-        recent: vec![safari],
+        current: Some(editor.clone()),
+        recent: vec![editor],
     });
 
     assert_eq!(
@@ -1085,12 +1108,12 @@ fn the_active_profile_is_the_default_until_the_app_in_front_is_overridden() {
     state.config.edit(|config| {
         config.set_per_app_binding(
             KNOWN_MOUSE_KEY,
-            "com.apple.Safari",
+            "com.example.Editor",
             ButtonId::Back,
             Some(Action::Undo),
         );
     });
-    assert_eq!(state.active_profile_name(), Some("Safari"));
+    assert_eq!(state.active_profile_name(), Some("Editor"));
 }
 
 #[test]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,5 +1,5 @@
 # OpenLogi configuration example. Copy only the sections you need.
-schema_version = 7
+schema_version = 8
 selected_device = "receiver:aabbccdd:slot:1"
 
 [app_settings]
@@ -48,6 +48,14 @@ Right = "NextDesktop"
 
 [devices."receiver:aabbccdd:slot:1".per_app_bindings."com.microsoft.VSCode"]
 Back = "Undo"
+
+# Seeded automatically on macOS for every pointing device: Finder and Safari
+# never navigate on mouse buttons 4/5, so Back/Forward are overlaid with the
+# apps' own Go/History shortcuts. Delete or edit freely - the seed never
+# returns once the device has been seen.
+[devices."receiver:aabbccdd:slot:1".per_app_bindings."com.apple.finder"]
+Back = "BrowserBack"
+Forward = "BrowserForward"
 
 [devices."receiver:aabbccdd:slot:1".per_app_bindings."exe:sharex.exe"]
 MiddleClick = { CustomShortcut = "F1" }


### PR DESCRIPTION
## Summary

Back/Forward work in Chrome but do nothing in Finder or Safari: neither app implements mouse-button-4/5 navigation, and every driver that makes them work there (Logi Options+ included) synthesizes the app's own Go/History shortcut instead. This PR seeds the same two per-app overrides — `com.apple.finder` / `com.apple.Safari` → `BrowserBack`/`BrowserForward` (⌘[ / ⌘]) — for every pointing device.

Because the seeded actions differ from the Back/Forward defaults, the app-scoped capture plan HID++-diverts the buttons while those apps are frontmost, so dispatch does not depend on the OS hook attributing Bluetooth-direct mice (#722). Builds on #1225.

## Changes

- `openlogi-core`: `seed_navigation_profiles`, applied exactly once per device (first identity record) and once per config (v7→v8 migration). An app key with any existing per-app entry is never touched, and a v8 file missing the profile is the user's deletion, not a gap to refill. macOS-only — the stock file managers and browsers on Linux/Windows navigate on buttons 4/5 natively. `SCHEMA_VERSION` 7 → 8; `docs/config.example.toml` updated.
- `openlogi-desktop`: five state tests moved off `com.apple.Safari` onto neutral bundle ids (Safari now legitimately ships a built-in profile), plus a new test pinning the inventory → identity → seed path.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` (`RUSTFLAGS=-D warnings`), `cargo test --workspace`, and the non-GUI rustdoc gate — green on macOS arm64.
- `cargo xtask ci`: rustfmt, clippy, MSRV, rustdoc, macOS tests, windows clippy proxy, typos, wasm — pass. Not run locally: tests (linux), cargo-deny (no dependency changes), shell (no shell changes).
- Cross-lints for the cfg-gated diff: clippy `--target aarch64-unknown-linux-musl` and `--target x86_64-pc-windows-gnu` — green.
- Not runtime-tested on hardware. To verify: build this branch, start from a fresh config (or delete the two seeded profiles), let the device be sighted once, then press Back/Forward in Finder and Safari — both navigate; Chrome keeps the native buttons 4/5. The hand-written equivalent (per-app ⌘[/⌘] overrides) is what #1263's commenters confirmed working on hardware.

Refs #1263, #354, #1118, #722

Fixes #582