### PR TITLE
fix(windows): suppress console flash from RunShellCommand

### DIFF
--- a/crates/openlogi-inject/Cargo.toml
+++ b/crates/openlogi-inject/Cargo.toml
@@ -42,4 +42,4 @@ objc2-core-graphics = { workspace = true, features = ["CGEvent"] }
 objc2-foundation = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys = { workspace = true, features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_System_Threading"] }

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -2,8 +2,10 @@
 #![expect(unsafe_code, reason = "SendInput is the Win32 API for synthetic input")]
 
 use std::mem::size_of;
+use std::os::windows::process::CommandExt;
 use std::sync::{LazyLock, Mutex};
 
+use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
     INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_KEYUP, MOUSEEVENTF_HWHEEL,
     MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP,
@@ -200,7 +202,13 @@ fn run_workflow(steps: &[WorkflowStep]) {
 }
 
 fn run_shell_command(cmd: &str) {
-    let _ = std::process::Command::new("cmd").args(["/C", cmd]).output();
+    // Without this flag `cmd.exe` allocates and briefly flashes a visible
+    // console window, since the agent itself is a console-less GUI/background
+    // process and the child would otherwise get one of its own.
+    let _ = std::process::Command::new("cmd")
+        .args(["/C", cmd])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output();
 }
 
 fn post_click(button: MouseButton) {


### PR DESCRIPTION
## Summary

`RunShellCommand` bindings on Windows briefly flash a visible `cmd.exe`
console window on every invocation, since the agent spawns `cmd /C <cmd>`
via `std::process::Command::new("cmd").args(["/C", cmd]).output()` with no
`CREATE_NO_WINDOW`. The window shows nothing useful either way — `.output()`
already captures and discards stdout/stderr, and `Command::output()` sets
stdin to null regardless of console visibility — so this is a pure visual
defect with no behavior change to the command itself.

## Changes

- `openlogi-inject` (Windows only): `run_shell_command` now passes
  `CREATE_NO_WINDOW` via `CommandExt::creation_flags`, so `cmd.exe` never
  allocates a console. Requires enabling the `Win32_System_Threading`
  windows-sys feature in `crates/openlogi-inject/Cargo.toml`.
- No public API, config schema, or wire-format changes. The touched function
  is private (`fn run_shell_command`, not `pub`).

## Testing

Because `Cargo.toml` changed (a new `windows-sys` feature), the affected-package
tier doesn't apply here per `AGENTS.md` — ran the full local gate instead.

```sh
export RUSTFLAGS="-D warnings"
cargo build --release -p openlogi-agent
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent
```

- **Clippy (full workspace, `-D warnings`)**: 0 errors — this machine's host OS
  is Windows, so this run *is* the `clippy (windows)` CI job natively, not a proxy.
- **Cross-platform check** (per `.claude/rules/cross-platform.md`, since this
  diff touches `crates/openlogi-inject/src/inject/windows.rs`):
  `cargo clippy --target aarch64-unknown-linux-musl -p openlogi-hook -p openlogi-inject -p openlogi-hid -p openlogi-hidpp -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-ipc -p openlogi-permissions --all-targets -- -D warnings`
  — 0 errors.
- **`cargo test --workspace`**: 1345 passed, 1 failed. The one failure
  (`xtask::commands::ci::jobs::tests::ci_yml_runs_what_this_runner_runs`) is
  pre-existing and unrelated — confirmed by running the same test against an
  unmodified `v0.8.3` checkout, where it fails identically. `xtask` and
  `.github/workflows/ci.yml` are untouched by this diff.
- **rustdoc** (`-D warnings`, CI's exact exclusion list): 0 errors.
- **`cargo fmt --check`**: clean.
- Affected-package set for context (not load-bearing here since the full
  tier applies regardless): `cargo tree --workspace --target all --invert
  openlogi-inject` → `openlogi-agent`, `openlogi-agent-core`,
  `openlogi-desktop`, `openlogi-hook`, `openlogi-inject`, `openlogi-overlay`.

**Hardware-verified**: reproduced and fixed on Windows 11, an MX Master 4 +
MX Keys S over a Logi Bolt receiver, OpenLogi built from the `v0.8.3` tag.
Confirmed no console window appears on `RunShellCommand` dispatch after this
change; the bound command's behavior (exit status still discarded, as
before) is otherwise unchanged.

Local host: Windows 11, rustc 1.98.1.
