### PR TITLE
fix(hidpp): tell another protocol's reports apart from malformed HID++

### DIFF
--- a/crates/openlogi-hid/src/recording/cassette.rs
+++ b/crates/openlogi-hid/src/recording/cassette.rs
@@ -378,7 +378,9 @@ impl<'a> CassetteBuilder<'a> {
 
     fn validate_unassociated(&mut self) {
         for evidence in &self.channel.unassociated {
-            self.reject(None, unassociated_rejection(&evidence.observation));
+            if let Some(reason) = unassociated_rejection(&evidence.observation) {
+                self.reject(None, reason);
+            }
         }
     }
 

--- a/crates/openlogi-hid/src/recording/cassette/sanitizer.rs
+++ b/crates/openlogi-hid/src/recording/cassette/sanitizer.rs
@@ -59,8 +59,12 @@ impl ProtocolSanitizer {
     }
 }
 
-pub(super) fn unassociated_rejection(observation: &ChannelObservation) -> CassetteRejectionReason {
-    match observation {
+/// The rejection an unassociated observation earns, or `None` when it is
+/// evidence about no HID++ exchange at all and the cassette may ignore it.
+pub(super) fn unassociated_rejection(
+    observation: &ChannelObservation,
+) -> Option<CassetteRejectionReason> {
+    Some(match observation {
         ChannelObservation::OutgoingReport { report, .. } => {
             if is_pairing_identity_traffic(report.as_bytes()) {
                 CassetteRejectionReason::PairingTraffic
@@ -78,11 +82,15 @@ pub(super) fn unassociated_rejection(observation: &ChannelObservation) -> Casset
         ChannelObservation::MalformedIncomingReport { .. } => {
             CassetteRejectionReason::MalformedIncomingReport
         }
+        // Another protocol's report on the same node (Logitech DJ next to
+        // HID++ on a Unifying receiver) never enters the cassette, so it
+        // cannot leak identity or break replay.
+        ChannelObservation::ForeignIncomingReport { .. } => return None,
         ChannelObservation::RequestOutcome { .. } => {
             CassetteRejectionReason::UnsupportedObservation
         }
         _ => CassetteRejectionReason::UnsupportedObservation,
-    }
+    })
 }
 
 fn map_protocol_error(error: &ProtocolIdentityError) -> CassetteRejectionReason {

--- a/crates/openlogi-hid/src/recording/cassette/tests.rs
+++ b/crates/openlogi-hid/src/recording/cassette/tests.rs
@@ -348,6 +348,27 @@ async fn rejects_malformed_unmatched_and_unproven_fire_and_forget_evidence() {
 }
 
 #[tokio::test]
+async fn ignores_foreign_protocol_reports_from_the_same_node() {
+    // Wire-captured Logitech DJ "device paired" notification from a Unifying
+    // receiver on Linux, which shares its node with HID++.
+    let evidence = record_unassociated(vec![vec![
+        0x20, 0x01, 0x41, 0x01, 0x6f, 0x40, 0x1e, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00,
+    ]])
+    .await;
+
+    let report = evidence.build_hid_cassette(metadata());
+
+    assert!(
+        !report
+            .rejections
+            .iter()
+            .any(|rejection| rejection.reason == CassetteRejectionReason::MalformedIncomingReport),
+        "a foreign DJ report must not reject the cassette: {:?}",
+        report.rejections
+    );
+}
+
+#[tokio::test]
 async fn rejects_every_unsuccessful_terminal_outcome() {
     let transaction = root_mapping(CAPTURE_SW_ID, 0x0003, 5);
     let mut channel = record_successes(vec![

--- a/crates/openlogi-hid/src/recording/cassette/tests.rs
+++ b/crates/openlogi-hid/src/recording/cassette/tests.rs
@@ -348,24 +348,40 @@ async fn rejects_malformed_unmatched_and_unproven_fire_and_forget_evidence() {
 }
 
 #[tokio::test]
-async fn ignores_foreign_protocol_reports_from_the_same_node() {
+async fn foreign_protocol_reports_from_the_same_node_add_no_rejection() {
     // Wire-captured Logitech DJ "device paired" notification from a Unifying
-    // receiver on Linux, which shares its node with HID++.
-    let evidence = record_unassociated(vec![vec![
+    // receiver on Linux, which shares its node with HID++. A recording that
+    // would commit without it must still commit with it — asserting the whole
+    // rejection set, not just the absence of one reason.
+    let dj_notification = vec![
+        0x20, 0x01, 0x41, 0x01, 0x6f, 0x40, 0x1e, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00,
+    ];
+    let request = short(0xff, 0x83, 0xfb, [0, 0, 0]);
+    let response = long(0xff, 0x83, 0xfb, BOLT_UNIQUE_ID);
+
+    let report = record_successes_with_foreign_reports(
+        vec![(request.clone(), response.clone())],
+        vec![dj_notification],
+    )
+    .await
+    .build_hid_cassette(metadata());
+
+    assert!(report.is_committable(), "{:?}", report.rejections);
+    assert_eq!(report.cassette.expect("cassette").exchanges.len(), 1);
+
+    // The same recording without the exchange is rejected as empty only —
+    // the foreign report itself contributes no rejection of its own.
+    let foreign_only = record_unassociated(vec![vec![
         0x20, 0x01, 0x41, 0x01, 0x6f, 0x40, 0x1e, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00,
     ]])
-    .await;
-
-    let report = evidence.build_hid_cassette(metadata());
-
-    assert!(
-        !report
-            .rejections
-            .iter()
-            .any(|rejection| rejection.reason == CassetteRejectionReason::MalformedIncomingReport),
-        "a foreign DJ report must not reject the cassette: {:?}",
-        report.rejections
-    );
+    .await
+    .build_hid_cassette(metadata());
+    let reasons: Vec<_> = foreign_only
+        .rejections
+        .iter()
+        .map(|rejection| rejection.reason.clone())
+        .collect();
+    assert_eq!(reasons, vec![CassetteRejectionReason::EmptyCassette]);
 }
 
 #[tokio::test]
@@ -572,6 +588,45 @@ async fn record_successes_with_support(
     wait_for_accepted(&recorder, 2 + transactions.len() * 3).await;
     drop(channel);
     wait_for_accepted(&recorder, 3 + transactions.len() * 3).await;
+    recorder.finish().unwrap().channels.remove(0)
+}
+
+async fn record_successes_with_foreign_reports(
+    transactions: Vec<(Vec<u8>, Vec<u8>)>,
+    foreign: Vec<Vec<u8>>,
+) -> RecordedChannel {
+    let foreign_count = foreign.len();
+    let recorder = NativeRecorder::new(256).unwrap();
+    let sink = recorder.sink();
+    let mut capture = sink.begin_channel(test_node()).unwrap();
+    let (raw, handle) = FakeRawHidChannel::new();
+    let channel = HidppChannel::from_raw_channel_with_observer(raw, capture.observer())
+        .await
+        .unwrap();
+    capture.complete(RecordedChannelOpenOutcome::Opened {
+        supports_short: true,
+        supports_long: true,
+    });
+    drop(capture);
+
+    for (index, (request, response)) in transactions.iter().enumerate() {
+        let request = HidppMessage::read_raw(request).expect("valid synthetic request");
+        let expected = HidppMessage::read_raw(response).expect("valid synthetic response");
+        let send = channel.send(request, move |candidate| *candidate == expected);
+        let respond = async {
+            handle.wait_for_writes(index + 1).await;
+            handle.send_raw(response.clone());
+        };
+        let (result, ()) = tokio::join!(send, respond);
+        assert_eq!(result.unwrap(), expected);
+    }
+    for report in foreign {
+        handle.send_raw(report);
+    }
+
+    wait_for_accepted(&recorder, 2 + transactions.len() * 3 + foreign_count).await;
+    drop(channel);
+    wait_for_closed(&recorder).await;
     recorder.finish().unwrap().channels.remove(0)
 }
 

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -28,6 +28,7 @@ pub(crate) mod tests;
 pub use error::ChannelError;
 pub use message::{
     HidppMessage, LONG_REPORT_ID, LONG_REPORT_LENGTH, SHORT_REPORT_ID, SHORT_REPORT_LENGTH,
+    is_hidpp_report_id,
 };
 pub use observation::{ChannelObservation, ChannelObserver, ObservedReport, RequestOutcome};
 pub use raw::RawHidChannel;
@@ -651,10 +652,20 @@ async fn read_loop(
         };
 
         let Some(msg) = HidppMessage::read_raw(&buf[..len]) else {
+            // Only a HID++ report ID can be malformed here: any other ID
+            // belongs to a protocol sharing this node — Logitech DJ on a
+            // Unifying receiver — and is foreign traffic, not broken HID++.
+            let foreign = buf[..len]
+                .first()
+                .is_some_and(|id| !is_hidpp_report_id(*id));
             emit_report(observer, &buf[..len], |report| {
-                ChannelObservation::MalformedIncomingReport { report }
+                if foreign {
+                    ChannelObservation::ForeignIncomingReport { report }
+                } else {
+                    ChannelObservation::MalformedIncomingReport { report }
+                }
             });
-            trace!(len, "report not HID++ — dropped");
+            trace!(len, foreign, "report not HID++ — dropped");
             continue;
         };
 

--- a/crates/openlogi-hidpp/src/channel/message.rs
+++ b/crates/openlogi-hidpp/src/channel/message.rs
@@ -13,6 +13,17 @@ pub const LONG_REPORT_ID: u8 = 0x11;
 /// The length of long HID++ message reports (including report ID).
 pub const LONG_REPORT_LENGTH: usize = 20;
 
+/// Whether `report_id` is one of the two HID++ report IDs.
+///
+/// A HID node can carry another protocol on the same interface — a Unifying
+/// receiver on Linux also emits Logitech DJ reports (`0x20`/`0x21`) — so an
+/// incoming report with any other ID is foreign traffic rather than a broken
+/// HID++ report.
+#[must_use]
+pub const fn is_hidpp_report_id(report_id: u8) -> bool {
+    matches!(report_id, SHORT_REPORT_ID | LONG_REPORT_ID)
+}
+
 /// Represents an unversioned HID++ message.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum HidppMessage {
@@ -98,5 +109,19 @@ impl HidppMessage {
             }
             long @ Self::Long(_) => long,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LONG_REPORT_ID, SHORT_REPORT_ID, is_hidpp_report_id};
+
+    #[test]
+    fn only_hidpp_report_ids_are_hidpp() {
+        assert!(is_hidpp_report_id(SHORT_REPORT_ID));
+        assert!(is_hidpp_report_id(LONG_REPORT_ID));
+        // Logitech DJ short/long reports share the node on Linux.
+        assert!(!is_hidpp_report_id(0x20));
+        assert!(!is_hidpp_report_id(0x21));
     }
 }

--- a/crates/openlogi-hidpp/src/channel/observation.rs
+++ b/crates/openlogi-hidpp/src/channel/observation.rs
@@ -112,8 +112,16 @@ pub enum ChannelObservation {
         /// The exact bytes returned by the raw transport.
         report: ObservedReport,
     },
-    /// Raw incoming bytes rejected by HID++ report parsing.
+    /// Raw incoming bytes carrying a HID++ report ID that failed HID++ report
+    /// parsing.
     MalformedIncomingReport {
+        /// The exact bytes returned by the raw transport.
+        report: ObservedReport,
+    },
+    /// An incoming report belonging to another protocol sharing this node —
+    /// Logitech DJ (`0x20`/`0x21`) on a Unifying receiver, for instance. It
+    /// says nothing about the HID++ exchange and the channel drops it.
+    ForeignIncomingReport {
         /// The exact bytes returned by the raw transport.
         report: ObservedReport,
     },


### PR DESCRIPTION
## Summary

Fixes #1349: `openlogi fixture contribute` step 2 can never succeed for a Unifying receiver on Linux, because the receiver's node also carries Logitech DJ reports (`0x20`/`0x21`) and every one of them was classified as a malformed HID++ report, which rejects the whole cassette.

The channel conflated two different facts: a report carrying a HID++ report ID whose framing is invalid, and a report belonging to another protocol that shares the node. Only the first is malformed HID++. The channel already drops both, so replay never needed the foreign ones.

## Changes

- `openlogi-hidpp`: add `is_hidpp_report_id`, and a `ChannelObservation::ForeignIncomingReport` variant. The read loop now reports a non-HID++ report ID as foreign traffic and keeps `MalformedIncomingReport` for HID++ IDs that fail parsing. A zero-length read stays malformed.
- `openlogi-hid`: `unassociated_rejection` returns `Option<CassetteRejectionReason>` and yields `None` for foreign reports; the cassette builder skips those. Foreign reports never entered the cassette itself, so this changes no privacy or replay guarantee.

## Testing

- `cargo test -p openlogi-hidpp` / `cargo test -p openlogi-hid` — 212 and 40 passed. Full tier on Linux x86_64 as well: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude openlogi-desktop --no-fail-fast` (1404 passed), and the non-GUI rustdoc gate — all green. macOS/Windows cross-lints not run.
- `cargo clippy -p openlogi-hidpp -p openlogi-hid --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- New coverage: `is_hidpp_report_id` rejects the DJ report IDs; a wire-captured DJ "device paired" notification no longer rejects a cassette, while the existing malformed-HID++ rejection test still passes.
- Hardware: on an MX Ergo behind a Unifying receiver on Arch Linux (`hid-logitech-dj` bound), `openlogi fixture contribute` step 2 now records all eight cassettes and passes strict verification. The same command rejected every attempt (4/4) before this change.

Fixes #1349
