### PR TITLE
feat(fixture): add an MX Ergo Unifying fixture

### DIFF
--- a/fixtures/devices/mx-ergo-001/cases/backlight-state.json
+++ b/fixtures/devices/mx-ergo-001/cases/backlight-state.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "name": "backlight-state",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000198200",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/cases/dpi-info.json
+++ b/fixtures/devices/mx-ergo-001/cases/dpi-info.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "name": "dpi-info",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000220100",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000220200",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/cases/feature-table.json
+++ b/fixtures/devices/mx-ergo-001/cases/feature-table.json
@@ -1,0 +1,248 @@
+{
+  "schema_version": 1,
+  "name": "feature-table",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000000100",
+      "response": "1101000001000100000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010100000000",
+      "response": "1101010023000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110000000",
+      "response": "1101011000000001000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110010000",
+      "response": "1101011000010001000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110020000",
+      "response": "1101011000030002000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110030000",
+      "response": "1101011000050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110040000",
+      "response": "110101101d4b0000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110050000",
+      "response": "1101011000070000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110060000",
+      "response": "1101011000200000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110070000",
+      "response": "1101011000210001000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110080000",
+      "response": "1101011010000001000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110090000",
+      "response": "1101011013000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101100a0000",
+      "response": "110101101b040003000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101100b0000",
+      "response": "110101101c000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101100c0000",
+      "response": "1101011020060000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101100d0000",
+      "response": "1101011022050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101100e0000",
+      "response": "1101011021000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101100f0000",
+      "response": "1101011000c20000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110100000",
+      "response": "1101011018026000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110110000",
+      "response": "1101011018036000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110120000",
+      "response": "1101011018066000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110130000",
+      "response": "1101011018056000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110140000",
+      "response": "1101011018136000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110150000",
+      "response": "1101011018140001000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110160000",
+      "response": "1101011018150001000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110170000",
+      "response": "1101011018306000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110180000",
+      "response": "1101011018616000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110190000",
+      "response": "1101011018906000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101101a0000",
+      "response": "1101011018916000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101101b0000",
+      "response": "1101011018a16000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101101c0000",
+      "response": "110101101df36000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101101d0000",
+      "response": "110101101e004000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101101e0000",
+      "response": "110101101eb06000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100101101f0000",
+      "response": "1101011018b16000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110200000",
+      "response": "1101011018506000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110210000",
+      "response": "110101101f036000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110220000",
+      "response": "1101011018c06000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010110230000",
+      "response": "1101011021300000000000000000000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/cases/firmware-entities.json
+++ b/fixtures/devices/mx-ergo-001/cases/firmware-entities.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "name": "firmware-entities",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000000300",
+      "response": "1101000002000200000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010200000000",
+      "response": "11010200034f4c44010006b01d406f0000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010210000000",
+      "response": "1101021001424f5449000001000000cde885f300",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010210010000",
+      "response": "11010210004d504d0603002201406fcde885f300",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010210020000",
+      "response": "11010210050000000000005a0000000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/cases/raw-battery.json
+++ b/fixtures/devices/mx-ergo-001/cases/raw-battery.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "name": "raw-battery",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000100400",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000100000",
+      "response": "1101000008000100000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010800000000",
+      "response": "1101080032140000000000000000000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/cases/reprogrammable-controls.json
+++ b/fixtures/devices/mx-ergo-001/cases/reprogrammable-controls.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": 1,
+  "name": "reprogrammable-controls",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "100100001b0400",
+      "response": "110100000a000300000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010a00000000",
+      "response": "11010a0009000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1000000000000000000000000000000000",
+      "response": "11010a1000500038110001010000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1001000000000000000000000000000000",
+      "response": "11010a1000510039110001010000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1002000000000000000000000000000000",
+      "response": "11010a100052003a710002030100000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1003000000000000000000000000000000",
+      "response": "11010a100053003c710002030100000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1004000000000000000000000000000000",
+      "response": "11010a100056003e710002030100000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1005000000000000000000000000000000",
+      "response": "11010a1000ed00c4710002030100000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1006000000000000000000000000000000",
+      "response": "11010a10005b003f710002030100000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1007000000000000000000000000000000",
+      "response": "11010a10005d0040710002030100000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "11010a1008000000000000000000000000000000",
+      "response": "11010a1000d700b4a00003000300000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/cases/smartshift-status.json
+++ b/fixtures/devices/mx-ergo-001/cases/smartshift-status.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "name": "smartshift-status",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000211100",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000211100",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000211000",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/cases/wheel-mode.json
+++ b/fixtures/devices/mx-ergo-001/cases/wheel-mode.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "name": "wheel-mode",
+  "channel": "target",
+  "report_support": "short_and_long",
+  "exchanges": [
+    {
+      "request_match": "exact",
+      "request": "10ff83b5030000",
+      "response": "11ff83b5034f4c52011706070000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010010000000",
+      "response": "1101001004050000000000000000000000000000",
+      "required": true
+    },
+    {
+      "request_match": "hidpp20",
+      "request": "10010000212100",
+      "response": "1101000000000000000000000000000000000000",
+      "required": true
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/manifest.json
+++ b/fixtures/devices/mx-ergo-001/manifest.json
@@ -1,0 +1,212 @@
+{
+  "schema_version": 1,
+  "id": "mx-ergo-001",
+  "profile_id": "mx-ergo-001-profile",
+  "cases": [
+    {
+      "name": "feature-table",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    },
+    {
+      "name": "firmware-entities",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    },
+    {
+      "name": "reprogrammable-controls",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    },
+    {
+      "name": "raw-battery",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    },
+    {
+      "name": "dpi-info",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    },
+    {
+      "name": "smartshift-status",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    },
+    {
+      "name": "wheel-mode",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    },
+    {
+      "name": "backlight-state",
+      "channel": "target",
+      "relationship": {
+        "kind": "device",
+        "device": "device-1"
+      }
+    }
+  ],
+  "identity_ledger": [
+    {
+      "principal": {
+        "kind": "receiver",
+        "id": "receiver-1"
+      },
+      "representations": [
+        {
+          "kind": "unifying_receiver_serial",
+          "value": [
+            79,
+            76,
+            82,
+            1
+          ],
+          "profile_route": "4F4C5201",
+          "binary_occurrences": [
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "backlight-state",
+                "channel": "target"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "dpi-info",
+                "channel": "target"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "feature-table",
+                "channel": "target"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "firmware-entities",
+                "channel": "target"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "raw-battery",
+                "channel": "target"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "reprogrammable-controls",
+                "channel": "target"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "smartshift-status",
+                "channel": "target"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "wheel-mode",
+                "channel": "target"
+              },
+              "count": 1
+            }
+          ],
+          "route_occurrences": [
+            {
+              "location": {
+                "asset": "profile",
+                "field": "receiver_identity"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "profile",
+                "field": "receiver_route"
+              },
+              "count": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "principal": {
+        "kind": "device",
+        "id": "device-1",
+        "route": {
+          "kind": "unifying",
+          "receiver": "receiver-1",
+          "slot": 1
+        }
+      },
+      "representations": [
+        {
+          "kind": "device_unit_id",
+          "value": [
+            79,
+            76,
+            68,
+            1
+          ],
+          "occurrences": [
+            {
+              "location": {
+                "asset": "profile",
+                "field": "device_unit_id"
+              },
+              "count": 1
+            },
+            {
+              "location": {
+                "asset": "cassette",
+                "case": "firmware-entities",
+                "channel": "target"
+              },
+              "count": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/devices/mx-ergo-001/profile.json
+++ b/fixtures/devices/mx-ergo-001/profile.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": 1,
+  "id": "mx-ergo-001-profile",
+  "name": "MX Ergo",
+  "inventories": [
+    {
+      "receiver": {
+        "name": "Unifying Receiver",
+        "vendor_id": 1133,
+        "product_id": 50475,
+        "unique_id": "4F4C5201"
+      },
+      "paired": [
+        {
+          "slot": 1,
+          "codename": "MX Ergo Multi-Device Trackball ",
+          "wpid": 16495,
+          "kind": "trackball",
+          "online": true,
+          "battery": {
+            "percentage": 50,
+            "level": "good",
+            "status": "discharging"
+          },
+          "model_info": {
+            "entity_count": 3,
+            "serial_number": null,
+            "unit_id": [
+              79,
+              76,
+              68,
+              1
+            ],
+            "transports": {
+              "usb": false,
+              "equad": true,
+              "btle": true,
+              "bluetooth": false
+            },
+            "model_ids": [
+              45085,
+              16495,
+              0
+            ],
+            "extended_model_id": 0
+          },
+          "capabilities": {
+            "buttons": true,
+            "pointer": false,
+            "lighting": false,
+            "scroll_inversion": false,
+            "hires_wheel": false,
+            "thumbwheel": false,
+            "haptic_feedback": false,
+            "haptic_panel": false
+          }
+        }
+      ]
+    }
+  ],
+  "standalone": [],
+  "settings": [
+    {
+      "route": {
+        "Unifying": {
+          "receiver_uid": "4F4C5201",
+          "slot": 1
+        }
+      },
+      "dpi": {
+        "support": "unsupported"
+      },
+      "smartshift": {
+        "support": "unsupported"
+      },
+      "wheel": {
+        "support": "unsupported"
+      },
+      "backlight": {
+        "support": "unsupported"
+      },
+      "lighting": "unsupported",
+      "light": "unsupported"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the first captured fixture to the corpus: an original MX Ergo (wpid `406f`, firmware `MPM06.03_B0022`) on a Unifying receiver, produced with `openlogi fixture contribute`. It covers a device shape the synthetic corpus does not: a trackball that reports no `0x2201`/`0x2202` and no `0x2110`, so DPI and SmartShift are legitimately unsupported, while `0x1b04` exposes wheel tilt and a precision button.

## Changes

- `fixtures/devices/mx-ergo-001/`: manifest, semantic profile and eight read-only cassettes (feature table, firmware entities, reprogrammable controls, raw battery, DPI info, SmartShift status, wheel mode, backlight state).

## Testing

- `openlogi fixture contribute` completed both phases against the hardware; the wizard's own strict verification passed (schema, synthetic identity ledger, profile/case relationships, and replay of all eight cassettes).
- `cargo test -p openlogi-cli fixture` on this branch — 48 passed, including `fixture::verify`, which discovers and strictly verifies every directory in the corpus (this branch has no source changes, so the fixture is validated by unmodified verification code)
- Identity check by hand: the receiver serial, the device unit id and the receiver-register serial of this unit appear nowhere in the committed files; only the synthetic `4F4C5201` does.

## Note

Step 2 of the wizard cannot complete on a Unifying receiver on Linux today (#1349): the receiver's node also carries Logitech DJ reports and the recorder rejects the cassette. This capture was taken with the fix in #1373 applied. The fixture itself does not depend on that fix — it verifies against master as shown above — but it cannot be reproduced on this hardware until the fix lands.
