### PR TITLE
perf(hook): bypass the macOS input filter for unheld pointer motion

### DIFF
--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -579,8 +579,6 @@ const CALLBACK_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(20);
 const LIFECYCLE_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const FREEZE_HAZARD_EXIT_CODE: i32 = 78;
 
-/// Event types the HID tap observes. Pointer *Dragged variants are required
-/// because a held button makes the OS emit those instead of `MouseMoved`.
 /// The macOS backend: a `CGEventTap` serviced by a private run-loop thread.
 pub(crate) struct Backend;
 
@@ -776,6 +774,10 @@ impl HookBackend for Backend {
     }
 }
 
+/// Filter button/key edges and scrolling, and observe held-button motion for
+/// gestures. Unheld `MouseMoved` events must bypass this synchronous HID tap:
+/// there is no gesture hold to update, and even passing them through makes
+/// cursor delivery wait for the agent's run-loop thread.
 fn hooked_event_types() -> Vec<CGEventType> {
     vec![
         CGEventType::LeftMouseDown,
@@ -785,7 +787,6 @@ fn hooked_event_types() -> Vec<CGEventType> {
         CGEventType::OtherMouseDown,
         CGEventType::OtherMouseUp,
         CGEventType::ScrollWheel,
-        CGEventType::MouseMoved,
         CGEventType::LeftMouseDragged,
         CGEventType::RightMouseDragged,
         CGEventType::OtherMouseDragged,
@@ -1194,9 +1195,52 @@ fn process_name(pid: i32) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use core_graphics::event::CGMouseButton;
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+    use core_graphics::geometry::CGPoint;
 
     use super::*;
+
+    #[test]
+    fn tap_observes_gesture_drags_without_filtering_unheld_motion() {
+        let events = hooked_event_types();
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, CGEventType::MouseMoved)),
+            "ordinary cursor motion must not wait for the filtering tap"
+        );
+
+        let source = CGEventSource::new(CGEventSourceStateID::Private)
+            .expect("CGEventSourceCreate must succeed");
+        for event_type in [
+            CGEventType::LeftMouseDragged,
+            CGEventType::RightMouseDragged,
+            CGEventType::OtherMouseDragged,
+        ] {
+            assert!(
+                events
+                    .iter()
+                    .any(|event| *event as u32 == event_type as u32)
+            );
+            let event = CGEvent::new_mouse_event(
+                source.clone(),
+                event_type,
+                CGPoint::new(0.0, 0.0),
+                CGMouseButton::Center,
+            )
+            .expect("CGEventCreateMouseEvent must succeed");
+            event.set_integer_value_field(EventField::MOUSE_EVENT_DELTA_X, 7);
+            event.set_integer_value_field(EventField::MOUSE_EVENT_DELTA_Y, -3);
+            assert!(matches!(
+                translate(event_type, &event),
+                Some(MouseEvent::Moved {
+                    delta_x: 7,
+                    delta_y: -3,
+                })
+            ));
+        }
+    }
 
     #[test]
     fn tap_callback_suppresses_normally_and_passes_through_panics() {


### PR DESCRIPTION
## Summary

Stop subscribing to ordinary `MouseMoved` events in the macOS filtering HID tap. Even returning `PassThrough` makes cursor delivery wait for the agent's event-tap thread. Ordinary motion has no active button hold to update, and the event monitor discards movement events.

This removes an unnecessary synchronous step from cursor delivery. It is a candidate fix for desktop-wide pointer stutter reported with a Bluetooth MX Master 3, where stopping the OpenLogi agent improved smoothness. It does not establish that this is the only cause or claim a measured FPS improvement.

## Changes

- **openlogi-hook:** Remove `MouseMoved` from the tap mask; retain all three `*MouseDragged` variants, buttons, scrolling, and keys.
- Add a regression test asserting ordinary motion bypasses the tap while gesture drags remain subscribed and translate with their original deltas. Confirmed the test fails with the original mask.
- No new dependencies or configuration changes.

## Testing

Passed on Apple Silicon / macOS 26.6.2 with Rust 1.98.1:

```sh
cargo fmt --all -- --check
git diff --check
RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --locked -- -D warnings
RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent --locked
RUSTFLAGS="-D warnings" cargo test -p openlogi-hook -p openlogi-agent-core -p openlogi-agent
RUSTFLAGS="-D warnings" cargo test -p openlogi-desktop -p openlogi-overlay
```

542 unit tests and one doctest passed across the hook's affected dependency closure. Independent source review found no actionable regressions. Windows/Linux runtime validation was not performed; this patch only changes the macOS implementation.

**Hardware check:** A temporary native HID tap suppressed the physical MX Master 3 middle-button down/up. During the hold, both the HID and downstream session observers received 260 `OtherMouseDragged` events and zero `MouseMoved` events. This verifies the OS still supplies the retained drag event type when the button edge is suppressed. It is not an end-to-end configured-gesture test.

**Draft / remaining validation:** Compare visible smoothness with the patched agent and exercise configured middle/back/forward gestures. The installed v0.8.3 agent runs under Rosetta on this machine; architecture is a separate confounder, not a demonstrated cause. The installed app has not been replaced.
